### PR TITLE
fix: Linux install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -130,9 +130,9 @@ adjust_os() {
   # adjust archive name based on OS
   case ${OS} in
     386) OS=32-bit ;;
-    amd64) OS=64-bit ;;
+    amd64) OS=64bit ;;
     darwin) OS=macOS ;;
-    linux) OS=Linux ;;
+    linux) OS=linux ;;
     windows) OS=Windows ;;
   esac
   true
@@ -141,9 +141,9 @@ adjust_arch() {
   # adjust archive name based on ARCH
   case ${ARCH} in
     386) ARCH=32-bit ;;
-    amd64) ARCH=64-bit ;;
+    amd64) ARCH=64bit ;;
     darwin) ARCH=macOS ;;
-    linux) ARCH=Linux ;;
+    linux) ARCH=linux ;;
     windows) ARCH=Windows ;;
   esac
   true


### PR DESCRIPTION
## Related issue
I tried to install on
```
Distributor ID:	Ubuntu
Description:	Ubuntu 18.04.4 LTS
Release:	18.04
Codename:	bionic
```
but it failed when I ran  install.sh.

## Proposed changes

Remove inconsistencies between continuous deployment artfact names and the install script.

## Checklist


- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [ ] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments
