### PR TITLE
Fix the query parameter name in the get self-service error endpoint in API docs

### DIFF
--- a/docs/api.swagger.json
+++ b/docs/api.swagger.json
@@ -875,7 +875,7 @@
         "parameters": [
           {
             "type": "string",
-            "name": "id",
+            "name": "error",
             "in": "query"
           }
         ],

--- a/internal/httpclient/client/common/get_self_service_error_parameters.go
+++ b/internal/httpclient/client/common/get_self_service_error_parameters.go
@@ -60,8 +60,8 @@ for the get self service error operation typically these are written to a http.R
 */
 type GetSelfServiceErrorParams struct {
 
-	/*ID*/
-	ID *string
+	/*Error*/
+	Error *string
 
 	timeout    time.Duration
 	Context    context.Context
@@ -101,15 +101,15 @@ func (o *GetSelfServiceErrorParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithID adds the id to the get self service error params
-func (o *GetSelfServiceErrorParams) WithID(id *string) *GetSelfServiceErrorParams {
-	o.SetID(id)
+// WithError adds the error to the get self service error params
+func (o *GetSelfServiceErrorParams) WithError(error *string) *GetSelfServiceErrorParams {
+	o.SetError(error)
 	return o
 }
 
-// SetID adds the id to the get self service error params
-func (o *GetSelfServiceErrorParams) SetID(id *string) {
-	o.ID = id
+// SetError adds the error to the get self service error params
+func (o *GetSelfServiceErrorParams) SetError(error *string) {
+	o.Error = error
 }
 
 // WriteToRequest writes these params to a swagger request
@@ -120,16 +120,16 @@ func (o *GetSelfServiceErrorParams) WriteToRequest(r runtime.ClientRequest, reg 
 	}
 	var res []error
 
-	if o.ID != nil {
+	if o.Error != nil {
 
-		// query param id
-		var qrID string
-		if o.ID != nil {
-			qrID = *o.ID
+		// query param error
+		var qrError string
+		if o.Error != nil {
+			qrError = *o.Error
 		}
-		qID := qrID
-		if qID != "" {
-			if err := r.SetQueryParam("id", qID); err != nil {
+		qError := qrError
+		if qError != "" {
+			if err := r.SetQueryParam("error", qError); err != nil {
 				return err
 			}
 		}

--- a/selfservice/errorx/handler.go
+++ b/selfservice/errorx/handler.go
@@ -57,7 +57,7 @@ type errorContainerResponse struct {
 // swagger:parameters getSelfServiceError
 type errorContainerParameters struct {
 	// in: query
-	ID string `json:"id"`
+	Error string `json:"error"`
 }
 
 // swagger:route GET /self-service/errors common public admin getSelfServiceError


### PR DESCRIPTION
## Related issue

None

## Proposed changes

The query parameter for the self-service errors endpoint was named `id` in the API docs, whereas it is the `error` param that is used by the handler.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

I regenerated the SDK