### PR TITLE
docs: fix typo in oauth sign in documentation

### DIFF
--- a/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
+++ b/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
@@ -35,7 +35,7 @@ http(s)://<domain-of-ory-kratos>:<public-port>/self-service/browser/flows/strate
 ```
 
 The provider ID must point to the provider's ID set in the ORY Kratos
-configuration file (explained in further detail at [OpenID Connect and OAuth2 Credentails](../concepts/credentials/openid-connect-oidc-oauth2.mdx)).
+configuration file (explained in further detail at [OpenID Connect and OAuth2 Credentials](../concepts/credentials/openid-connect-oidc-oauth2.mdx)).
 
 :::note
 
@@ -51,7 +51,7 @@ Not all GitHub fields are supported however. Check the list of supported fields
 :::
 
 As explained in
-[OpenID Connect and OAuth2 Credentails](../concepts/credentials/openid-connect-oidc-oauth2.mdx),
+[OpenID Connect and OAuth2 Credentials](../concepts/credentials/openid-connect-oidc-oauth2.mdx),
 you must also create a Jsonnet code snippet for the provider. Save the code in
 `<kratos-directory>/contrib/quickstart/kratos/email-password/oidc.github.jsonnet`.
 The following schema takes `email_primary` and maps it to `traits.email`:


### PR DESCRIPTION
## Related issue
None

## Proposed changes
Fixing a small typo

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments

Should I have adjusted the file in the 0.3 documentation sub-folder as well?
