### PR TITLE
feat: Add support for Multitenant Azure AD as an OIDC provider

### DIFF
--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -61,12 +61,13 @@
         },
         "provider": {
           "title": "Provider",
-          "description": "Can be one of github, generic, google.",
+          "description": "Can be one of github, generic, google, microsoft.",
           "type": "string",
           "enum": [
             "github",
             "generic",
-            "google"
+            "google",
+            "microsoft"
           ],
           "examples": [
             "google"
@@ -119,6 +120,18 @@
               "profile"
             ]
           }
+        },
+        "tenant": {
+          "title": "Azure AD Tenant",
+          "description": "The Azure AD Tenant to use for authentication.",
+          "type": "string",
+          "examples": [
+            "common",
+            "organizations",
+            "consumers",
+            "8eaef023-2b34-4da1-9baa-8bc8c9d6a490",
+            "contoso.onmicrosoft.com"
+          ]
         }
       },
       "additionalProperties": false,

--- a/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
+++ b/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
@@ -132,9 +132,15 @@ local claims = std.extVar('claims');
 {
   identity: {
     traits: {
-      [if "email" in claims then "email" else null]: claims.email,
+      // Allowing unverified email addresses enables account
+      // enumeration attacks, especially if the value is used for
+      // e.g. verification or as a password login identifier.
+      //
+      // If connecting only to your organization (one tenant), claims.email is safe to use if you have not actively disabled e-mail verification during signup.
+      //
       // The email might be empty if the account is not linked to an email address.
       // For a human readable identifier, consider using the "preferred_username" claim.
+      [if "email" in claims then "email" else null]: claims.email,
     },
   },
 }

--- a/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
+++ b/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
@@ -105,46 +105,42 @@ This will enable you to log in using any Azure AD directory - Multitenant and
 personal Microsoft accounts (e.g. Skype, Xbox) depending on the settings made
 when creating the application in Azure AD.
 
-To set up "Sign in with Microsoft" you must first register an application
-[Register an application with the Microsoft identity platform](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app).
 
-It might be nessecary to enable the implicit grant flow for access tokens and ID
-tokens.
+#### Creating an Application in Azure AD
+To set up "Sign in with Microsoft" you must first [register an application with
+the Microsoft identity platform](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app).
 
-Set the "Authorization callback URL" to:
-
-```
-https://public.server.fqdn.example.org/.ory/kratos/public/self-service/browser/flows/strategies/oidc/callback/azuread
-```
-
-The pattern of this URL is:
+Select "Web" as the "Redirect URI" type, and set the URI to:
 
 ```
 http(s)://<domain-of-ory-kratos>:<public-port>/self-service/browser/flows/strategies/oidc/callback/<provider-id>
 ```
 
-```json title="contrib/quickstart/kratos/email-password/oidc.azuread.jsonnet"
-# claims contains all the data sent by the upstream.
+After the "App Registration" is created, make note of the `Application ID` and
+`Directory ID` on top of the Overview page. To create the client secret,
+navigate to "Certificates & secrets" and click "+ New client secret". Remember
+to copy the secret value as it will only be shown once.
+
+#### Configuring Kratos
+Create a Jsonnet claims mapper as described in
+[OpenID Connect and OAuth2 Credentials](../concepts/credentials/openid-connect-oidc-oauth2.mdx).
+Save the code in
+`<kratos-directory>/contrib/quickstart/kratos/email-password/oidc.microsoft.jsonnet`.
+
+```json title="contrib/quickstart/kratos/email-password/oidc.microsoft.jsonnet"
 local claims = std.extVar('claims');
 {
   identity: {
     traits: {
-      // Allowing unverified email addresses enables account
-      // enumeration attacks, especially if the value is used for
-      // e.g. verification or as a password login identifier.
-      //
-      // If connecting only to your organization (one tenant), claims.email is safe to use if you have not actively disabled e-mail
-      //verification during signup.
-      email: claims.email
+      [if "email" in claims then "email" else null]: claims.email,
+      // The email might be empty if the account is not linked to an email address.
+      // For a human readable identifier, consider using the "preferred_username" claim.
     },
   },
 }
 ```
 
-Also see ["Disable email verification during customer sign-up in Azure Active
-Directory B2C"] for warnings.
-
-Enable the Microsoft Azure provider in the ORY Kratos config located at
+Enable the Microsoft provider in the ORY Kratos config located at
 `<kratos-directory>/contrib/quickstart/kratos/email-password/.kratos.yml`.
 
 ```yaml title="contrib/quickstart/kratos/email-password/.kratos.yml"
