### PR TITLE
fix: require selfservice.default_browser_return_url to be set in config

### DIFF
--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -256,6 +256,9 @@
     "selfservice": {
       "type": "object",
       "additionalProperties": false,
+      "required": [
+        "default_browser_return_url"
+      ],
       "properties": {
         "default_browser_return_url": {
           "$ref": "#/definitions/defaultReturnTo"


### PR DESCRIPTION
## Related issue

Kratos requires `selfservice.default_browser_return_url` to be set but this was not reflected in the config schema.