### PR TITLE
docs: Replaced mailhog references with mailslurper in current documentation.

### DIFF
--- a/docs/docs/guides/zero-trust-iap-proxy-identity-access-proxy.mdx
+++ b/docs/docs/guides/zero-trust-iap-proxy-identity-access-proxy.mdx
@@ -83,7 +83,7 @@ This demo makes use of several services:
 3. [ORY Oathkeeper](https://github.com/ory/oathkeeper)
 - Reverse proxy (port 4455) - a reverse proxy to protect the **SecureApp**.
 - API (port 4456) - Oathkeeper's API. This is made public only so we can test via the CLI.
-4. [MailHog](https://github.com/mailhog/MailHog)
+4. [MailSlurper](https://github.com/mailslurper)
 - Public (port 4436) - a development SMTP server with which ORY Kratos sends emails.
 
 To better understand the application architecture, let's take a look at the network
@@ -168,7 +168,7 @@ come from the same hostname.
 
 ## Perform Registration, Login, and Logout
 
-Enough theory! Let's start by opening 
+Enough theory! Let's start by opening
 the dashboard: go to [127.0.0.1:4455/dashboard](http://127.0.0.1:4455/dashboard).
 
 Check the [Quickstart](../quickstart.mdx) for the other flows!
@@ -236,7 +236,7 @@ authenticators
 
 The
 [Allowed Authenticator](https://www.ory.sh/docs/oathkeeper/pipeline/authz#allowed)
-simply allows all users to access the URL. Since we don't have Role-based access control (RBAC) or an Access Control list (ACL) in 
+simply allows all users to access the URL. Since we don't have Role-based access control (RBAC) or an Access Control list (ACL) in
 place for this example, this will be enough.
 
 ```yaml title="contrib/quickstart/oathkeeper/.oathkeeper.yml"
@@ -256,13 +256,13 @@ takes all the available session information and puts it into a JSON Web Token
 
 ```Authorization: bearer <jwt...>```
 
-in the HTTP Header instead of 
+in the HTTP Header instead of
 
 ```Cookie: ory_kratos_session=...```
 
 The JWT is
 signed using a RS256 key. To verify the JWT we can use the public key provided
-by ORY Oathkeeper's JWKS API: 
+by ORY Oathkeeper's JWKS API:
 
 ```http://127.0.0.1:4456/.well-known/jwks.json```
 

--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -214,7 +214,7 @@ This demo makes use of several services:
 2. [SecureApp](http://github.com/ory/kratos-selfservice-ui-node)
 - Public (port 4455) - an example application written in NodeJS
   that implements the login, registration, logout, dashboard, and other UIs.
-3. [MailHog](https://github.com/mailhog/MailHog)
+3. [MailSlurper](https://github.com/mailslurper)
 - Public (port 4436) - a development SMTP server which ORY Kratos will use to send emails.
 
 :::note


### PR DESCRIPTION
The docs referenced Mailhog but the quickstart uses MailSlurper.

This PR replaces references to Mailhog with Mailslurper in the latest docs. I did not update the versioned docs as I do not know when Mailhog was actually used.

urls:
- https://www.ory.sh/kratos/docs/quickstart
- https://www.ory.sh/kratos/docs/guides/zero-trust-iap-proxy-identity-access-proxy
