### PR TITLE
fix: Improve grammar of similar password error

### DIFF
--- a/selfservice/strategy/password/validator.go
+++ b/selfservice/strategy/password/validator.go
@@ -155,7 +155,7 @@ func (s *DefaultPasswordValidator) Validate(identifier, password string) error {
 
 	compIdentifier, compPassword := strings.ToLower(identifier), strings.ToLower(password)
 	if levenshtein.Distance(compIdentifier, compPassword) < s.minIdentifierPasswordDist || lcsLength(compIdentifier, compPassword) > s.maxIdentifierPasswordSubstr {
-		return errors.Errorf("the password is to similar to the user identifier")
+		return errors.Errorf("the password is too similar to the user identifier")
 	}
 
 	/* #nosec G401 sha1 is used for k-anonymity */

--- a/test/e2e/cypress/integration/profiles/email/registration/errors.spec.js
+++ b/test/e2e/cypress/integration/profiles/email/registration/errors.spec.js
@@ -45,7 +45,7 @@ context('Registration', () => {
       cy.get('input[name="password"]').type(identity)
 
       cy.get('button[type="submit"]').click()
-      cy.get('.form-errors .message').should('contain.text', 'to similar')
+      cy.get('.form-errors .message').should('contain.text', 'too similar')
     })
 
     it('should show an error when the password is empty', () => {

--- a/test/e2e/cypress/integration/profiles/email/registration/errors.spec.js
+++ b/test/e2e/cypress/integration/profiles/email/registration/errors.spec.js
@@ -39,7 +39,7 @@ context('Registration', () => {
       cy.get('.form-errors .message').should('contain.text', 'data breaches')
     })
 
-    it('should show an error when the password is to similar', () => {
+    it('should show an error when the password is too similar', () => {
       cy.get('input[name="traits.website"]').type('https://www.ory.sh')
       cy.get('input[name="traits.email"]').type(identity)
       cy.get('input[name="password"]').type(identity)


### PR DESCRIPTION
## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
