### PR TITLE
fix: fallback to default return url if logout after url is not defined

### DIFF
--- a/driver/configuration/provider_viper.go
+++ b/driver/configuration/provider_viper.go
@@ -407,7 +407,12 @@ func (p *ViperProvider) SelfServiceFlowRegistrationRequestLifespan() time.Durati
 }
 
 func (p *ViperProvider) SelfServiceFlowLogoutRedirectURL() *url.URL {
-	return mustParseURLFromViper(p.l, ViperKeySelfServiceLogoutBrowserDefaultReturnTo)
+	redir, err := url.ParseRequestURI(
+		viperx.GetString(p.l, ViperKeySelfServiceLogoutBrowserDefaultReturnTo, ""))
+	if err != nil {
+		return p.SelfServiceBrowserDefaultReturnTo()
+	}
+	return redir
 }
 
 func (p *ViperProvider) CourierSMTPFrom() string {

--- a/driver/configuration/provider_viper_test.go
+++ b/driver/configuration/provider_viper_test.go
@@ -79,6 +79,10 @@ func TestViperProvider(t *testing.T) {
 
 			assert.Equal(t, "https://self-service/settings/password/return_to", p.SelfServiceFlowSettingsReturnTo("password", p.SelfServiceBrowserDefaultReturnTo()).String())
 			assert.Equal(t, "https://self-service/settings/return_to", p.SelfServiceFlowSettingsReturnTo("profile", p.SelfServiceBrowserDefaultReturnTo()).String())
+
+			assert.Equal(t, "http://test.kratos.ory.sh:4000/", p.SelfServiceFlowLogoutRedirectURL().String())
+			viper.Set(configuration.ViperKeySelfServiceLogoutBrowserDefaultReturnTo, "")
+			assert.Equal(t, "http://return-to-3-test.ory.sh/", p.SelfServiceFlowLogoutRedirectURL().String())
 		})
 
 		t.Run("group=identity", func(t *testing.T) {

--- a/internal/httpclient/client/admin/create_identity_responses.go
+++ b/internal/httpclient/client/admin/create_identity_responses.go
@@ -43,7 +43,7 @@ func (o *CreateIdentityReader) ReadResponse(response runtime.ClientResponse, con
 		return nil, result
 
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 

--- a/internal/httpclient/client/admin/delete_identity_responses.go
+++ b/internal/httpclient/client/admin/delete_identity_responses.go
@@ -43,7 +43,7 @@ func (o *DeleteIdentityReader) ReadResponse(response runtime.ClientResponse, con
 		return nil, result
 
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 

--- a/internal/httpclient/client/admin/get_identity_responses.go
+++ b/internal/httpclient/client/admin/get_identity_responses.go
@@ -43,7 +43,7 @@ func (o *GetIdentityReader) ReadResponse(response runtime.ClientResponse, consum
 		return nil, result
 
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 

--- a/internal/httpclient/client/admin/list_identities_responses.go
+++ b/internal/httpclient/client/admin/list_identities_responses.go
@@ -37,7 +37,7 @@ func (o *ListIdentitiesReader) ReadResponse(response runtime.ClientResponse, con
 		return nil, result
 
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 

--- a/internal/httpclient/client/admin/update_identity_responses.go
+++ b/internal/httpclient/client/admin/update_identity_responses.go
@@ -49,7 +49,7 @@ func (o *UpdateIdentityReader) ReadResponse(response runtime.ClientResponse, con
 		return nil, result
 
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 

--- a/internal/httpclient/client/common/get_schema_responses.go
+++ b/internal/httpclient/client/common/get_schema_responses.go
@@ -43,7 +43,7 @@ func (o *GetSchemaReader) ReadResponse(response runtime.ClientResponse, consumer
 		return nil, result
 
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 

--- a/internal/httpclient/client/common/get_self_service_browser_login_request_responses.go
+++ b/internal/httpclient/client/common/get_self_service_browser_login_request_responses.go
@@ -55,7 +55,7 @@ func (o *GetSelfServiceBrowserLoginRequestReader) ReadResponse(response runtime.
 		return nil, result
 
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 

--- a/internal/httpclient/client/common/get_self_service_browser_recovery_request_responses.go
+++ b/internal/httpclient/client/common/get_self_service_browser_recovery_request_responses.go
@@ -55,7 +55,7 @@ func (o *GetSelfServiceBrowserRecoveryRequestReader) ReadResponse(response runti
 		return nil, result
 
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 

--- a/internal/httpclient/client/common/get_self_service_browser_registration_request_responses.go
+++ b/internal/httpclient/client/common/get_self_service_browser_registration_request_responses.go
@@ -55,7 +55,7 @@ func (o *GetSelfServiceBrowserRegistrationRequestReader) ReadResponse(response r
 		return nil, result
 
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 

--- a/internal/httpclient/client/common/get_self_service_browser_settings_request_responses.go
+++ b/internal/httpclient/client/common/get_self_service_browser_settings_request_responses.go
@@ -55,7 +55,7 @@ func (o *GetSelfServiceBrowserSettingsRequestReader) ReadResponse(response runti
 		return nil, result
 
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 

--- a/internal/httpclient/client/common/get_self_service_error_responses.go
+++ b/internal/httpclient/client/common/get_self_service_error_responses.go
@@ -49,7 +49,7 @@ func (o *GetSelfServiceErrorReader) ReadResponse(response runtime.ClientResponse
 		return nil, result
 
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 

--- a/internal/httpclient/client/common/get_self_service_verification_request_responses.go
+++ b/internal/httpclient/client/common/get_self_service_verification_request_responses.go
@@ -49,7 +49,7 @@ func (o *GetSelfServiceVerificationRequestReader) ReadResponse(response runtime.
 		return nil, result
 
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 

--- a/internal/httpclient/client/health/is_instance_alive_responses.go
+++ b/internal/httpclient/client/health/is_instance_alive_responses.go
@@ -37,7 +37,7 @@ func (o *IsInstanceAliveReader) ReadResponse(response runtime.ClientResponse, co
 		return nil, result
 
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 

--- a/internal/httpclient/client/health/is_instance_ready_responses.go
+++ b/internal/httpclient/client/health/is_instance_ready_responses.go
@@ -37,7 +37,7 @@ func (o *IsInstanceReadyReader) ReadResponse(response runtime.ClientResponse, co
 		return nil, result
 
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 

--- a/internal/httpclient/client/public/complete_self_service_browser_recovery_link_strategy_flow_responses.go
+++ b/internal/httpclient/client/public/complete_self_service_browser_recovery_link_strategy_flow_responses.go
@@ -37,7 +37,7 @@ func (o *CompleteSelfServiceBrowserRecoveryLinkStrategyFlowReader) ReadResponse(
 		return nil, result
 
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 

--- a/internal/httpclient/client/public/complete_self_service_browser_settings_o_id_c_settings_flow_responses.go
+++ b/internal/httpclient/client/public/complete_self_service_browser_settings_o_id_c_settings_flow_responses.go
@@ -37,7 +37,7 @@ func (o *CompleteSelfServiceBrowserSettingsOIDCSettingsFlowReader) ReadResponse(
 		return nil, result
 
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 

--- a/internal/httpclient/client/public/complete_self_service_browser_settings_password_strategy_flow_responses.go
+++ b/internal/httpclient/client/public/complete_self_service_browser_settings_password_strategy_flow_responses.go
@@ -37,7 +37,7 @@ func (o *CompleteSelfServiceBrowserSettingsPasswordStrategyFlowReader) ReadRespo
 		return nil, result
 
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 

--- a/internal/httpclient/client/public/complete_self_service_browser_settings_profile_strategy_flow_responses.go
+++ b/internal/httpclient/client/public/complete_self_service_browser_settings_profile_strategy_flow_responses.go
@@ -37,7 +37,7 @@ func (o *CompleteSelfServiceBrowserSettingsProfileStrategyFlowReader) ReadRespon
 		return nil, result
 
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 

--- a/internal/httpclient/client/public/complete_self_service_browser_verification_flow_responses.go
+++ b/internal/httpclient/client/public/complete_self_service_browser_verification_flow_responses.go
@@ -37,7 +37,7 @@ func (o *CompleteSelfServiceBrowserVerificationFlowReader) ReadResponse(response
 		return nil, result
 
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 

--- a/internal/httpclient/client/public/initialize_self_service_browser_login_flow_responses.go
+++ b/internal/httpclient/client/public/initialize_self_service_browser_login_flow_responses.go
@@ -37,7 +37,7 @@ func (o *InitializeSelfServiceBrowserLoginFlowReader) ReadResponse(response runt
 		return nil, result
 
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 

--- a/internal/httpclient/client/public/initialize_self_service_browser_logout_flow_responses.go
+++ b/internal/httpclient/client/public/initialize_self_service_browser_logout_flow_responses.go
@@ -37,7 +37,7 @@ func (o *InitializeSelfServiceBrowserLogoutFlowReader) ReadResponse(response run
 		return nil, result
 
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 

--- a/internal/httpclient/client/public/initialize_self_service_browser_registration_flow_responses.go
+++ b/internal/httpclient/client/public/initialize_self_service_browser_registration_flow_responses.go
@@ -37,7 +37,7 @@ func (o *InitializeSelfServiceBrowserRegistrationFlowReader) ReadResponse(respon
 		return nil, result
 
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 

--- a/internal/httpclient/client/public/initialize_self_service_browser_verification_flow_responses.go
+++ b/internal/httpclient/client/public/initialize_self_service_browser_verification_flow_responses.go
@@ -37,7 +37,7 @@ func (o *InitializeSelfServiceBrowserVerificationFlowReader) ReadResponse(respon
 		return nil, result
 
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 

--- a/internal/httpclient/client/public/initialize_self_service_recovery_flow_responses.go
+++ b/internal/httpclient/client/public/initialize_self_service_recovery_flow_responses.go
@@ -37,7 +37,7 @@ func (o *InitializeSelfServiceRecoveryFlowReader) ReadResponse(response runtime.
 		return nil, result
 
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 

--- a/internal/httpclient/client/public/initialize_self_service_settings_flow_responses.go
+++ b/internal/httpclient/client/public/initialize_self_service_settings_flow_responses.go
@@ -37,7 +37,7 @@ func (o *InitializeSelfServiceSettingsFlowReader) ReadResponse(response runtime.
 		return nil, result
 
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 

--- a/internal/httpclient/client/public/self_service_browser_verify_responses.go
+++ b/internal/httpclient/client/public/self_service_browser_verify_responses.go
@@ -37,7 +37,7 @@ func (o *SelfServiceBrowserVerifyReader) ReadResponse(response runtime.ClientRes
 		return nil, result
 
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 

--- a/internal/httpclient/client/public/whoami_responses.go
+++ b/internal/httpclient/client/public/whoami_responses.go
@@ -43,7 +43,7 @@ func (o *WhoamiReader) ReadResponse(response runtime.ClientResponse, consumer ru
 		return nil, result
 
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 

--- a/internal/httpclient/client/version/get_version_responses.go
+++ b/internal/httpclient/client/version/get_version_responses.go
@@ -31,7 +31,7 @@ func (o *GetVersionReader) ReadResponse(response runtime.ClientResponse, consume
 		return result, nil
 
 	default:
-		return nil, runtime.NewAPIError("unknown error", response, response.Code())
+		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
 }
 


### PR DESCRIPTION
## Related issue

When `selfservice.flows.logout.after.default_browser_return_url` was not set a logout resulted in a fatal crash.

## Proposed changes

The fallback now is `selfservice.default_browser_return_url`

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
