### PR TITLE
fix: Access rules of oathkeeper for quick start

### DIFF
--- a/contrib/quickstart/oathkeeper/access-rules.yml
+++ b/contrib/quickstart/oathkeeper/access-rules.yml
@@ -44,7 +44,7 @@
     preserve_host: true
     url: "http://kratos-selfservice-ui-node:4435"
   match:
-    url: "http://127.0.0.1:4455/<{,debug,dashboard,settings}{/,}>"
+    url: "http://127.0.0.1:4455/<{,debug,dashboard,settings}>"
     methods:
       - GET
   authenticators:


### PR DESCRIPTION
## Related issue

close #389

## Proposed changes

Fix access rules of oathkeeper for quick start to access `/` as dashboard same as standalone quick start.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

