### PR TITLE
configs: fix networks config for quickstart-postgres.yml

### DIFF
--- a/quickstart-postgres.yml
+++ b/quickstart-postgres.yml
@@ -17,3 +17,5 @@ services:
       - POSTGRES_USER=kratos
       - POSTGRES_PASSWORD=secret
       - POSTGRES_DB=kratos
+    networks:
+      - intranet


### PR DESCRIPTION
## Related issue

Discussed issue with @aeneasr in slack chat.

## Proposed changes

If I run postgres quickstart example, then kratos and kratos-migrate cannot connect to the postgres database.

```
$ docker-compose -f quickstart.yml -f quickstart-oathkeeper.yml -f quickstart-postgres.yml  up --build --force-recreate

Pulling oathkeeper (oryd/oathkeeper:v0.38)...
v0.38: Pulling from oryd/oathkeeper
ef9dc5060082: Pull complete
1a9961535d58: Pull complete
Digest: sha256:c1219f993ca20669afc03a4df0caf436e2747ea3322a15d58eab342997e8dd62
Status: Downloaded newer image for oryd/oathkeeper:v0.38
Recreating kratos_mailslurper_1                ... done
Recreating kratos_kratos-selfservice-ui-node_1 ... done
Recreating kratos_postgresd_1                  ... done
Recreating kratos_kratos-migrate_1             ... done
Recreating kratos_kratos_1                     ... done
Recreating kratos_oathkeeper_1                 ... done
Attaching to kratos_postgresd_1, kratos_kratos-selfservice-ui-node_1, kratos_mailslurper_1, kratos_kratos-migrate_1, kratos_kratos_1, kratos_oathkeeper_1
kratos-migrate_1              | time="2020-06-21T06:46:22Z" level=info msg="Config file loaded successfully." path=/etc/config/kratos/.kratos.yml
kratos-selfservice-ui-node_1  | 
kratos-selfservice-ui-node_1  | > kratos-selfservice-ui-node@0.0.1 serve /usr/src/app
kratos-selfservice-ui-node_1  | > node lib/index.js
kratos-selfservice-ui-node_1  | 
mailslurper_1                 | time="2020-06-21T06:46:22Z" level=info msg="Starting MailSlurper Server v1.14.1" who=MailSlurper
kratos_1                      | time="2020-06-21T06:46:22Z" level=info msg="Config file loaded successfully." path=/etc/config/kratos/.kratos.yml
kratos_1                      | time="2020-06-21T06:46:22Z" level=warning msg="\n\nYOU ARE RUNNING ORY KRATOS IN DEV MODE.\nSECURITY IS DISABLED.\nDON'T DO THIS IN PRODUCTION!\n\n"
kratos-migrate_1              | time="2020-06-21T06:46:22Z" level=warning msg="Unable to ping database, retrying." error="dial tcp: lookup postgresd on 127.0.0.11:53: no such host"
postgresd_1                   | 
mailslurper_1                 | time="2020-06-21T06:46:22Z" level=info msg="Connecting to database" who=MailSlurper
kratos-migrate_1              | time="2020-06-21T06:46:23Z" level=warning msg="Unable to ping database, retrying." error="dial tcp: lookup postgresd on 127.0.0.11:53: no such host"
kratos_1                      | time="2020-06-21T06:46:22Z" level=warning msg="Unable to ping database, retrying." error="dial tcp: lookup postgresd on 127.0.0.11:53: no such host"
postgresd_1                   | PostgreSQL Database directory appears to contain a database; Skipping initialization
postgresd_1                   | 
kratos_1                      | time="2020-06-21T06:46:23Z" level=warning msg="Unable to ping database, retrying." error="dial tcp: lookup postgresd on 127.0.0.11:53: no such host"
mailslurper_1                 | time="2020-06-21T06:46:22Z" level=info msg="Creating database tables..." who=MailSlurper
postgresd_1                   | LOG:  database system was shut down at 2020-06-19 07:24:13 UTC
mailslurper_1                 | time="2020-06-21T06:46:22Z" level=info msg="Created tables successfully." who=MailSlurper
postgresd_1                   | LOG:  MultiXact member wraparound protections are now enabled
mailslurper_1                 | time="2020-06-21T06:46:22Z" level=info msg="Worker pool configured for 1000 workers" who="SMTP Server Pool"
mailslurper_1                 | time="2020-06-21T06:46:22Z" level=info msg="SMTP listener running on SSL 0.0.0.0:1025" who="SMTP Listener"
postgresd_1                   | LOG:  autovacuum launcher started
postgresd_1                   | LOG:  database system is ready to accept connections
mailslurper_1                 | time="2020-06-21T06:46:22Z" level=info msg="HTTP admin listener running on 0.0.0.0:4436" who=MailSlurper
mailslurper_1                 | ⇨ http server started on [::]:4436
mailslurper_1                 | time="2020-06-21T06:46:22Z" level=info msg="1 receiver(s) listening" who="SMTP Listener"
mailslurper_1                 | ⇨ http server started on [::]:4437
oathkeeper_1                  | {"level":"info","msg":"Config file loaded successfully.","path":"/etc/config/oathkeeper/.oathkeeper.yml","time":"2020-06-21T06:46:23Z"}
oathkeeper_1                  | Thank you for using ORY Oathkeeper v0.38.2-beta.1!
oathkeeper_1                  | 
oathkeeper_1                  | Take security seriously and subscribe to the ORY Security Newsletter. Stay on top of new patches and security insights.                                                                                                
oathkeeper_1                  | 
oathkeeper_1                  | >> Subscribe now: http://eepurl.com/di390P <<
oathkeeper_1                  | {"event":"matching_strategy_config_change","level":"debug","msg":"Viper detected a configuration change, updating matching strategy","source":"entrypoint","time":"2020-06-21T06:46:23Z"}
oathkeeper_1                  | {"event":"config_change","level":"debug","msg":"Viper detected a configuration change, reloading config.","source":"entrypoint","time":"2020-06-21T06:46:23Z"}
oathkeeper_1                  | {"event":"repository_change","file":"file:///etc/config/oathkeeper/access-rules.yml","level":"debug","msg":"One or more access rule repositories changed, reloading access rules.","source":"config_update","time":"2020-06-21T06:46:23Z"}
oathkeeper_1                  | {"level":"debug","location":"file:///etc/config/oathkeeper/access-rules.yml","msg":"Fetching access rules from given location because something changed.","time":"2020-06-21T06:46:23Z"}
oathkeeper_1                  | {"level":"info","msg":"Software quality assurance features are enabled. Learn more at: https://www.ory.sh/docs/ecosystem/sqa","time":"2020-06-21T06:46:23Z"}
oathkeeper_1                  | {"level":"info","msg":"No tracer configured - skipping tracing setup","time":"2020-06-21T06:46:23Z"}
oathkeeper_1                  | {"level":"info","msg":"Listening on http://:9000","time":"2020-06-21T06:46:23Z"}
oathkeeper_1                  | {"level":"info","msg":"TLS has not been configured for api, skipping","time":"2020-06-21T06:46:23Z"}
oathkeeper_1                  | {"level":"info","msg":"Listening on http://:4456","time":"2020-06-21T06:46:23Z"}
oathkeeper_1                  | {"level":"info","msg":"TLS has not been configured for proxy, skipping","time":"2020-06-21T06:46:23Z"}
oathkeeper_1                  | {"level":"info","msg":"Listening on http://:4455","time":"2020-06-21T06:46:23Z"}
kratos-migrate_1              | time="2020-06-21T06:46:23Z" level=warning msg="Unable to ping database, retrying." error="dial tcp: lookup postgresd on 127.0.0.11:53: no such host"
kratos-selfservice-ui-node_1  | Listening on http://0.0.0.0:4435
kratos-selfservice-ui-node_1  | Security mode: jwt
kratos_1                      | time="2020-06-21T06:46:23Z" level=warning msg="Unable to ping database, retrying." error="dial tcp: lookup postgresd on 127.0.0.11:53: no such host"
kratos-migrate_1              | time="2020-06-21T06:46:24Z" level=warning msg="Unable to ping database, retrying." error="dial tcp: lookup postgresd on 127.0.0.11:53: no such host"
kratos_1                      | time="2020-06-21T06:46:24Z" level=warning msg="Unable to ping database, retrying." error="dial tcp: lookup postgresd on 127.0.0.11:53: no such host"
kratos_1                      | time="2020-06-21T06:46:25Z" level=warning msg="Unable to ping database, retrying." error="dial tcp: lookup postgresd on 127.0.0.11:53: no such host"
kratos-migrate_1              | time="2020-06-21T06:46:26Z" level=warning msg="Unable to ping database, retrying." error="dial tcp: lookup postgresd on 127.0.0.11:53: no such host"
kratos-migrate_1              | time="2020-06-21T06:46:28Z" level=warning msg="Unable to ping database, retrying." error="dial tcp: lookup postgresd on 127.0.0.11:53: no such host"
kratos_1                      | time="2020-06-21T06:46:28Z" level=warning msg="Unable to ping database, retrying." error="dial tcp: lookup postgresd on 127.0.0.11:53: no such host"
```

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).
