### PR TITLE
refactor: rename prompt=login to refresh=true

### DIFF
--- a/selfservice/flow/login/handler_test.go
+++ b/selfservice/flow/login/handler_test.go
@@ -84,29 +84,29 @@ func TestHandlerSettingForced(t *testing.T) {
 		assert.Contains(t, res.Request.URL.String(), loginTS.URL)
 	})
 
-	t.Run("case=does not set forced flag on unauthenticated request with prompt=login", func(t *testing.T) {
+	t.Run("case=does not set forced flag on unauthenticated request with refresh=true", func(t *testing.T) {
 		res, body := mur(t, url.Values{
-			"prompt": {"login"},
+			"refresh": {"true"},
 		})
 		ab(body, true)
 		assert.Contains(t, res.Request.URL.String(), loginTS.URL)
 	})
 
-	t.Run("case=does not set forced flag on authenticated request without prompt=login", func(t *testing.T) {
+	t.Run("case=does not set forced flag on authenticated request without refresh=true", func(t *testing.T) {
 		res, _ := mar(t, url.Values{})
 		assert.Contains(t, res.Request.URL.String(), "https://www.ory.sh")
 	})
 
-	t.Run("case=does not set forced flag on authenticated request with prompt=false", func(t *testing.T) {
+	t.Run("case=does not set forced flag on authenticated request with refresh=false", func(t *testing.T) {
 		res, _ := mar(t, url.Values{
-			"prompt": {"false"},
+			"refresh": {"false"},
 		})
 		assert.Contains(t, res.Request.URL.String(), "https://www.ory.sh")
 	})
 
-	t.Run("case=does set forced flag on authenticated request with prompt=login", func(t *testing.T) {
+	t.Run("case=does set forced flag on authenticated request with refresh=true", func(t *testing.T) {
 		res, body := mar(t, url.Values{
-			"prompt": {"login"},
+			"refresh": {"true"},
 		})
 		ab(body, true)
 		assert.Contains(t, res.Request.URL.String(), loginTS.URL)

--- a/selfservice/flow/login/request.go
+++ b/selfservice/flow/login/request.go
@@ -83,7 +83,7 @@ func NewRequest(exp time.Duration, csrf string, r *http.Request) *Request {
 		RequestURL: source.String(),
 		Methods:    map[identity.CredentialsType]*RequestMethod{},
 		CSRFToken:  csrf,
-		Forced:     r.URL.Query().Get("prompt") == "login",
+		Forced:     r.URL.Query().Get("refresh") == "true",
 	}
 }
 

--- a/selfservice/flow/settings/error.go
+++ b/selfservice/flow/settings/error.go
@@ -62,7 +62,7 @@ func (s *ErrorHandler) reauthenticate(
 	s.c.SelfPublicURL()
 	u := urlx.AppendPaths(
 		urlx.CopyWithQuery(s.c.SelfPublicURL(), url.Values{
-			"prompt":    {"login"},
+			"refresh":    {"true"},
 			"return_to": {returnTo.String()},
 		}), login.BrowserLoginPath)
 

--- a/selfservice/strategy/password/login_test.go
+++ b/selfservice/strategy/password/login_test.go
@@ -107,7 +107,7 @@ func TestLoginNew(t *testing.T) {
 
 		u := ts.URL + login.BrowserLoginPath
 		if force {
-			u = u + "?prompt=login"
+			u = u + "?refresh=true"
 		}
 
 		res, err := c.Get(u)
@@ -304,17 +304,17 @@ func TestLoginNew(t *testing.T) {
 		require.Contains(t, res.Request.URL.Path, "return-ts", "%s", res.Request.URL.String())
 		assert.Equal(t, identifier, gjson.GetBytes(body, "identity.traits.subject").String(), "%s", body)
 
-		t.Run("retry with different prompts", func(t *testing.T) {
+		t.Run("retry with different refresh", func(t *testing.T) {
 			c := &http.Client{Jar: jar}
 
-			t.Run("redirect to returnTS if prompt is missing", func(t *testing.T) {
+			t.Run("redirect to returnTS if refresh is missing", func(t *testing.T) {
 				res, err := c.Get(ts.URL + login.BrowserLoginPath)
 				require.NoError(t, err)
 				require.EqualValues(t, http.StatusOK, res.StatusCode)
 			})
 
 			t.Run("show UI and hint at username", func(t *testing.T) {
-				res, err := c.Get(ts.URL + login.BrowserLoginPath + "?prompt=login")
+				res, err := c.Get(ts.URL + login.BrowserLoginPath + "?refresh=true")
 				require.NoError(t, err)
 				require.EqualValues(t, http.StatusOK, res.StatusCode)
 


### PR DESCRIPTION
Closes #477

BREAKING CHANGE: To refresh a login session it is now required to append `refresh=true` instead of `prompt=login` as the second has implications for revoking an existing issue and might be confusing when used in combination with OpenID Connect.

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
