### PR TITLE
Optionally allow only one active session per identity 

### DIFF
--- a/docs/.kratos.yaml
+++ b/docs/.kratos.yaml
@@ -68,14 +68,14 @@ selfservice:
     after:
       password:
         - run: session
-        - run: revoke_active_sesions
+        - run: revoke_active_sessions
         - run: redirect
           config:
             default_redirect_url: http://test.kratos.ory.sh:4000/
             allow_user_defined_redirect: true
       oidc:
         - run: session
-        - run: revoke_active_sesions
+        - run: revoke_active_sessions
         - run: redirect
           config:
             default_redirect_url: http://test.kratos.ory.sh:4000/

--- a/docs/.kratos.yaml
+++ b/docs/.kratos.yaml
@@ -68,12 +68,14 @@ selfservice:
     after:
       password:
         - run: session
+        - run: revoke_active_sesions
         - run: redirect
           config:
             default_redirect_url: http://test.kratos.ory.sh:4000/
             allow_user_defined_redirect: true
       oidc:
         - run: session
+        - run: revoke_active_sesions
         - run: redirect
           config:
             default_redirect_url: http://test.kratos.ory.sh:4000/

--- a/driver/registry_default_hooks.go
+++ b/driver/registry_default_hooks.go
@@ -13,7 +13,6 @@ import (
 
 func (m *RegistryDefault) hooksPost(credentialsType identity.CredentialsType, configs []configuration.SelfServiceHook) postHooks {
 	var i postHooks
-
 	for _, h := range configs {
 		switch h.Run {
 		case hook.KeySessionIssuer:

--- a/driver/registry_default_hooks.go
+++ b/driver/registry_default_hooks.go
@@ -21,6 +21,11 @@ func (m *RegistryDefault) hooksPost(credentialsType identity.CredentialsType, co
 				i,
 				hook.NewSessionIssuer(m),
 			)
+		case hook.KeySessionDestroyer:
+			i = append(
+				i,
+				hook.NewSessionDestroyer(m),
+			)
 		case hook.KeyRedirector:
 			var rc struct {
 				R string `json:"default_redirect_url"`

--- a/driver/registry_default_hooks.go
+++ b/driver/registry_default_hooks.go
@@ -13,6 +13,7 @@ import (
 
 func (m *RegistryDefault) hooksPost(credentialsType identity.CredentialsType, configs []configuration.SelfServiceHook) postHooks {
 	var i postHooks
+
 	for _, h := range configs {
 		switch h.Run {
 		case hook.KeySessionIssuer:

--- a/persistence/sql/persister_session.go
+++ b/persistence/sql/persister_session.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/gofrs/uuid"
-	"github.com/pkg/errors"
 
 	"github.com/ory/x/sqlcon"
 
@@ -30,12 +29,9 @@ func (p *Persister) DeleteSession(ctx context.Context, sid uuid.UUID) error {
 }
 
 func (p *Persister) DeleteSessionsFor(ctx context.Context, sid uuid.UUID) error {
-	count, err := p.c.RawQuery("DELETE FROM sessions WHERE identity_id =?", sid).ExecWithCount()
+	count, err := p.c.RawQuery("DELETE FROM sessions WHERE identity_id =?", sid).Exec()
 	if err != nil {
 		return sqlcon.HandleError(err)
-	}
-	if count == 0 {
-		return errors.WithStack(sqlcon.ErrNoRows)
 	}
 	return nil
 }

--- a/persistence/sql/persister_session.go
+++ b/persistence/sql/persister_session.go
@@ -29,8 +29,7 @@ func (p *Persister) DeleteSession(ctx context.Context, sid uuid.UUID) error {
 }
 
 func (p *Persister) DeleteSessionsFor(ctx context.Context, sid uuid.UUID) error {
-	count, err := p.c.RawQuery("DELETE FROM sessions WHERE identity_id =?", sid).Exec()
-	if err != nil {
+	if err := p.c.RawQuery("DELETE FROM sessions WHERE identity_id =?", sid).Exec(); err != nil {
 		return sqlcon.HandleError(err)
 	}
 	return nil

--- a/selfservice/hook/hooks.go
+++ b/selfservice/hook/hooks.go
@@ -3,5 +3,5 @@ package hook
 const (
 	KeySessionIssuer    = "session"
 	KeyRedirector       = "redirect"
-	KeySessionDestroyer = "revoke_active_sesions"
+	KeySessionDestroyer = "revoke_active_sessions"
 )

--- a/selfservice/hook/hooks.go
+++ b/selfservice/hook/hooks.go
@@ -1,6 +1,7 @@
 package hook
 
 const (
-	KeySessionIssuer = "session"
-	KeyRedirector    = "redirect"
+	KeySessionIssuer    = "session"
+	KeyRedirector       = "redirect"
+	KeySessionDestroyer = "revoke_active_sesions"
 )

--- a/selfservice/hook/session_destroyer.go
+++ b/selfservice/hook/session_destroyer.go
@@ -1,0 +1,36 @@
+package hook
+
+import (
+	"net/http"
+
+	"github.com/ory/kratos/selfservice/flow/login"
+	"github.com/ory/kratos/selfservice/flow/registration"
+	"github.com/ory/kratos/session"
+)
+
+var _ login.PostHookExecutor = new(SessionDestroyer)
+
+type sessionDestroyerDependencies interface {
+	session.ManagementProvider
+	session.PersistenceProvider
+}
+
+type SessionDestroyer struct {
+	r sessionDestroyerDependencies
+}
+
+func NewSessionDestroyer(r sessionDestroyerDependencies) *SessionDestroyer {
+	return &SessionDestroyer{r: r}
+}
+
+func (e *SessionDestroyer) ExecuteRegistrationPostHook(w http.ResponseWriter, r *http.Request, a *registration.Request, s *session.Session) error {
+
+	return nil
+}
+
+func (e *SessionDestroyer) ExecuteLoginPostHook(w http.ResponseWriter, r *http.Request, a *login.Request, s *session.Session) error {
+	if err := e.r.SessionPersister().DeleteSession(r.Context(), s.Identity.ID); err != nil {
+		return err
+	}
+	return nil
+}

--- a/selfservice/hook/session_destroyer.go
+++ b/selfservice/hook/session_destroyer.go
@@ -9,6 +9,7 @@ import (
 )
 
 var _ login.PostHookExecutor = new(SessionDestroyer)
+var _ registration.PostHookExecutor = new(SessionIssuer)
 
 type sessionDestroyerDependencies interface {
 	session.ManagementProvider

--- a/selfservice/hook/session_destroyer.go
+++ b/selfservice/hook/session_destroyer.go
@@ -24,12 +24,11 @@ func NewSessionDestroyer(r sessionDestroyerDependencies) *SessionDestroyer {
 }
 
 func (e *SessionDestroyer) ExecuteRegistrationPostHook(w http.ResponseWriter, r *http.Request, a *registration.Request, s *session.Session) error {
-
 	return nil
 }
 
 func (e *SessionDestroyer) ExecuteLoginPostHook(w http.ResponseWriter, r *http.Request, a *login.Request, s *session.Session) error {
-	if err := e.r.SessionPersister().DeleteSession(r.Context(), s.Identity.ID); err != nil {
+	if err := e.r.SessionPersister().DeleteSessionsFor(r.Context(), s.Identity.ID); err != nil {
 		return err
 	}
 	return nil

--- a/selfservice/hook/session_destroyer_test.go
+++ b/selfservice/hook/session_destroyer_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/ory/kratos/x"
 )
 
-func TestSessionIssuer(t *testing.T) {
+func TestSessionDestroyer(t *testing.T) {
 	_, reg := internal.NewRegistryDefault(t)
 	viper.Set(configuration.ViperKeyURLsSelfPublic, "http://localhost/")
 	viper.Set(configuration.ViperKeyDefaultIdentityTraitsSchemaURL, "file://./stub/stub.schema.json")
@@ -27,7 +27,7 @@ func TestSessionIssuer(t *testing.T) {
 	var r http.Request
 	h := hook.NewSessionIssuer(reg)
 
-	t.Run("method=sign-in", func(t *testing.T) {
+	t.Run("method=ExecuteLoginPostHook", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		sid := x.NewUUID()
 

--- a/selfservice/hook/session_destroyer_test.go
+++ b/selfservice/hook/session_destroyer_test.go
@@ -33,6 +33,10 @@ func TestSessionDestroyer(t *testing.T) {
 
 		i := identity.NewIdentity("")
 		require.NoError(t, reg.IdentityPool().CreateIdentity(context.Background(), i))
+		err := reg.SessionPersister().CreateSession(context.Background(), &session.Session{ID: sid, Identity: i}))
+		require.NoError(t, err)
+		err = reg.SessionPersister().CreateSession(context.Background(), &session.Session{ID: sid, Identity: i}))
+		require.NoError(t, err)		
 		require.NoError(t, h.ExecuteLoginPostHook(w, &r, nil, &session.Session{ID: sid, Identity: i}))
 
 		got, err := reg.SessionPersister().GetSession(context.Background(), sid)

--- a/selfservice/hook/session_destroyer_test.go
+++ b/selfservice/hook/session_destroyer_test.go
@@ -1,0 +1,43 @@
+package hook_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ory/viper"
+
+	"github.com/ory/kratos/driver/configuration"
+	"github.com/ory/kratos/identity"
+	"github.com/ory/kratos/internal"
+	"github.com/ory/kratos/selfservice/hook"
+	"github.com/ory/kratos/session"
+	"github.com/ory/kratos/x"
+)
+
+func TestSessionIssuer(t *testing.T) {
+	_, reg := internal.NewRegistryDefault(t)
+	viper.Set(configuration.ViperKeyURLsSelfPublic, "http://localhost/")
+	viper.Set(configuration.ViperKeyDefaultIdentityTraitsSchemaURL, "file://./stub/stub.schema.json")
+
+	var r http.Request
+	h := hook.NewSessionIssuer(reg)
+
+	t.Run("method=sign-in", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		sid := x.NewUUID()
+
+		i := identity.NewIdentity("")
+		require.NoError(t, reg.IdentityPool().CreateIdentity(context.Background(), i))
+		require.NoError(t, h.ExecuteLoginPostHook(w, &r, nil, &session.Session{ID: sid, Identity: i}))
+
+		got, err := reg.SessionPersister().GetSession(context.Background(), sid)
+		require.NoError(t, err)
+		assert.NoEqual(t, sid, got.ID) // check if session not exist
+	})
+
+}

--- a/selfservice/hook/session_destroyer_test.go
+++ b/selfservice/hook/session_destroyer_test.go
@@ -40,7 +40,9 @@ func TestSessionDestroyer(t *testing.T) {
 		require.NoError(t, err)		
 		require.NoError(t, h.ExecuteLoginPostHook(w, &r, nil, &session.Session{ID: sid, Identity: i}))
 
-		_, err := reg.SessionPersister().GetSession(context.Background(), i)
+		_, err := reg.SessionPersister().GetSession(context.Background(), sid1)
+		require.Error(t, err)
+		_, err := reg.SessionPersister().GetSession(context.Background(), sid2)
 		require.Error(t, err)
 	})
 

--- a/selfservice/hook/session_destroyer_test.go
+++ b/selfservice/hook/session_destroyer_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ory/kratos/selfservice/hook"
 	"github.com/ory/kratos/session"
 	"github.com/ory/kratos/x"
+	"github.com/ory/x/sqlcon"
 )
 
 func TestSessionDestroyer(t *testing.T) {
@@ -39,9 +40,8 @@ func TestSessionDestroyer(t *testing.T) {
 		require.NoError(t, err)		
 		require.NoError(t, h.ExecuteLoginPostHook(w, &r, nil, &session.Session{ID: sid, Identity: i}))
 
-		got, err := reg.SessionPersister().GetSession(context.Background(), sid)
-		require.NoError(t, err)
-		assert.NoEqual(t, sid, got.ID) // check if session not exist
+		_, err := reg.SessionPersister().GetSession(context.Background(), sid)
+		assert.EqualError(t, err,  sqlcon.ErrNoRows)
 	})
 
 }

--- a/selfservice/hook/session_destroyer_test.go
+++ b/selfservice/hook/session_destroyer_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ory/kratos/selfservice/hook"
 	"github.com/ory/kratos/session"
 	"github.com/ory/kratos/x"
-	"github.com/ory/x/sqlcon"
 )
 
 func TestSessionDestroyer(t *testing.T) {
@@ -41,7 +40,7 @@ func TestSessionDestroyer(t *testing.T) {
 		require.NoError(t, h.ExecuteLoginPostHook(w, &r, nil, &session.Session{ID: sid, Identity: i}))
 
 		_, err := reg.SessionPersister().GetSession(context.Background(), sid)
-		assert.EqualError(t, err,  sqlcon.ErrNoRows)
+		require.Error(t, err)
 	})
 
 }

--- a/selfservice/hook/session_destroyer_test.go
+++ b/selfservice/hook/session_destroyer_test.go
@@ -29,17 +29,18 @@ func TestSessionDestroyer(t *testing.T) {
 
 	t.Run("method=ExecuteLoginPostHook", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		sid := x.NewUUID()
+		sid1 := x.NewUUID()
+		sid2 := x.NewUUID()
 
 		i := identity.NewIdentity("")
 		require.NoError(t, reg.IdentityPool().CreateIdentity(context.Background(), i))
-		err := reg.SessionPersister().CreateSession(context.Background(), &session.Session{ID: sid, Identity: i}))
+		err := reg.SessionPersister().CreateSession(context.Background(), &session.Session{ID: sid1, Identity: i}))
 		require.NoError(t, err)
-		err = reg.SessionPersister().CreateSession(context.Background(), &session.Session{ID: sid, Identity: i}))
+		err = reg.SessionPersister().CreateSession(context.Background(), &session.Session{ID: sid2, Identity: i}))
 		require.NoError(t, err)		
 		require.NoError(t, h.ExecuteLoginPostHook(w, &r, nil, &session.Session{ID: sid, Identity: i}))
 
-		_, err := reg.SessionPersister().GetSession(context.Background(), sid)
+		_, err := reg.SessionPersister().GetSession(context.Background(), i)
 		require.Error(t, err)
 	})
 

--- a/session/persistence.go
+++ b/session/persistence.go
@@ -95,7 +95,7 @@ func TestPersister(p interface {
 			require.NoError(t, p.DeleteSessionsFor(context.Background(), expected2.IdentityID))
 			_, err := p.GetSession(context.Background(), expected1.ID)
 			require.Error(t, err)
-			_, err := p.GetSession(context.Background(), expected2.ID)
+			_, err = p.GetSession(context.Background(), expected2.ID)
 			require.Error(t, err)
 		})
 	}

--- a/session/persistence.go
+++ b/session/persistence.go
@@ -30,7 +30,7 @@ type Persister interface {
 	// Delete removes a session from the store
 	DeleteSession(ctx context.Context, sid uuid.UUID) error
 
-	// Delete removes a session the store
+	// DeleteSessionsFor removes all active session from the store for the given identity.
 	DeleteSessionsFor(ctx context.Context, sid uuid.UUID) error
 }
 

--- a/session/persistence.go
+++ b/session/persistence.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ory/viper"
-	"github.com/ory/x/sqlcon"
 
 	"github.com/ory/kratos/driver/configuration"
 	"github.com/ory/kratos/identity"
@@ -87,9 +86,9 @@ func TestPersister(p interface {
 			require.NoError(t, p.CreateSession(context.Background(), &expected))
 			require.NoError(t, p.CreateSession(context.Background(), &expected))
 
-			require.NoError(t, p.DeleteSessionFor(context.Background(), expected.ID))
+			require.NoError(t, p.DeleteSessionsFor(context.Background(), expected.ID))
 			_, err := p.GetSession(context.Background(), expected.ID)
-			assert.EqualError(t, err, sqlcon.ErrNoRows)
+			require.Error(t, err)
 		})
 	}
 }

--- a/session/persistence.go
+++ b/session/persistence.go
@@ -92,7 +92,7 @@ func TestPersister(p interface {
 			expected2.IdentityID = expected1.IdentityID
 			require.NoError(t, p.CreateSession(context.Background(), &expected2))
 
-			require.NoError(t, p.DeleteSessionsFor(context.Background(), identity.ID))
+			require.NoError(t, p.DeleteSessionsFor(context.Background(), expected2.IdentityID))
 			_, err := p.GetSession(context.Background(), expected1.ID)
 			require.Error(t, err)
 			_, err := p.GetSession(context.Background(), expected2.ID)

--- a/session/persistence.go
+++ b/session/persistence.go
@@ -80,14 +80,22 @@ func TestPersister(p interface {
 		})
 
 		t.Run("case=delete session for", func(t *testing.T) {
-			var expected Session
-			require.NoError(t, faker.FakeData(&expected))
-			require.NoError(t, p.CreateIdentity(context.Background(), expected.Identity))
-			require.NoError(t, p.CreateSession(context.Background(), &expected))
-			require.NoError(t, p.CreateSession(context.Background(), &expected))
+			var expected1 Session
+			var expected2 Session
+			require.NoError(t, faker.FakeData(&expected1))
+			require.NoError(t, p.CreateIdentity(context.Background(), expected1.Identity))
 
-			require.NoError(t, p.DeleteSessionsFor(context.Background(), expected.ID))
-			_, err := p.GetSession(context.Background(), expected.ID)
+			require.NoError(t, p.CreateSession(context.Background(), &expected1))
+
+			require.NoError(t, faker.FakeData(&expected2))
+			expected2.Identity = expected1.Identity
+			expected2.IdentityID = expected1.IdentityID
+			require.NoError(t, p.CreateSession(context.Background(), &expected2))
+
+			require.NoError(t, p.DeleteSessionsFor(context.Background(), identity.ID))
+			_, err := p.GetSession(context.Background(), expected1.ID)
+			require.Error(t, err)
+			_, err := p.GetSession(context.Background(), expected2.ID)
 			require.Error(t, err)
 		})
 	}

--- a/session/persistence.go
+++ b/session/persistence.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ory/viper"
+	"github.com/ory/x/sqlcon"
 
 	"github.com/ory/kratos/driver/configuration"
 	"github.com/ory/kratos/identity"
@@ -77,6 +78,17 @@ func TestPersister(p interface {
 			require.NoError(t, p.DeleteSession(context.Background(), expected.ID))
 			_, err := p.GetSession(context.Background(), expected.ID)
 			require.Error(t, err)
+		})
+
+		t.Run("case=delete session for", func(t *testing.T) {
+			var expected Session
+			require.NoError(t, faker.FakeData(&expected))
+			require.NoError(t, p.CreateIdentity(context.Background(), expected.Identity))
+			require.NoError(t, p.CreateSession(context.Background(), &expected))
+
+			require.NoError(t, p.DeleteSessionFor(context.Background(), expected.ID))
+			_, err := p.GetSession(context.Background(), expected.ID)
+			assert.EqualError(t, err, sqlcon.ErrNoRows)
 		})
 	}
 }

--- a/session/persistence.go
+++ b/session/persistence.go
@@ -85,6 +85,7 @@ func TestPersister(p interface {
 			require.NoError(t, faker.FakeData(&expected))
 			require.NoError(t, p.CreateIdentity(context.Background(), expected.Identity))
 			require.NoError(t, p.CreateSession(context.Background(), &expected))
+			require.NoError(t, p.CreateSession(context.Background(), &expected))
 
 			require.NoError(t, p.DeleteSessionFor(context.Background(), expected.ID))
 			_, err := p.GetSession(context.Background(), expected.ID)

--- a/session/persistence.go
+++ b/session/persistence.go
@@ -29,6 +29,9 @@ type Persister interface {
 
 	// Delete removes a session from the store
 	DeleteSession(ctx context.Context, sid uuid.UUID) error
+
+	// Delete removes a session the store
+	DeleteSessionsFor(ctx context.Context, sid uuid.UUID) error
 }
 
 func TestPersister(p interface {


### PR DESCRIPTION
## Related issue
This PR will close #139 

## Proposed changes

- [x] Add session_destroyer hook 
- [x] Add session_destroyer hook testcase
- [x] Create a new key for hook `	KeySessionDestroyer = "revoke_active_sesions" `
- [x] Register hook in `registry_default_hooks.go `

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
- [x] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