@@ -154,20 +150,31 @@ selfservice:
       enabled: true
       config:
         providers:
-          - id: azuread
-            provider: generic
-            auth_url: https://login.microsoftonline.com/{TENANTID}/oauth2/v2.0/authorize
-            token_url: https://login.microsoftonline.com/{TENANTID}/oauth2/v2.0/token
-            issuer_url: https://login.microsoftonline.com/{TENANTID}/v2.0
-            client_id: {CLIENTID_FROM_AZURE_PORTAL} (Application (client) ID)
-            client_secret:  {SECRET_FROM_AZURE_PORTAL} (from certificates & secrets)
-            mapper_url: file:///etc/config/kratos/oidc.azuread.jsonnet
+          - id: microsoft # this is `<provider-id>` in the Authorization callback URL. DO NOT CHANGE IT ONCE SET!
+            provider: microsoft
+            client_id: .... # Replace this with the Application ID from the App Registration
+            client_secret: .... # Replace this with the generated Secret value from the App Registration
+            tenant: .... # Replace this with the Tenant of your choice (see below)
+            mapper_url: file:///etc/config/kratos/oidc.microsoft.jsonnet
             scope:
               - profile
               - email
 ```
 
 Azure AD is now an option to log in to kratos.
+
+##### Choosing Tenant
+There are two ways to use the `microsoft` provider for authentication:
+
+1. For authenticating users in a single Azure AD Directory (organisation),
+set the `tenant` value to either the `Directory ID` from the "App Registration"
+page, or the organisation domain. E.g. `8eaef023-2b34-4da1-9baa-8bc8c9d6a490`
+or `contoso.onmicrosoft.com`.
+2. For authenticating any user in the Microsoft identity platform, set the
+`tenant` value to either:
+   * `organizations` to allow users with work or school accounts, or
+   * `consumers` to allow users with personal accounts, or
+   * `common` to allow both kind of accounts.
 
 ## Google, LinkedIn, Facebook
 

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/davidrjonas/semver-cli v0.0.0-20190116233701-ee19a9a0dda6
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-errors/errors v1.0.1
 	github.com/go-openapi/errors v0.19.4

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,7 @@ github.com/dgraph-io/ristretto v0.0.1 h1:cJwdnj42uV8Jg4+KLrYovLiCgIfz9wtWm6E6KA+
 github.com/dgraph-io/ristretto v0.0.1/go.mod h1:T40EBc7CJke8TkpiYfGGKAeFjSaxuFXhuXRyumBd6RE=
 github.com/dgraph-io/ristretto v0.0.2 h1:a5WaUrDa0qm0YrAAS1tUykT5El3kt62KNZZeMxQn3po=
 github.com/dgraph-io/ristretto v0.0.2/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=

--- a/selfservice/strategy/oidc/provider_config.go
+++ b/selfservice/strategy/oidc/provider_config.go
@@ -78,7 +78,7 @@ func (c ConfigurationCollection) Provider(id string, public *url.URL) (Provider,
 			case "microsoft":
 				return NewProviderMicrosoft(&p, public), nil
 			}
-			return nil, errors.Errorf("provider type %s is not supported, supported are: %v", p.Provider, []string{"google"})
+			return nil, errors.Errorf("provider type %s is not supported, supported are: %v", p.Provider, []string{"generic", "google", "github", "microsoft"})
 		}
 	}
 	return nil, errors.WithStack(herodot.ErrNotFound.WithReasonf(`OpenID Connect Provider "%s" is unknown or has not been configured`, id))

--- a/selfservice/strategy/oidc/provider_config.go
+++ b/selfservice/strategy/oidc/provider_config.go
@@ -40,6 +40,11 @@ type Configuration struct {
 	// `provider` is set to `generic`.
 	TokenURL string `json:"token_url"`
 
+	// Tenant is the Azure AD Tenant to use for authentication, and must be set when `provider` is set to `microsoft`.
+	// Can be either `common`, `organizations`, `consumers` for a multitenant application or a specific tenant like
+	// `8eaef023-2b34-4da1-9baa-8bc8c9d6a490` or `contoso.onmicrosoft.com`.
+	Tenant string `json:"tenant"`
+
 	// Scope specifies optional requested permissions.
 	Scope []string `json:"scope"`
 
@@ -70,6 +75,8 @@ func (c ConfigurationCollection) Provider(id string, public *url.URL) (Provider,
 				return NewProviderGoogle(&p, public), nil
 			case "github":
 				return NewProviderGitHub(&p, public), nil
+			case "microsoft":
+				return NewProviderMicrosoft(&p, public), nil
 			}
 			return nil, errors.Errorf("provider type %s is not supported, supported are: %v", p.Provider, []string{"google"})
 		}

--- a/selfservice/strategy/oidc/provider_generic_oidc.go
+++ b/selfservice/strategy/oidc/provider_generic_oidc.go
@@ -46,14 +46,7 @@ func (g *ProviderGenericOIDC) provider(ctx context.Context) (*gooidc.Provider, e
 	return g.p, nil
 }
 
-func (g *ProviderGenericOIDC) OAuth2(ctx context.Context) (*oauth2.Config, error) {
-	p, err := g.provider(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	endpoint := p.Endpoint()
-
+func (g *ProviderGenericOIDC) oauth2ConfigFromEndpoint(endpoint oauth2.Endpoint) *oauth2.Config {
 	scope := g.config.Scope
 	if !stringslice.Has(scope, gooidc.ScopeOpenID) {
 		scope = append(scope, gooidc.ScopeOpenID)
@@ -65,7 +58,18 @@ func (g *ProviderGenericOIDC) OAuth2(ctx context.Context) (*oauth2.Config, error
 		Endpoint:     endpoint,
 		Scopes:       scope,
 		RedirectURL:  g.config.Redir(g.public),
-	}, nil
+	}
+}
+
+func (g *ProviderGenericOIDC) OAuth2(ctx context.Context) (*oauth2.Config, error) {
+	p, err := g.provider(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint := p.Endpoint()
+
+	return g.oauth2ConfigFromEndpoint(endpoint), nil
 }
 
 func (g *ProviderGenericOIDC) AuthCodeURLOptions(r request) []oauth2.AuthCodeOption {

--- a/selfservice/strategy/oidc/provider_microsoft.go
+++ b/selfservice/strategy/oidc/provider_microsoft.go
@@ -66,21 +66,7 @@ func (m *ProviderMicrosoft) Claims(ctx context.Context, exchange *oauth2.Token) 
 		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("Unable to initialize OpenID Connect Provider: %s", err))
 	}
 
-	token, err := p.
-		Verifier(&gooidc.Config{
-			ClientID: m.config.ClientID,
-		}).
-		Verify(ctx, raw)
-	if err != nil {
-		return nil, errors.WithStack(herodot.ErrBadRequest.WithReasonf("%s", err))
-	}
-
-	var claims Claims
-	if err := token.Claims(&claims); err != nil {
-		return nil, errors.WithStack(herodot.ErrBadRequest.WithReasonf("%s", err))
-	}
-
-	return &claims, nil
+	return m.verifyAndDecodeClaimsWithProvider(ctx, p, raw)
 }
 
 type microsoftUnverifiedClaims struct {

--- a/selfservice/strategy/oidc/provider_microsoft.go
+++ b/selfservice/strategy/oidc/provider_microsoft.go
@@ -9,7 +9,6 @@ import (
 
 	gooidc "github.com/coreos/go-oidc"
 	"github.com/ory/herodot"
-	"github.com/ory/x/stringslice"
 	"github.com/pkg/errors"
 	"golang.org/x/oauth2"
 )
@@ -41,18 +40,7 @@ func (m *ProviderMicrosoft) OAuth2(ctx context.Context) (*oauth2.Config, error) 
 		TokenURL: endpointPrefix + "/oauth2/v2.0/token",
 	}
 
-	scope := m.config.Scope
-	if !stringslice.Has(scope, gooidc.ScopeOpenID) {
-		scope = append(scope, gooidc.ScopeOpenID)
-	}
-
-	return &oauth2.Config{
-		ClientID:     m.config.ClientID,
-		ClientSecret: m.config.ClientSecret,
-		Endpoint:     endpoint,
-		Scopes:       scope,
-		RedirectURL:  m.config.Redir(m.public),
-	}, nil
+	return m.oauth2ConfigFromEndpoint(endpoint), nil
 }
 
 func (m *ProviderMicrosoft) Claims(ctx context.Context, exchange *oauth2.Token) (*Claims, error) {

--- a/selfservice/strategy/oidc/provider_microsoft.go
+++ b/selfservice/strategy/oidc/provider_microsoft.go
@@ -1,0 +1,100 @@
+package oidc
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/dgrijalva/jwt-go"
+
+	gooidc "github.com/coreos/go-oidc"
+	"github.com/ory/herodot"
+	"github.com/ory/x/stringslice"
+	"github.com/pkg/errors"
+	"golang.org/x/oauth2"
+)
+
+type ProviderMicrosoft struct {
+	config *Configuration
+	public *url.URL
+}
+
+func NewProviderMicrosoft(
+	config *Configuration,
+	public *url.URL,
+) *ProviderMicrosoft {
+	return &ProviderMicrosoft{
+		config: config,
+		public: public,
+	}
+}
+
+func (m *ProviderMicrosoft) Config() *Configuration {
+	return m.config
+}
+
+func (m *ProviderMicrosoft) OAuth2(ctx context.Context) (*oauth2.Config, error) {
+	endpointPrefix := "https://login.microsoftonline.com/" + m.config.Tenant
+	endpoint := oauth2.Endpoint{
+		AuthURL:  endpointPrefix + "/oauth2/v2.0/authorize",
+		TokenURL: endpointPrefix + "/oauth2/v2.0/token",
+	}
+
+	scope := m.config.Scope
+	if !stringslice.Has(scope, gooidc.ScopeOpenID) {
+		scope = append(scope, gooidc.ScopeOpenID)
+	}
+
+	return &oauth2.Config{
+		ClientID:     m.config.ClientID,
+		ClientSecret: m.config.ClientSecret,
+		Endpoint:     endpoint,
+		Scopes:       scope,
+		RedirectURL:  m.config.Redir(m.public),
+	}, nil
+}
+
+func (m *ProviderMicrosoft) AuthCodeURLOptions(r request) []oauth2.AuthCodeOption {
+	return []oauth2.AuthCodeOption{}
+}
+
+func (m *ProviderMicrosoft) Claims(ctx context.Context, exchange *oauth2.Token) (*Claims, error) {
+	raw, ok := exchange.Extra("id_token").(string)
+	if !ok || len(raw) == 0 {
+		return nil, errors.WithStack(ErrIDTokenMissing)
+	}
+
+	parser := new(jwt.Parser)
+	unverifiedClaims := microsoftUnverifiedClaims{}
+	if _, _, err := parser.ParseUnverified(raw, &unverifiedClaims); err != nil {
+		return nil, err
+	}
+
+	p, err := gooidc.NewProvider(context.Background(), unverifiedClaims.Issuer)
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("Unable to initialize OpenID Connect Provider: %s", err))
+	}
+
+	token, err := p.
+		Verifier(&gooidc.Config{
+			ClientID: m.config.ClientID,
+		}).
+		Verify(ctx, raw)
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrBadRequest.WithReasonf("%s", err))
+	}
+
+	var claims Claims
+	if err := token.Claims(&claims); err != nil {
+		return nil, errors.WithStack(herodot.ErrBadRequest.WithReasonf("%s", err))
+	}
+
+	return &claims, nil
+}
+
+type microsoftUnverifiedClaims struct {
+	Issuer string `json:"iss,omitempty"`
+}
+
+func (c *microsoftUnverifiedClaims) Valid() error {
+	return nil
+}


### PR DESCRIPTION
## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

This PR adds a new OIDC provider called `microsoft`, that adds support for the multi-tenant features of the Microsoft identity platform. The platform can already be used as an OIDC provider when authenticating towards a specific Tenant - as it behaves as a generic OIDC provider - but when using it to authenticate e.g. with personal Microsoft accounts the endpoints behave in a somewhat special way, described in [this blog post](https://www.cloudidentity.com/blog/2014/08/26/the-common-endpoint-walks-like-a-tenant-talks-like-a-tenant-but-is-not-a-tenant/).

The proposed code differs from the generic OIDC provider by getting the issuer from the returned JWT `id_token`, but subsequently verifies the returned token in the exact same way. It also adds another property in the OIDC provider configuration called `Tenant` that is to be used with the `microsoft` provider.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

I have not added any tests, as I couldn't get the current test suite to run with `go test ./...`. I get a lot of errors like these
```
...
internal/testhelpers/selfservice_settings.go:140:3: t.Cleanup undefined (type *testing.T has no field or method Cleanup)
internal/testhelpers/selfservice_settings.go:140:3: too many errors
...
time="2020-05-26T21:08:10+02:00" level=warning msg="Unable to connect to database, retrying." error="unsupported dialect 'sqlite3'"
time="2020-05-26T21:08:11+02:00" level=warning msg="Unable to connect to database, retrying." error="unsupported dialect 'sqlite3'"
...
```
So any help with that would be greatly appreciated, and allow me to write a few tests for the new provider.

The `Tenant` configuration property was added directly to the OIDC provider configuration. It would perhaps be nicer to have per-provider configuration schemas, but that didn't seem like a reasonable thing to do just now.

Also, I have not written any new documentation about this feature, but just noticed PR #433, and assume that it would make sense to build upon that if that is merged.