### PR TITLE
fix: resolve identity admin api issues 

### DIFF
--- a/identity/handler_test.go
+++ b/identity/handler_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ory/x/urlx"
 
+	"github.com/ory/kratos/internal/testhelpers"
 	"github.com/ory/kratos/schema"
 
 	"github.com/stretchr/testify/assert"
@@ -32,15 +33,14 @@ func TestHandler(t *testing.T) {
 	defer ts.Close()
 
 	mockServerURL := urlx.ParseOrPanic("http://example.com")
-	defaultSchemaInternalURL := urlx.ParseOrPanic("file://./stub/identity.schema.json")
-	defaultSchema := schema.Schema{
-		ID:  "default",
-		URL: defaultSchemaInternalURL,
-	}
-	defaultSchemaExternalURL := defaultSchema.SchemaURL(mockServerURL).String()
+	defaultSchemaExternalURL := (&schema.Schema{ID: "default"}).SchemaURL(mockServerURL).String()
 
 	viper.Set(configuration.ViperKeyAdminBaseURL, ts.URL)
-	viper.Set(configuration.ViperKeyDefaultIdentitySchemaURL, defaultSchemaInternalURL.String())
+	testhelpers.SetDefaultIdentitySchema("file://./stub/identity.schema.json")
+	testhelpers.SetIdentitySchemas(map[string]string{
+		"customer": "file://./stub/handler/customer.schema.json",
+		"employee": "file://./stub/handler/employee.schema.json",
+	})
 	viper.Set(configuration.ViperKeyPublicBaseURL, mockServerURL.String())
 
 	var get = func(t *testing.T, href string, expectCode int) gjson.Result {
@@ -91,67 +91,147 @@ func TestHandler(t *testing.T) {
 	})
 
 	t.Run("case=should fail to create an identity because schema id does not exist", func(t *testing.T) {
-		var i identity.Identity
+		var i identity.CreateIdentityRequestPayload
 		i.SchemaID = "does-not-exist"
 		res := send(t, "POST", "/identities", http.StatusBadRequest, &i)
 		assert.Contains(t, res.Get("error.reason").String(), "does-not-exist", "%s", res)
 	})
 
 	t.Run("case=should fail to create an entity because schema is not validating", func(t *testing.T) {
-		var i identity.Identity
-		i.Traits = identity.Traits(`{"bar":123}`)
+		var i identity.CreateIdentityRequestPayload
+		i.Traits = []byte(`{"bar":123}`)
 		res := send(t, "POST", "/identities", http.StatusBadRequest, &i)
 		assert.Contains(t, res.Get("error.reason").String(), "I[#/traits/bar] S[#/properties/traits/properties/bar/type] expected string, but got number")
 	})
 
 	t.Run("case=should fail to create an entity with schema_url set", func(t *testing.T) {
-		var i identity.Identity
-		i.SchemaURL = "http://example.com"
-		res := send(t, "POST", "/identities", http.StatusBadRequest, &i)
-		assert.Contains(t, res.Get("error.reason").String(), "set a traits schema")
+		res := send(t, "POST", "/identities", http.StatusBadRequest, json.RawMessage(`{"schema_url":"12345","traits":{}}`))
+		assert.Contains(t, res.Get("error.message").String(), "schema_url")
 	})
 
 	t.Run("case=should create an identity without an ID", func(t *testing.T) {
-		var i identity.Identity
-		i.Traits = identity.Traits(`{"bar":"baz"}`)
+		var i identity.CreateIdentityRequestPayload
+		i.Traits = []byte(`{"bar":"baz"}`)
 		res := send(t, "POST", "/identities", http.StatusCreated, &i)
 		assert.NotEmpty(t, res.Get("id").String(), "%s", res.Raw)
 		assert.EqualValues(t, "baz", res.Get("traits.bar").String(), "%s", res.Raw)
 		assert.Empty(t, res.Get("credentials").String(), "%s", res.Raw)
 	})
 
-	var i identity.Identity
-	t.Run("case=should create an identity with an ID which is ignored", func(t *testing.T) {
-		i.ID = x.NewUUID()
-		i.Traits = identity.Traits(`{"bar":"baz"}`)
-		res := send(t, "POST", "/identities", http.StatusCreated, &i)
-		assert.NotEqual(t, i.ID.String(), res.Get("id").String(), "%s", res.Raw)
-
-		i.ID = x.ParseUUID(res.Get("id").String())
-		assert.EqualValues(t, "baz", res.Get("traits.bar").String(), "%s", res.Raw)
-		assert.Empty(t, res.Get("credentials").String(), "%s", res.Raw)
-		assert.EqualValues(t, defaultSchemaExternalURL, res.Get("schema_url").String(), "%s", res.Raw)
-		assert.EqualValues(t, configuration.DefaultIdentityTraitsSchemaID, res.Get("schema_id").String(), "%s", res.Raw)
+	t.Run("case=unable to set ID itself", func(t *testing.T) {
+		res := send(t, "POST", "/identities", http.StatusBadRequest, json.RawMessage(`{"id":"12345","traits":{}}`))
+		assert.Contains(t, res.Raw, "id")
 	})
 
-	t.Run("case=should be able to get the identity", func(t *testing.T) {
-		res := get(t, "/identities/"+i.ID.String(), http.StatusOK)
-		assert.EqualValues(t, i.ID.String(), res.Get("id").String(), "%s", res.Raw)
-		assert.EqualValues(t, "baz", res.Get("traits.bar").String(), "%s", res.Raw)
-		assert.EqualValues(t, defaultSchemaExternalURL, res.Get("schema_url").String(), "%s", res.Raw)
-		assert.EqualValues(t, configuration.DefaultIdentityTraitsSchemaID, res.Get("schema_id").String(), "%s", res.Raw)
-		assert.Empty(t, res.Get("credentials").String(), "%s", res.Raw)
+	t.Run("suite=create and update", func(t *testing.T) {
+		var i identity.Identity
+		t.Run("case=should create an identity with an ID which is ignored", func(t *testing.T) {
+			res := send(t, "POST", "/identities", http.StatusCreated, json.RawMessage(`{"traits": {"bar":"baz"}}`))
+
+			i.Traits = []byte(res.Get("traits").Raw)
+			i.ID = x.ParseUUID(res.Get("id").String())
+			assert.NotEmpty(t, res.Get("id").String())
+
+			assert.EqualValues(t, "baz", res.Get("traits.bar").String(), "%s", res.Raw)
+			assert.Empty(t, res.Get("credentials").String(), "%s", res.Raw)
+			assert.EqualValues(t, defaultSchemaExternalURL, res.Get("schema_url").String(), "%s", res.Raw)
+			assert.EqualValues(t, configuration.DefaultIdentityTraitsSchemaID, res.Get("schema_id").String(), "%s", res.Raw)
+		})
+
+		t.Run("case=should be able to get the identity", func(t *testing.T) {
+			res := get(t, "/identities/"+i.ID.String(), http.StatusOK)
+			assert.EqualValues(t, i.ID.String(), res.Get("id").String(), "%s", res.Raw)
+			assert.EqualValues(t, "baz", res.Get("traits.bar").String(), "%s", res.Raw)
+			assert.EqualValues(t, defaultSchemaExternalURL, res.Get("schema_url").String(), "%s", res.Raw)
+			assert.EqualValues(t, configuration.DefaultIdentityTraitsSchemaID, res.Get("schema_id").String(), "%s", res.Raw)
+			assert.Empty(t, res.Get("credentials").String(), "%s", res.Raw)
+		})
+
+		t.Run("case=should update an identity and persist the changes", func(t *testing.T) {
+			ur := identity.UpdateIdentityRequestPayload{Traits: []byte(`{"bar":"baz","foo":"baz"}`), SchemaID: i.SchemaID}
+			res := send(t, "PUT", "/identities/"+i.ID.String(), http.StatusOK, &ur)
+			assert.EqualValues(t, "baz", res.Get("traits.bar").String(), "%s", res.Raw)
+			assert.EqualValues(t, "baz", res.Get("traits.foo").String(), "%s", res.Raw)
+
+			res = get(t, "/identities/"+i.ID.String(), http.StatusOK)
+			assert.EqualValues(t, i.ID.String(), res.Get("id").String(), "%s", res.Raw)
+			assert.EqualValues(t, "baz", res.Get("traits.bar").String(), "%s", res.Raw)
+		})
+
+		t.Run("case=should delete a client and no longer be able to retrieve it", func(t *testing.T) {
+			remove(t, "/identities/"+i.ID.String(), http.StatusNoContent)
+			_ = get(t, "/identities/"+i.ID.String(), http.StatusNotFound)
+		})
 	})
 
-	t.Run("case=should update an identity and persist the changes", func(t *testing.T) {
-		i.Traits = identity.Traits(`{"bar":"baz","foo":"baz"}`)
-		res := send(t, "PUT", "/identities/"+i.ID.String(), http.StatusOK, &i)
-		assert.EqualValues(t, "baz", res.Get("traits.bar").String(), "%s", res.Raw)
-		assert.EqualValues(t, "baz", res.Get("traits.foo").String(), "%s", res.Raw)
+	t.Run("case=should not be able to create an identity with an invalid schema", func(t *testing.T) {
+		var cr identity.CreateIdentityRequestPayload
+		cr.SchemaID = "unknown"
+		cr.Traits = []byte(`{"email":"` + x.NewUUID().String() + `@ory.sh"}`)
+		res := send(t, "POST", "/identities", http.StatusBadRequest, &cr)
+		assert.Contains(t, res.Raw, "unknown")
+	})
 
-		res = get(t, "/identities/"+i.ID.String(), http.StatusOK)
-		assert.EqualValues(t, i.ID.String(), res.Get("id").String(), "%s", res.Raw)
-		assert.EqualValues(t, "baz", res.Get("traits.bar").String(), "%s", res.Raw)
+	t.Run("case=should create an identity with a different schema", func(t *testing.T) {
+		var cr identity.CreateIdentityRequestPayload
+		cr.SchemaID = "employee"
+		cr.Traits = []byte(`{"email":"` + x.NewUUID().String() + `@ory.sh"}`)
+
+		res := send(t, "POST", "/identities", http.StatusCreated, &cr)
+		assert.JSONEq(t, string(cr.Traits), res.Get("traits").Raw, "%s", res.Raw)
+		assert.EqualValues(t, "employee", res.Get("schema_id").String(), "%s", res.Raw)
+		assert.EqualValues(t, mockServerURL.String()+"/schemas/employee", res.Get("schema_url").String(), "%s", res.Raw)
+	})
+
+	t.Run("case=should create and sync metadata and update privileged traits", func(t *testing.T) {
+		var cr identity.CreateIdentityRequestPayload
+		cr.SchemaID = "employee"
+		originalEmail := x.NewUUID().String() + "@ory.sh"
+		cr.Traits = []byte(`{"email":"` + originalEmail + `"}`)
+		res := send(t, "POST", "/identities", http.StatusCreated, &cr)
+		assert.EqualValues(t, originalEmail, res.Get("recovery_addresses.0.value").String(), "%s", res.Raw)
+		assert.EqualValues(t, originalEmail, res.Get("verifiable_addresses.0.value").String(), "%s", res.Raw)
+
+		id := res.Get("id").String()
+		updatedEmail := x.NewUUID().String() + "@ory.sh"
+		res = send(t, "PUT", "/identities/"+id, http.StatusOK, &identity.UpdateIdentityRequestPayload{
+			Traits: []byte(`{"email":"` + updatedEmail + `", "department": "ory"}`),
+		})
+
+		assert.EqualValues(t, "employee", res.Get("schema_id").String(), "%s", res.Raw)
+		assert.EqualValues(t, mockServerURL.String()+"/schemas/employee", res.Get("schema_url").String(), "%s", res.Raw)
+		assert.EqualValues(t, updatedEmail, res.Get("traits.email").String(), "%s", res.Raw)
+		assert.EqualValues(t, "ory", res.Get("traits.department").String(), "%s", res.Raw)
+		assert.EqualValues(t, updatedEmail, res.Get("recovery_addresses.0.value").String(), "%s", res.Raw)
+		assert.EqualValues(t, updatedEmail, res.Get("verifiable_addresses.0.value").String(), "%s", res.Raw)
+	})
+
+	t.Run("case=should update the schema id and fail because traits are invalid", func(t *testing.T) {
+		var cr identity.CreateIdentityRequestPayload
+		cr.SchemaID = "employee"
+		cr.Traits = []byte(`{"email":"` + x.NewUUID().String() + `@ory.sh", "department": "ory"}`)
+		res := send(t, "POST", "/identities", http.StatusCreated, &cr)
+
+		id := res.Get("id").String()
+		res = send(t, "PUT", "/identities/"+id, http.StatusBadRequest, &identity.UpdateIdentityRequestPayload{
+			SchemaID: "customer",
+			Traits:   cr.Traits,
+		})
+		assert.Contains(t, res.Get("error.reason").String(), `additionalProperties "department" not allowed`, "%s", res.Raw)
+	})
+
+	t.Run("case=should update the schema id", func(t *testing.T) {
+		var cr identity.CreateIdentityRequestPayload
+		cr.SchemaID = "employee"
+		cr.Traits = []byte(`{"email":"` + x.NewUUID().String() + `@ory.sh", "department": "ory"}`)
+		res := send(t, "POST", "/identities", http.StatusCreated, &cr)
+
+		id := res.Get("id").String()
+		res = send(t, "PUT", "/identities/"+id, http.StatusOK, &identity.UpdateIdentityRequestPayload{
+			SchemaID: "customer",
+			Traits:   []byte(`{"email":"` + x.NewUUID().String() + `@ory.sh", "address": "ory street"}`),
+		})
+		assert.EqualValues(t, "ory street", res.Get("traits.address").String(), "%s", res.Raw)
 	})
 
 	t.Run("case=should list all identities", func(t *testing.T) {
@@ -161,16 +241,8 @@ func TestHandler(t *testing.T) {
 	})
 
 	t.Run("case=should not be able to update an identity that does not exist yet", func(t *testing.T) {
-		var i identity.Identity
-		i.ID = x.NewUUID()
-		i.Traits = identity.Traits(`{"bar":"baz"}`)
-		res := send(t, "PUT", "/identities/"+i.ID.String(), http.StatusNotFound, &i)
+		res := send(t, "PUT", "/identities/not-found", http.StatusNotFound, json.RawMessage(`{"traits": {"bar":"baz"}}`))
 		assert.Contains(t, res.Get("error.message").String(), "Unable to locate the resource", "%s", res.Raw)
-	})
-
-	t.Run("case=should delete a client and no longer be able to retrieve it", func(t *testing.T) {
-		remove(t, "/identities/"+i.ID.String(), http.StatusNoContent)
-		_ = get(t, "/identities/"+i.ID.String(), http.StatusNotFound)
 	})
 
 	t.Run("case=should return 404 for non-existing identities", func(t *testing.T) {

--- a/identity/manager.go
+++ b/identity/manager.go
@@ -48,7 +48,7 @@ func NewManager(r managerDependencies, c configuration.Provider) *Manager {
 	return &Manager{r: r, c: c}
 }
 
-func ManagerExposeValidationErrors(options *managerOptions) {
+func ManagerExposeValidationErrorsForInternalTypeAssertion(options *managerOptions) {
 	options.ExposeValidationErrors = true
 }
 
@@ -108,6 +108,25 @@ func (m *Manager) Update(ctx context.Context, updated *Identity, opts ...Manager
 	}
 
 	return m.r.IdentityPool().(PrivilegedPool).UpdateIdentity(ctx, updated)
+}
+
+func (m *Manager) UpdateSchemaID(ctx context.Context, id uuid.UUID, schemaID string, opts ...ManagerOption) error {
+	o := newManagerOptions(opts)
+	original, err := m.r.IdentityPool().(PrivilegedPool).GetIdentityConfidential(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	if !o.AllowWriteProtectedTraits && original.SchemaID != schemaID {
+		return errors.WithStack(ErrProtectedFieldModified)
+	}
+
+	original.SchemaID = schemaID
+	if err := m.validate(original, o); err != nil {
+		return err
+	}
+
+	return m.r.IdentityPool().(PrivilegedPool).UpdateIdentity(ctx, original)
 }
 
 func (m *Manager) UpdateTraits(ctx context.Context, id uuid.UUID, traits Traits, opts ...ManagerOption) error {

--- a/identity/manager_test.go
+++ b/identity/manager_test.go
@@ -67,7 +67,7 @@ func TestManager(t *testing.T) {
 		t.Run("case=should expose validation errors with option", func(t *testing.T) {
 			original := identity.NewIdentity(configuration.DefaultIdentityTraitsSchemaID)
 			original.Traits = identity.Traits(`{"email":"not an email"}`)
-			err := reg.IdentityManager().Create(context.Background(), original, identity.ManagerExposeValidationErrors)
+			err := reg.IdentityManager().Create(context.Background(), original, identity.ManagerExposeValidationErrorsForInternalTypeAssertion)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "\"not an email\" is not valid \"email\"")
 		})

--- a/identity/stub/handler/customer.schema.json
+++ b/identity/stub/handler/customer.schema.json
@@ -1,0 +1,33 @@
+{
+  "$id": "https://example.com/customer.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Person",
+  "type": "object",
+  "properties": {
+    "traits": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string",
+          "ory.sh/kratos": {
+            "credentials": {
+              "password": {
+                "identifier": true
+              }
+            },
+            "verification": {
+              "email": true
+            },
+            "recovery": {
+              "email": true
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/identity/stub/handler/employee.schema.json
+++ b/identity/stub/handler/employee.schema.json
@@ -1,0 +1,32 @@
+{
+  "$id": "https://example.com/employee.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Person",
+  "type": "object",
+  "properties": {
+    "traits": {
+      "type": "object",
+      "properties": {
+        "department": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string",
+          "ory.sh/kratos": {
+            "credentials": {
+              "password": {
+                "identifier": true
+              }
+            },
+            "verification": {
+              "via": "email"
+            },
+            "recovery": {
+              "via": "email"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/testhelpers/identity_schema.go
+++ b/internal/testhelpers/identity_schema.go
@@ -1,0 +1,26 @@
+package testhelpers
+
+import (
+	"github.com/ory/viper"
+
+	"github.com/ory/kratos/driver/configuration"
+)
+
+// SetDefaultIdentitySchema sets the identity schemas in viper config:
+//
+//	testhelpers.SetDefaultIdentitySchema("file://customer.json")
+func SetDefaultIdentitySchema(location string) {
+	viper.Set(configuration.ViperKeyDefaultIdentitySchemaURL, location)
+}
+
+// SetIdentitySchemas sets the identity schemas in viper config:
+//
+//	testhelpers.SetIdentitySchemas(map[string]string{"customer": "file://customer.json"})
+func SetIdentitySchemas(schemas map[string]string) {
+	var s []configuration.SchemaConfig
+	for id, location := range schemas {
+		s = append(s, configuration.SchemaConfig{ID: id, URL: location})
+	}
+
+	viper.Set(configuration.ViperKeyIdentitySchemas, s)
+}

--- a/selfservice/flow/settings/hook.go
+++ b/selfservice/flow/settings/hook.go
@@ -99,7 +99,7 @@ func (e *HookExecutor) PostSettingsHook(w http.ResponseWriter, r *http.Request, 
 		}
 	}
 
-	options := []identity.ManagerOption{identity.ManagerExposeValidationErrors}
+	options := []identity.ManagerOption{identity.ManagerExposeValidationErrorsForInternalTypeAssertion}
 	ttl := e.c.SelfServiceFlowSettingsPrivilegedSessionMaxAge()
 	if ctxUpdate.Session.AuthenticatedAt.Add(ttl).After(time.Now()) {
 		options = append(options, identity.ManagerAllowWriteProtectedTraits)


### PR DESCRIPTION
This patch resolves several issues that occurred when creating or updating identities using the Admin API. Now, all hooks are running properly and updating privileged properties no longer causes errors.

Closes #435
See #500