### PR TITLE
feat: add the already declared (and settable) tracer as a middleware

### DIFF
--- a/cmd/daemon/serve.go
+++ b/cmd/daemon/serve.go
@@ -85,6 +85,10 @@ func serveAdmin(d driver.Driver, wg *sync.WaitGroup, cmd *cobra.Command, args []
 	n.Use(NewNegroniLoggerMiddleware(l, "admin#"+c.SelfAdminURL().String()))
 	n.Use(sqa(cmd, d))
 
+	if tracer := d.Registry().Tracer(); tracer.IsLoaded() {
+		n.Use(tracer)
+	}
+
 	n.UseHandler(router)
 	server := graceful.WithDefaults(&http.Server{
 		Addr:    c.AdminListenOn(),

--- a/cmd/daemon/serve.go
+++ b/cmd/daemon/serve.go
@@ -45,6 +45,10 @@ func servePublic(d driver.Driver, wg *sync.WaitGroup, cmd *cobra.Command, args [
 	n.Use(NewNegroniLoggerMiddleware(l, "public#"+c.SelfPublicURL().String()))
 	n.Use(sqa(cmd, d))
 
+	if tracer := d.Registry().Tracer(); tracer.IsLoaded() {
+		n.Use(tracer)
+	}
+
 	csrf := x.NewCSRFHandler(
 		router,
 		r.Writer(),

--- a/driver/configuration/provider_viper.go
+++ b/driver/configuration/provider_viper.go
@@ -438,7 +438,7 @@ func mustParseURLFromViper(l *logrusx.Logger, key string) *url.URL {
 }
 
 func (p *ViperProvider) TracingServiceName() string {
-	return viperx.GetString(p.l, "tracing.service_name", "ORY Hydra")
+	return viperx.GetString(p.l, "tracing.service_name", "ORY Kratos")
 }
 
 func (p *ViperProvider) TracingProvider() string {

--- a/driver/registry.go
+++ b/driver/registry.go
@@ -1,6 +1,8 @@
 package driver
 
 import (
+	"github.com/ory/x/tracing"
+
 	"github.com/gorilla/sessions"
 	"github.com/pkg/errors"
 
@@ -54,6 +56,7 @@ type Registry interface {
 	RegisterRoutes(public *x.RouterPublic, admin *x.RouterAdmin)
 	RegisterPublicRoutes(public *x.RouterPublic)
 	RegisterAdminRoutes(admin *x.RouterAdmin)
+	Tracer() *tracing.Tracer
 
 	x.CSRFProvider
 	x.WriterProvider
@@ -115,7 +118,6 @@ type Registry interface {
 
 	recovery.RequestPersistenceProvider
 	recovery.ErrorHandlerProvider
-	recovery.StrategyProvider
 	recovery.HandlerProvider
 	recovery.StrategyProvider
 


### PR DESCRIPTION
## Proposed changes

It looks like the tracer is declared but not used even if one is allowed to set env vars to activate and configure it.

I just added it as a negroni middleware, exactly like it's already done on oathkeeper.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).
