### PR TITLE
fix:add graceful shutdown to courier handler

### DIFF
--- a/cmd/daemon/serve.go
+++ b/cmd/daemon/serve.go
@@ -1,7 +1,6 @@
 package daemon
 
 import (
-	stdctx "context"
 	"net/http"
 	"strings"
 	"sync"
@@ -165,9 +164,10 @@ func sqa(cmd *cobra.Command, d driver.Driver) *metricsx.Service {
 func bgTasks(d driver.Driver, wg *sync.WaitGroup, cmd *cobra.Command, args []string) {
 	defer wg.Done()
 
-	if err := d.Registry().Courier().Work(stdctx.Background()); err != nil {
+	if err := graceful.Graceful(d.Registry().Courier().Work, d.Registry().Courier().Shutdown); err != nil {
 		d.Logger().WithError(err).Fatalf("Failed to run courier worker.")
 	}
+	d.Logger().Println("courier worker was shutdown gracefully")
 }
 
 func ServeAll(d driver.Driver) func(cmd *cobra.Command, args []string) {

--- a/courier/courier_test.go
+++ b/courier/courier_test.go
@@ -104,7 +104,7 @@ func TestSMTP(t *testing.T) {
 	c := reg.Courier()
 
 	go func() {
-		require.NoError(t, c.Work(context.Background()))
+		require.NoError(t, c.Work())
 	}()
 
 	t.Run("case=queue messages", func(t *testing.T) {


### PR DESCRIPTION
Courier would not stop with the provided Background handler.
This changes the methods of Courier so that the graceful package can be
used in the same way as the http endpoints can be used.

## Related issue

#295 
@aeneasr

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

This adapts the API of courier to match the API of http servers and therefore allows the usage of graceful.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
