### PR TITLE
fix: verified_at field should not be required

### DIFF
--- a/identity/address.go
+++ b/identity/address.go
@@ -41,7 +41,6 @@ type (
 		// required: true
 		Via VerifiableAddressType `json:"via" db:"via"`
 
-		// required: true
 		VerifiedAt *time.Time `json:"verified_at" faker:"-" db:"verified_at"`
 
 		// required: true


### PR DESCRIPTION
## Related issue
Closes ory/sdk#11

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

I have marked the field `verified_at` as not required because if a user is not verified then the field must be null. This causes problems when using the Python SDK.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
Signed-off-by: Jakob Sinclair <sinclair.jakob@mailbox.org>