### PR TITLE
fix: Set SeenAt on ErrorContainer init

### DIFF
--- a/persistence/sql/persister_errorx.go
+++ b/persistence/sql/persister_errorx.go
@@ -30,6 +30,7 @@ func (p *Persister) Add(ctx context.Context, csrfToken string, errs ...error) (u
 	c := &errorx.ErrorContainer{
 		CSRFToken: csrfToken,
 		Errors:    buf.Bytes(),
+		SeenAt:    time.Now().UTC(),
 		WasSeen:   false,
 	}
 


### PR DESCRIPTION
## Related issue

#244

## Proposed changes

Added `SeenAt` field when initializing `ErrorContainer` (MySQL complains when a `DATETIME` column is empty)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

Feel free to dispose this PR if it's not the best solution for given issue.