### PR TITLE
fix: password validator uses relative threshold to judge longest common substring

### DIFF
--- a/selfservice/strategy/password/validator.go
+++ b/selfservice/strategy/password/validator.go
@@ -78,7 +78,7 @@ func b20(src []byte) string {
 }
 
 // code inspired by https://rosettacode.org/wiki/Longest_Common_Substring#Go
-func lcsLength(a, b string) float32 {
+func lcsLength(a, b string) int {
 	lengths := make([]int, len(a)*len(b))
 	greatestLength := 0
 	for i, x := range a {
@@ -96,7 +96,7 @@ func lcsLength(a, b string) float32 {
 			}
 		}
 	}
-	return float32(greatestLength)
+	return greatestLength
 }
 
 func (s *DefaultPasswordValidator) fetch(hpw []byte) error {
@@ -155,7 +155,7 @@ func (s *DefaultPasswordValidator) Validate(identifier, password string) error {
 
 	compIdentifier, compPassword := strings.ToLower(identifier), strings.ToLower(password)
 	dist := levenshtein.Distance(compIdentifier, compPassword)
-	lcs := lcsLength(compIdentifier, compPassword) / float32(len(compPassword))
+	lcs := float32(lcsLength(compIdentifier, compPassword)) / float32(len(compPassword))
 	if dist < s.minIdentifierPasswordDist || lcs > s.maxIdentifierPasswordSubstrThreshold {
 		return errors.Errorf("the password is too similar to the user identifier")
 	}

--- a/selfservice/strategy/password/validator_test.go
+++ b/selfservice/strategy/password/validator_test.go
@@ -62,13 +62,16 @@ func TestDefaultPasswordValidationStrategy(t *testing.T) {
 		{id: "abcd", pw: "9d3c8a1b", pass: true},
 		{id: "a", pw: "kjOkla", pass: true},
 		{id: "ab", pw: "0000ab0000", pass: true},
+		// longest common substring with long password
+		{id: "d4f6090b-5a84", pw: "d4f6090b-5a84-2184-4404-8d1b-8da3eb00ebbe", pass: true},
+		{id: "asdflasdflasdf", pw: "asdflasdflpiuhefnciluaksdzuföfhg", pass: true},
 	} {
 		t.Run(fmt.Sprintf("case=%d", k), func(t *testing.T) {
 			err := s.Validate(tc.id, tc.pw)
 			if tc.pass {
-				require.NoError(t, err, "%+v", err)
+				require.NoError(t, err, "err: %+v, id: %s, pw: %s", err, tc.id, tc.pw)
 			} else {
-				require.Error(t, err)
+				require.Error(t, err, "id: %s, pw: %s", tc.id, tc.pw)
 			}
 		})
 	}


### PR DESCRIPTION
## Related issue

closes #581 
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

Whether the longest common substring is too long is now relative to the length of the password.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->
