### PR TITLE
fix: detection of SQLite memory mode

### DIFF
--- a/driver/registry.go
+++ b/driver/registry.go
@@ -150,9 +150,7 @@ func NewRegistry(c configuration.Provider) (Registry, error) {
 	}
 
 	// if dsn is memory we have to run the migrations on every start
-	isSQLiteMemoryMode := IsSQLiteMemoryMode(dsn)
-
-	if isSQLiteMemoryMode {
+	if IsSQLiteMemoryMode(dsn) {
 		registry.Logger().Print("Kratos is running migrations on every startup as DSN is memory.\n")
 		registry.Logger().Print("This means your data is lost when Kratos terminates.\n")
 		if err := registry.Persister().MigrateUp(context.Background()); err != nil {

--- a/driver/registry_test.go
+++ b/driver/registry_test.go
@@ -1,0 +1,27 @@
+package driver_test
+
+import (
+	"fmt"
+	"testing"
+
+	driver "github.com/ory/kratos/driver"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDriverDefault_SQLiteMemoryMode(t *testing.T) {
+	t.Run("case=settings", func(t *testing.T) {
+		for k, tc := range []struct {
+			dsn string
+			boo bool
+		}{
+			{dsn: "sqlite://mem.db?mode=memory&_fk=true&cache=shared", boo: true},
+			{dsn: "sqlite://mem.db?mode=asd&_fk=true&cache=shared", boo: false},
+			{dsn: "invalidurl", boo: false},
+		} {
+			t.Run(fmt.Sprintf("run=%d", k), func(t *testing.T) {
+				isMem := driver.IsSQLiteMemoryMode(tc.dsn)
+				assert.Equal(t, tc.boo, isMem)
+			})
+		}
+	})
+}


### PR DESCRIPTION
## Proposed changes
The configuration shortcut `dsn="memory"` was not recognize correctly. This PR fixes the check for SQLite memory mode and extracts the test into a function and adds a test for the function.

## Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).