### PR TITLE
fix: redirect hook + documentation

### DIFF
--- a/docs/docs/self-service/hooks/index.mdx
+++ b/docs/docs/self-service/hooks/index.mdx
@@ -26,9 +26,10 @@ Self-Service Login Strategy in ORY Kratos' configuration file.
 selfservice:
   login:
     before:
-      - hook: redirect
-        config:
-          to: https://www.ory.sh/maintenance
+      hooks:
+        - hook: redirect
+          config:
+            default_redirect_url: https://www.ory.sh/maintenance
 ```
 
 #### `redirect`
@@ -41,9 +42,10 @@ when you want to disable any settings functionality (e.g. due to maintenance).
 selfservice:
   login:
     before:
-      - hook: redirect
-        config:
-          to: https://www.ory.sh/maintenance
+      hooks:
+        - hook: redirect
+          config:
+            default_redirect_url: https://www.ory.sh/maintenance
 ```
 
 
@@ -54,29 +56,11 @@ selfservice:
   login:
     after:
       oidc:
-        - hook: redirect
-          config:
-            to: https://www.ory.sh/
+        hooks:
+          - hook: revoke_active_sessions
       password:
-        - hook: revoke_active_sessions
-```
-
-#### `redirect`
-
-The `redirect` job sends HTTP 302 Found and redirects the client
-to the specified endpoint. This hook overrides the default redirection
-behaviour and enforces the specified redirect URL.
-
-Using this hook should be an exception.
-
-```yaml title="path/to/my/kratos.config.yml"
-selfservice:
-  login:
-    after:
-      <strategy>:
-        - hook: redirect
-          config:
-            to: https://url-to-redirect/to
+        hooks:
+          - hook: revoke_active_sessions
 ```
 
 #### `revoke_active_sessions`
@@ -89,8 +73,9 @@ selfservice:
   login:
     after:
       <strategy>:
-        - hook: revoke_active_sessions
-          # can not be configured
+        hooks:
+          - hook: revoke_active_sessions
+            # can not be configured
 ```
 
 ## Registration
@@ -104,9 +89,10 @@ Self-Service Registration Strategy in ORY Kratos' configuration file.
 selfservice:
   registration:
     before:
-    - hook: redirect
-      config:
-        to: https://www.ory.sh/maintenance
+      hooks:
+        - hook: redirect
+          config:
+            default_redirect_url: https://www.ory.sh/maintenance
 ```
 
 #### `redirect`
@@ -119,9 +105,10 @@ when you want to disable any settings functionality (e.g. due to maintenance).
 selfservice:
   registration:
     before:
-    - hook: redirect
-      config:
-        to: https://www.ory.sh/maintenance
+      hooks:
+        - hook: redirect
+          config:
+            default_redirect_url: https://www.ory.sh/maintenance
 ```
 
 ### After
@@ -131,9 +118,11 @@ selfservice:
   registration:
     after:
       oidc:
-        - hook: session
+        hooks:
+          - hook: session
       password:
-        - hook: session
+        hooks:
+          - hook: session
 ```
 
 #### `session`
@@ -171,8 +160,9 @@ selfservice:
   registration:
     after:
       <strategy>:
-        - hook: session
-          # can not be configured
+        hooks:
+          - hook: session
+            # can not be configured
 ```
 
 #### `redirect`
@@ -195,9 +185,10 @@ selfservice:
   registration:
     after:
       <strategy>:
-        - hook: redirect
-          config:
-            to: https://url-to-redirect/to
+        hooks:
+          - hook: redirect
+            config:
+              default_redirect_url: https://url-to-redirect/to
 ```
 
 ### `verify`
@@ -205,6 +196,15 @@ selfservice:
 The `verify` hook checks for verifiable email addresses and sends a verification / activation
 email. For more information,
 please read [User Verification and Account Activation](../flows/verify-email-account-activation.mdx).
+
+```yaml title="path/to/my/kratos.config.yml"
+selfservice:
+  registration:
+    after:
+      <strategy>:
+        hooks:
+          - hook: verify
+```
 
 ## Settings
 
@@ -221,29 +221,13 @@ Settings flows do not have before hooks.
 selfservice:
   settings:
     after:
-      - hook: redirect
-        config:
-         to: https://www.ory.sh/
+      <password|profile>:
+        hooks:
+          - hook: verify
 ```
 
-#### `redirect`
+### `verify`
 
-The `redirect` job sends HTTP 302 Found and redirects the client
-to the specified endpoint.
-
-Per default, the settings endpoint returns to the settings page
-with the original settings request ID. This is useful
-when you want to show e.g. a success message indicating
-that the data has successfully been saved.
-
-To override this behaviour, use this redirect hook.
-
-```yaml title="path/to/my/kratos.config.yml"
-selfservice:
-  settings:
-    after:
-      <strategy>:
-        - hook: redirect
-          config:
-            to: https://www.ory.sh/settings-updated
-```
+The `verify` hook checks for verifiable email addresses and sends a verification / activation
+email. For more information,
+please read [User Verification and Account Activation](../flows/verify-email-account-activation.mdx).

--- a/internal/testhelpers/selfservice.go
+++ b/internal/testhelpers/selfservice.go
@@ -64,7 +64,7 @@ func TestSelfServicePreHook(
 
 		t.Run("case=redirect", func(t *testing.T) {
 			t.Cleanup(SelfServiceHookConfigReset)
-			viper.Set(configKey, []configuration.SelfServiceHook{{Name: "redirect", Config: []byte(`{"to": "https://www.ory.sh/"}`)}})
+			viper.Set(configKey, []configuration.SelfServiceHook{{Name: "redirect", Config: []byte(`{"default_redirect_url": "https://www.ory.sh/"}`)}})
 
 			res, _ := makeRequestPre(t, newServer(t))
 			assert.EqualValues(t, http.StatusOK, res.StatusCode)

--- a/selfservice/hook/redirector.go
+++ b/selfservice/hook/redirector.go
@@ -75,9 +75,9 @@ func (e *Redirector) ExecuteLoginPostHook(w http.ResponseWriter, r *http.Request
 }
 
 func (e *Redirector) do(w http.ResponseWriter, r *http.Request) error {
-	rt := gjson.GetBytes(e.config, "to").String()
+	rt := gjson.GetBytes(e.config, "default_redirect_url").String()
 	if rt == "" {
-		return errors.WithStack(herodot.ErrInternalServerError.WithReasonf("A redirector hook was configured without a redirect_to value set."))
+		return errors.WithStack(herodot.ErrInternalServerError.WithReasonf("A redirector hook was configured without a default_redirect_url value set."))
 	}
 
 	http.Redirect(w, r, rt, http.StatusFound)

--- a/selfservice/hook/redirector_test.go
+++ b/selfservice/hook/redirector_test.go
@@ -24,7 +24,7 @@ func TestRedirector(t *testing.T) {
 	assert.Error(t, l.ExecuteLoginPreHook(nil, nil, nil))
 	assert.Error(t, l.ExecuteRegistrationPreHook(nil, nil, nil))
 
-	l = NewRedirector(json.RawMessage(`{"to":"https://www.ory.sh/"}`))
+	l = NewRedirector(json.RawMessage(`{"default_redirect_url":"https://www.ory.sh/"}`))
 	router := httprouter.New()
 	router.GET("/a", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		require.Error(t, l.ExecuteSettingsPrePersistHook(w, r, nil, nil), settings.ErrHookAbortRequest)


### PR DESCRIPTION
## Proposed changes

The redirect hook wasn't working because it was using an old config key. This wasn't caught because tests too were using the old wrong key. Additionally, the documentation for hooks was outdated.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

