### PR TITLE
feat: Add User ID to a header when calling whoami

### DIFF
--- a/session/handler.go
+++ b/session/handler.go
@@ -82,7 +82,7 @@ func (h *Handler) whoami(w http.ResponseWriter, r *http.Request, ps httprouter.P
 	s.Identity = s.Identity.CopyWithoutCredentials()
 	
 	// Set userId as the X-Authenticated-User header.
-	w.Header().Set("X-Authenticated-User", s.Identity.ID.String())
+	w.Header().Set("X-Kratos-Authenticated-Identity-Id", s.Identity.ID.String())
 
 	h.r.Writer().Write(w, r, s)
 }

--- a/session/handler.go
+++ b/session/handler.go
@@ -56,7 +56,8 @@ func (h *Handler) RegisterAdminRoutes(admin *x.RouterAdmin) {
 // Check who the current HTTP session belongs to
 //
 // Uses the HTTP Headers in the GET request to determine (e.g. by using checking the cookies) who is authenticated.
-// Returns a session object or 401 if the credentials are invalid or no credentials were sent.
+// Returns a session object in the body or 401 if the credentials are invalid or no credentials were sent.
+// Additionally when the request it successful it adds the user ID to the 'X-Kratos-Authenticated-Identity-Id' header in the response.
 //
 // This endpoint is useful for reverse proxies and API Gateways.
 //
@@ -80,8 +81,8 @@ func (h *Handler) whoami(w http.ResponseWriter, r *http.Request, ps httprouter.P
 
 	// s.Devices = nil
 	s.Identity = s.Identity.CopyWithoutCredentials()
-	
-	// Set userId as the X-Authenticated-User header.
+
+	// Set userId as the X-Kratos-Authenticated-Identity-Id header.
 	w.Header().Set("X-Kratos-Authenticated-Identity-Id", s.Identity.ID.String())
 
 	h.r.Writer().Write(w, r, s)

--- a/session/handler.go
+++ b/session/handler.go
@@ -80,6 +80,9 @@ func (h *Handler) whoami(w http.ResponseWriter, r *http.Request, ps httprouter.P
 
 	// s.Devices = nil
 	s.Identity = s.Identity.CopyWithoutCredentials()
+	
+	// Set userId as the X-Authenticated-User header.
+	w.Header().Set("X-Authenticated-User", s.Identity.ID.String())
 
 	h.r.Writer().Write(w, r, s)
 }

--- a/session/handler_test.go
+++ b/session/handler_test.go
@@ -72,6 +72,7 @@ func TestSessionWhoAmI(t *testing.T) {
 				res, err = client.Do(req)
 				require.NoError(t, err)
 				assert.EqualValues(t, http.StatusOK, res.StatusCode)
+				assert.NotEmpty(t, res.Header.Get("X-Kratos-Authenticated-Identity-Id"))
 			})
 		}
 	})


### PR DESCRIPTION
## Related issue
We're using the AuthService provided by Ambassador to check if the user is authenticated but right now we're separately calling the whoami again. This means that for every request that a user does we're talking to Kratos twice. By adding the User ID to a header we can prevent this by using the `allowed_authorization_headers` option (see Ambassador doc: https://www.getambassador.io/docs/latest/topics/running/services/auth-service/). 

## Proposed changes
Set the UserID in a header, I've put it on "X-Authenticated-User" right now.

## Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).
