### PR TITLE
fix: docker-compose quickstart connectivity issues

### DIFF
--- a/quickstart-crdb.yml
+++ b/quickstart-crdb.yml
@@ -14,3 +14,5 @@ services:
     ports:
       - "26257:26257"
     command: start --insecure
+    networks:
+      - intranet

--- a/quickstart-mysql.yml
+++ b/quickstart-mysql.yml
@@ -15,3 +15,5 @@ services:
       - "3306:3306"
     environment:
       - MYSQL_ROOT_PASSWORD=secret
+    networks:
+      - intranet

--- a/quickstart-postgres.yml
+++ b/quickstart-postgres.yml
@@ -17,3 +17,5 @@ services:
       - POSTGRES_USER=kratos
       - POSTGRES_PASSWORD=secret
       - POSTGRES_DB=kratos
+    networks:
+      - intranet


### PR DESCRIPTION
All of the databases must exist on the same docker network to allow the main kratos applications to communicate with them.

Fixes the issue described in https://community.ory.sh/t/running-kratos-with-postgres/1908, I've tested them all locally.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).