### PR TITLE
broken link

### DIFF
--- a/docs/versioned_docs/version-v0.3/sdk.md
+++ b/docs/versioned_docs/version-v0.3/sdk.md
@@ -11,7 +11,7 @@ code when upgrading versions. Therefore, we do not make backwards compatibility
 promises with regards to the generated SDKs. We hope to improve this process in
 the future.
 
-Before you check out the SDKs, head over to the [REST API](sdk/api) documentation
+Before you check out the SDKs, head over to the [REST API](reference/api) documentation
 which includes code samples for common programming languages for each REST
 endpoint.
 


### PR DESCRIPTION
the rest api is no longer under sdk but under reference.

