### PR TITLE
fix: Clear error messages after updating settings successfully

### DIFF
--- a/selfservice/flow/settings/hook.go
+++ b/selfservice/flow/settings/hook.go
@@ -122,6 +122,8 @@ func (e *HookExecutor) PostSettingsHook(w http.ResponseWriter, r *http.Request, 
 		}
 	}
 
+	ctxUpdate.Request.Methods[settingsType].Config.ResetErrors()
+
 	if err := e.d.SettingsRequestPersister().UpdateSettingsRequest(r.Context(), ctxUpdate.Request); err != nil {
 		return err
 	}

--- a/selfservice/flow/settings/hook.go
+++ b/selfservice/flow/settings/hook.go
@@ -122,7 +122,9 @@ func (e *HookExecutor) PostSettingsHook(w http.ResponseWriter, r *http.Request, 
 		}
 	}
 
-	ctxUpdate.Request.Methods[settingsType].Config.ResetErrors()
+	if method, ok := ctxUpdate.Request.Methods[settingsType]; ok {
+		method.Config.ResetErrors()
+	}
 
 	if err := e.d.SettingsRequestPersister().UpdateSettingsRequest(r.Context(), ctxUpdate.Request); err != nil {
 		return err

--- a/test/e2e/cypress/integration/profiles/email/settings/success.spec.js
+++ b/test/e2e/cypress/integration/profiles/email/settings/success.spec.js
@@ -34,12 +34,29 @@ context('Settings', () => {
 
   describe('password', () => {
     it('modifies the password with privileged session', () => {
+      // Once input weak password to test which error message is cleared after updating successfully
+      cy.get('#user-password input[name="password"]').clear().type('123')
+      cy.get('#user-password button[type="submit"]').click()
+      cy.get('.container').should(
+        'not.contain.text',
+        'Your changes have been saved!'
+      )
+      cy.get('.container').should(
+        'contain.text',
+        'the password does not fulfill the password policy because: password length must be at least 6 characters but only got 3'
+      )
+      cy.get('#user-password input[name="password"]').should('be.empty')
+
       password = up(password)
       cy.get('#user-password input[name="password"]').clear().type(password)
       cy.get('#user-password button[type="submit"]').click()
       cy.get('.container').should(
         'contain.text',
         'Your changes have been saved!'
+      )
+      cy.get('.container').should(
+        'not.contain.text',
+        'the password does not fulfill the password policy because: password length must be at least 6 characters but only got 3'
       )
       cy.get('#user-password input[name="password"]').should('be.empty')
     })


### PR DESCRIPTION
## Related issue

#420

## Proposed changes

Clear error messages after updating settings successfully.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

