### PR TITLE
feat: Add quickstart variant: kratos with hydra

### DIFF
--- a/contrib/quickstart/oidc-provider/config/kratos/email-password/.kratos.yml
+++ b/contrib/quickstart/oidc-provider/config/kratos/email-password/.kratos.yml
@@ -1,0 +1,72 @@
+selfservice:
+  strategies:
+    password:
+      enabled: true
+
+  settings:
+    privileged_session_max_age: 1m
+    after:
+      profile:
+        hooks:
+          -
+            hook: verify
+
+  verify:
+    return_to: http://127.0.0.1:3000/
+
+  logout:
+    redirect_to: http://127.0.0.1:3000/auth/login
+
+  login:
+    request_lifespan: 10m
+
+  registration:
+    request_lifespan: 10m
+    after:
+      password:
+        hooks:
+          -
+            hook: session
+          -
+            hook: verify
+
+log:
+  level: debug
+
+secrets:
+  session:
+    - PLEASE-CHANGE-ME-I-AM-VERY-INSECURE
+
+urls:
+  login_ui: http://127.0.0.1:3000/auth/login
+  registration_ui: http://127.0.0.1:3000/auth/registration
+  error_ui: http://127.0.0.1:3000/error
+  settings_ui: http://127.0.0.1:3000/settings
+  verify_ui: http://127.0.0.1:3000/verify
+
+  # These are undefined because not available in this demo
+  mfa_ui: http://127.0.0.1:3000/
+
+  self:
+    public: http://127.0.0.1:3000/.ory/kratos/public/
+    admin: http://kratos:4434/
+  default_return_to: http://127.0.0.1:3000/
+  whitelisted_return_to_urls:
+    - http://127.0.0.1:3000/
+    - http://127.0.0.1:3000/auth/hydra/login
+
+hashers:
+  argon2:
+    parallelism: 1
+    memory: 131072
+    iterations: 2
+    salt_length: 16
+    key_length: 16
+
+identity:
+  traits:
+    default_schema_url: file:///etc/config/kratos/identity.traits.schema.json
+
+courier:
+  smtp:
+    connection_uri: smtps://test:test@mailslurper:1025/?skip_ssl_verify=true

--- a/contrib/quickstart/oidc-provider/config/kratos/email-password/identity.traits.schema.json
+++ b/contrib/quickstart/oidc-provider/config/kratos/email-password/identity.traits.schema.json
@@ -1,0 +1,28 @@
+{
+  "$id": "https://schemas.ory.sh/presets/kratos/quickstart/email-password/identity.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Person",
+  "type": "object",
+  "properties": {
+    "email": {
+      "type": "string",
+      "format": "email",
+      "title": "E-Mail",
+      "minLength": 3,
+      "ory.sh/kratos": {
+        "credentials": {
+          "password": {
+            "identifier": true
+          }
+        },
+        "verification": {
+          "via": "email"
+        }
+      }
+    }
+  },
+  "required": [
+    "email"
+  ],
+  "additionalProperties": false
+}

--- a/contrib/quickstart/oidc-provider/pg-init/pg-init.sh
+++ b/contrib/quickstart/oidc-provider/pg-init/pg-init.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+set -u
+
+function create_user_and_database() {
+	local database=$1
+	echo "  Creating user and database '$database'"
+	psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
+	    CREATE USER $database;
+	    CREATE DATABASE $database;
+	    GRANT ALL PRIVILEGES ON DATABASE $database TO $database;
+EOSQL
+}
+
+if [ -n "$POSTGRES_MULTIPLE_DATABASES" ]; then
+	echo "Multiple database creation requested: $POSTGRES_MULTIPLE_DATABASES"
+	for db in $(echo $POSTGRES_MULTIPLE_DATABASES | tr ',' ' '); do
+		create_user_and_database $db
+	done
+	echo "Multiple databases created"
+fi

--- a/quickstart-hydra.yml
+++ b/quickstart-hydra.yml
@@ -1,0 +1,78 @@
+version: '3.7'
+
+services:
+  postgresd:
+    image: postgres:9.6
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=pguser
+      - POSTGRES_PASSWORD=secret
+      - POSTGRES_MULTIPLE_DATABASES=kratos,hydra
+    volumes:
+      - ./contrib/quickstart/oidc-provider/pg-init:/docker-entrypoint-initdb.d
+    networks:
+      - intranet
+
+  hydra-migrate:
+    image: oryd/hydra:1.4.8
+    depends_on:
+      - postgresd
+    environment:
+      - DSN=postgres://pguser:secret@postgresd:5432/hydra?sslmode=disable
+    command:
+      migrate sql -e --yes
+    restart: on-failure
+    networks:
+      - intranet
+
+  hydra:
+    image: oryd/hydra:1.4.8
+    depends_on:
+      - hydra-migrate
+    ports:
+      - "4444:4444" # Public port
+      - "4445:4445" # Admin port
+      - "5555:5555" # Port for hydra token user
+    command:
+      serve all --dangerous-force-http
+    restart: on-failure # TODO figure out why we need this (incorporate health check into hydra migrate command?)
+    environment:
+      - LOG_LEAK_SENSITIVE_VALUES=true
+      - URLS_SELF_ISSUER=http://127.0.0.1:4444
+      - URLS_SELF_PUBLIC=http://127.0.0.1:4444
+      - URLS_CONSENT=http://127.0.0.1:3000/auth/hydra/consent
+      - URLS_LOGIN=http://127.0.0.1:3000/auth/hydra/login
+      - URLS_LOGOUT=http://127.0.0.1:3000/logout
+      - SECRETS_SYSTEM=youReallyNeedToChangeThis
+      - OIDC_SUBJECT_IDENTIFIERS_SUPPORTED_TYPES=public,pairwise
+      - OIDC_SUBJECT_IDENTIFIERS_PAIRWISE_SALT=youReallyNeedToChangeThis
+      - DSN=postgres://pguser:secret@postgresd:5432/hydra?sslmode=disable
+    networks:
+      - intranet
+
+  kratos-migrate:
+    command:
+      -c /etc/config/kratos/.kratos.yml migrate sql -e --yes
+
+  kratos:
+    volumes:
+      -
+        type: bind
+        source: ./contrib/quickstart/oidc-provider/config/kratos/email-password
+        target: /etc/config/kratos
+
+  kratos-selfservice-ui-node:
+    # ToDo: change image back to ory-org (changed to make it testable)
+    image: k9ert/kratos-selfservice-ui-node:hydrakratos01
+    environment:
+      - HYDRA_ADMIN_URL=http://hydra:4445
+      - KRATOS_PUBLIC_URL=http://kratos:4433/
+      - KRATOS_ADMIN_URL=http://kratos:4434/
+      - SECURITY_MODE=standalone
+      - PORT=3000
+    ports:
+      - "3000:3000"
+
+networks:
+  intranet:


### PR DESCRIPTION
## Related issue

This is related to https://github.com/ory/kratos-selfservice-ui-node/pull/50
which in turn is related to #273 

## Proposed changes

This is adding a quickstart-variation which demonstrates one possible integration with hydra. 

## Checklist

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [X ] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

* As an absolute minimum, this PR needs to wait on a recent docker-image from kratos-selfservice-ui-node which need to be replaced in quickstart-hydra.yml.
* the kratos-configuration and the identity-traits can probably be removed and the standard ones can be used

Until these two points are resolved, this PR can be seen as WIP.
