### PR TITLE
feat: add discord provider for social login

### DIFF
--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -95,7 +95,8 @@
           "enum": [
             "github",
             "generic",
-            "google"
+            "google",
+            "discord"
           ],
           "examples": [
             "google"

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0
 	github.com/armon/go-metrics v0.3.3 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 // indirect
+	github.com/bwmarrin/discordgo v0.21.1 // indirect
 	github.com/bxcodec/faker/v3 v3.3.1
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/coreos/go-oidc v2.2.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
+github.com/bwmarrin/discordgo v0.21.1 h1:UI2PWwzvn5IFuscYcDc6QB/duhs9MUIjQ4HclcIZisc=
+github.com/bwmarrin/discordgo v0.21.1/go.mod h1:c1WtWUGN6nREDmzIpyTp/iD3VYt4Fpx+bVyfBG7JE+M=
 github.com/bxcodec/faker/v3 v3.3.1 h1:G7uldFk+iO/ES7W4v7JlI/WU9FQ6op9VJ15YZlDEhGQ=
 github.com/bxcodec/faker/v3 v3.3.1/go.mod h1:gF31YgnMSMKgkvl+fyEo1xuSMbEuieyqfeslGYFjneM=
 github.com/cenkalti/backoff v2.1.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
@@ -681,6 +683,7 @@ github.com/gorilla/sessions v1.1.2/go.mod h1:8KCfur6+4Mqcc6S0FEfKuN15Vl5MgXW92AE
 github.com/gorilla/sessions v1.1.3 h1:uXoZdcdA5XdXF3QzuSlheVRUvjl+1rKY7zBXL68L9RU=
 github.com/gorilla/sessions v1.1.3/go.mod h1:8KCfur6+4Mqcc6S0FEfKuN15Vl5MgXW92AE8ovaJD0w=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gotestyourself/gotestyourself v1.3.0 h1:9X3T0HDKAY/58/sEPpTkmyOg4wbb1ab9tZfV44mTSeE=
 github.com/gotestyourself/gotestyourself v1.3.0/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
@@ -1334,6 +1337,7 @@ golang.org/x/crypto v0.0.0-20181024171144-74cb1d3d52f4/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20181025113841-85e1b3f9139a/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181025213731-e84da0312774/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20181030102418-4d3f4d9ffa16/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181106171534-e4dc69e5b2fd/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181112202954-3d3f9f413869/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181127143415-eb0de9b17e85/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/selfservice/strategy/oidc/provider_config.go
+++ b/selfservice/strategy/oidc/provider_config.go
@@ -70,6 +70,8 @@ func (c ConfigurationCollection) Provider(id string, public *url.URL) (Provider,
 				return NewProviderGoogle(&p, public), nil
 			case "github":
 				return NewProviderGitHub(&p, public), nil
+			case "discord":
+				return NewProviderDiscord(&p, public), nil
 			}
 			return nil, errors.Errorf("provider type %s is not supported, supported are: %v", p.Provider, []string{"google"})
 		}

--- a/selfservice/strategy/oidc/provider_discord.go
+++ b/selfservice/strategy/oidc/provider_discord.go
@@ -1,0 +1,100 @@
+package oidc
+
+import (
+	"context"
+	"fmt"
+	"github.com/bwmarrin/discordgo"
+	"github.com/ory/herodot"
+	"github.com/ory/x/stringslice"
+	"github.com/ory/x/stringsx"
+	"github.com/pkg/errors"
+	"golang.org/x/oauth2"
+	"net/url"
+)
+
+type ProviderDiscord struct {
+	config *Configuration
+	public *url.URL
+}
+
+func NewProviderDiscord(
+	config *Configuration,
+	public *url.URL,
+) *ProviderDiscord {
+	return &ProviderDiscord{
+		config: config,
+		public: public,
+	}
+}
+
+func (d *ProviderDiscord) Config() *Configuration {
+	return d.config
+}
+
+func (d *ProviderDiscord) oauth2() *oauth2.Config {
+	scope := d.config.Scope
+	if !stringslice.Has(scope, "identify") {
+		scope = append(scope, "identify")
+	}
+
+	if !stringslice.Has(scope, "email") {
+		scope = append(scope, "email")
+	}
+
+	return &oauth2.Config{
+		ClientID:     d.config.ClientID,
+		ClientSecret: d.config.ClientSecret,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  discordgo.EndpointOauth2 + "authorize",
+			TokenURL: discordgo.EndpointOauth2 + "token",
+		},
+		RedirectURL: d.config.Redir(d.public),
+		Scopes:      scope,
+	}
+}
+
+func (d *ProviderDiscord) OAuth2(ctx context.Context) (*oauth2.Config, error) {
+	return d.oauth2(), nil
+}
+
+func (d *ProviderDiscord) AuthCodeURLOptions(r request) []oauth2.AuthCodeOption {
+	if isForced(r) {
+		return []oauth2.AuthCodeOption{
+			oauth2.SetAuthURLParam("prompt", "consent"),
+		}
+	}
+	return []oauth2.AuthCodeOption{}
+}
+
+func (d *ProviderDiscord) Claims(ctx context.Context, exchange *oauth2.Token) (*Claims, error) {
+	grantedScopes := stringsx.Splitx(fmt.Sprintf("%s", exchange.Extra("scope")), ",")
+	for _, check := range d.Config().Scope {
+		if !stringslice.Has(grantedScopes, check) {
+			return nil, errors.WithStack(ErrScopeMissing)
+		}
+	}
+
+	dg, err := discordgo.New(fmt.Sprintf("Bearer %s", exchange.AccessToken))
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+
+	user, err := dg.User("@me")
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+
+	claims := &Claims{
+		Issuer:            discordgo.EndpointOauth2,
+		Subject:           user.ID,
+		Name:              fmt.Sprintf("%s#%s", user.Username, user.Discriminator),
+		Nickname:          user.Username,
+		PreferredUsername: user.Username,
+		Picture:           user.AvatarURL(""),
+		Email:             user.Email,
+		EmailVerified:     user.Verified,
+		Locale:            user.Locale,
+	}
+
+	return claims, nil
+}


### PR DESCRIPTION
## Related issue

This PR closes #533 

## Proposed changes

Add a package for the discord api (https://github.com/bwmarrin/discordgo) and implement the provider similiar to the GitHub one.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

