### PR TITLE
fix: transaction usage in the identity persister

### DIFF
--- a/persistence/sql/persister_identity.go
+++ b/persistence/sql/persister_identity.go
@@ -149,6 +149,8 @@ func (p *Persister) CreateIdentity(ctx context.Context, i *identity.Identity) er
 	}
 
 	return sqlcon.HandleError(p.Transaction(ctx, func(tx *pop.Connection) error {
+		ctx := WithTransaction(ctx, tx)
+
 		if err := tx.Create(i); err != nil {
 			return err
 		}
@@ -186,6 +188,7 @@ func (p *Persister) UpdateIdentity(ctx context.Context, i *identity.Identity) er
 	}
 
 	return sqlcon.HandleError(p.Transaction(ctx, func(tx *pop.Connection) error {
+		ctx := WithTransaction(ctx, tx)
 		if count, err := tx.Where("id = ?", i.ID).Count(i); err != nil {
 			return err
 		} else if count == 0 {

--- a/persistence/sql/persister_identity.go
+++ b/persistence/sql/persister_identity.go
@@ -148,7 +148,7 @@ func (p *Persister) CreateIdentity(ctx context.Context, i *identity.Identity) er
 		return err
 	}
 
-	return sqlcon.HandleError(p.GetConnection(ctx).Transaction(func(tx *pop.Connection) error {
+	return sqlcon.HandleError(p.Transaction(ctx, func(tx *pop.Connection) error {
 		if err := tx.Create(i); err != nil {
 			return err
 		}
@@ -185,7 +185,7 @@ func (p *Persister) UpdateIdentity(ctx context.Context, i *identity.Identity) er
 		return err
 	}
 
-	return sqlcon.HandleError(p.GetConnection(ctx).Transaction(func(tx *pop.Connection) error {
+	return sqlcon.HandleError(p.Transaction(ctx, func(tx *pop.Connection) error {
 		if count, err := tx.Where("id = ?", i.ID).Count(i); err != nil {
 			return err
 		} else if count == 0 {


### PR DESCRIPTION
Just stumbled across this.
Using the transaction function this way we can call e.g. `CreateIdentity` from within another transaction and it will continue in the context of the outer one.