### PR TITLE
kratos client is not submitted to packagist.

### DIFF
--- a/docs/docs/sdk/index.md
+++ b/docs/docs/sdk/index.md
@@ -18,7 +18,7 @@ We publish our SDKs for popular languages in their respective package
 repositories:
 
 - [Python](https://pypi.org/project/ory-kratos-client/)
-- [PHP](https://packagist.org/packages/ory/kratos-client)
+- [PHP](https://github.com/ory/kratos-client-php)
 - [Go](https://github.com/ory/kratos-client-go)
 - [NodeJS](https://www.npmjs.com/package/@oryd/kratos-client) (with TypeScript)
 - [Java](https://search.maven.org/artifact/sh.ory.kratos/kratos-client)


### PR DESCRIPTION
So we need to follow the doc https://github.com/ory/kratos-client-php#installation--usage

## Related issue

I didn't find any open issues regarding this change.

## Proposed changes

Either you guys can submit the package to packagist and that will resolve the issue. I am not sure why you guys didn't submit the package. Only hydra client and sdk seems registered. 

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments

Some other similar ones are missing.  Eg : https://github.com/ory/keto/blob/master/docs/docs/sdk/index.md . See php section and linked url.