### PR TITLE
docs: Fixed username & password use case example by replacing email with username

### DIFF
--- a/docs/docs/concepts/credentials/username-email-password.mdx
+++ b/docs/docs/concepts/credentials/username-email-password.mdx
@@ -190,9 +190,8 @@ Schema:
   "title": "Person",
   "type": "object",
   "properties": {
-    "email": {
+    "username": {
       "type": "string",
-      "format": "email",
       "ory.sh/kratos": {
         "credentials": {
           "password": {

--- a/docs/versioned_docs/version-v0.1/self-service/strategies/username-email-password.md
+++ b/docs/versioned_docs/version-v0.1/self-service/strategies/username-email-password.md
@@ -162,9 +162,8 @@ Schema:
   "title": "Person",
   "type": "object",
   "properties": {
-    "email": {
+    "username": {
       "type": "string",
-      "format": "email",
       "ory.sh/kratos": {
         "credentials": {
           "password": {

--- a/docs/versioned_docs/version-v0.2/self-service/strategies/username-email-password.md
+++ b/docs/versioned_docs/version-v0.2/self-service/strategies/username-email-password.md
@@ -163,9 +163,8 @@ Schema:
   "title": "Person",
   "type": "object",
   "properties": {
-    "email": {
+    "username": {
       "type": "string",
-      "format": "email",
       "ory.sh/kratos": {
         "credentials": {
           "password": {

--- a/docs/versioned_docs/version-v0.3/concepts/credentials/username-email-password.mdx
+++ b/docs/versioned_docs/version-v0.3/concepts/credentials/username-email-password.mdx
@@ -189,9 +189,8 @@ Schema:
   "title": "Person",
   "type": "object",
   "properties": {
-    "email": {
+    "username": {
       "type": "string",
-      "format": "email",
       "ory.sh/kratos": {
         "credentials": {
           "password": {


### PR DESCRIPTION
This is a documentation correction

url: https://www.ory.sh/kratos/docs/concepts/credentials/username-email-password#use-case-username-and-password

**Problem**:
The Username and Password use case example shows an email example instead of a username example.

**Fix**:
This PR renames the `email` to `username` and removes `format` based on the username block in the following use case.