### PR TITLE
feat: use uri-reference for ui_url etc. to allow relative urls

### DIFF
--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -14,7 +14,7 @@
       "description": "ORY Kratos redirects to this URL per default on completion of self-service flows and other browser interaction. Read this [article for more information on browser redirects](https://www.ory.sh/kratos/docs/concepts/browser-redirect-flow-completion).",
       "type": "string",
       "format": "uri-reference",
-      "minLength": 6,
+      "minLength": 1,
       "examples": [
         "https://my-app.com/dashboard",
         "/dashboard"

--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -13,10 +13,11 @@
       "title": "Redirect browsers to set URL per default",
       "description": "ORY Kratos redirects to this URL per default on completion of self-service flows and other browser interaction. Read this [article for more information on browser redirects](https://www.ory.sh/kratos/docs/concepts/browser-redirect-flow-completion).",
       "type": "string",
-      "format": "uri",
+      "format": "uri-reference",
       "minLength": 6,
       "examples": [
-        "https://my-app.com/dashboard"
+        "https://my-app.com/dashboard",
+        "/dashboard"
       ]
     },
     "selfServiceSessionRevokerHook": {

--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -275,11 +275,12 @@
           "type": "array",
           "items": {
             "type": "string",
-            "format": "uri"
+            "format": "uri-reference"
           },
           "examples": [
             [
               "https://app.my-app.com/dashboard",
+              "/dashboard",
               "https://www.my-app.com/"
             ]
           ],

--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -671,9 +671,10 @@
               "title": "Public Base URL",
               "description": "The URL where the public endpoint is exposed at.",
               "type": "string",
-              "format": "uri",
+              "format": "uri-reference",
               "examples": [
-                "https://my-app.com/.ory/kratos/public"
+                "https://my-app.com/.ory/kratos/public",
+                "/.ory/kratos/public/"
               ]
             },
             "host": {

--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -296,7 +296,7 @@
                   "title": "URL of the Settings page.",
                   "description": "URL where the Settings UI is hosted. Check the [reference implementation](https://github.com/ory/kratos-selfservice-ui-node).",
                   "type": "string",
-                  "format": "uri",
+                  "format": "uri-reference",
                   "examples": [
                     "https://my-app.com/user/settings"
                   ],
@@ -350,7 +350,7 @@
                   "title": "Registration UI URL",
                   "description": "URL where the Registration UI is hosted. Check the [reference implementation](https://github.com/ory/kratos-selfservice-ui-node).",
                   "type": "string",
-                  "format": "uri",
+                  "format": "uri-reference",
                   "examples": [
                     "https://my-app.com/signup"
                   ],
@@ -379,7 +379,7 @@
                   "title": "Login UI URL",
                   "description": "URL where the Login UI is hosted. Check the [reference implementation](https://github.com/ory/kratos-selfservice-ui-node).",
                   "type": "string",
-                  "format": "uri",
+                  "format": "uri-reference",
                   "examples": [
                     "https://my-app.com/login"
                   ],
@@ -415,7 +415,7 @@
                   "title": "Verify UI URL",
                   "description": "URL where the ORY Verify UI is hosted. This is the page where users activate and / or verify their email or telephone number. Check the [reference implementation](https://github.com/ory/kratos-selfservice-ui-node).",
                   "type": "string",
-                  "format": "uri",
+                  "format": "uri-reference",
                   "examples": [
                     "https://my-app.com/verify"
                   ],
@@ -459,7 +459,7 @@
                   "title": "Recovery UI URL",
                   "description": "URL where the ORY Recovery UI is hosted. This is the page where users request and complete account recovery. Check the [reference implementation](https://github.com/ory/kratos-selfservice-ui-node).",
                   "type": "string",
-                  "format": "uri",
+                  "format": "uri-reference",
                   "examples": [
                     "https://my-app.com/verify"
                   ],
@@ -496,7 +496,7 @@
                   "title": "ORY Kratos Error UI URL",
                   "description": "URL where the ORY Kratos Error UI is hosted. Check the [reference implementation](https://github.com/ory/kratos-selfservice-ui-node).",
                   "type": "string",
-                  "format": "uri",
+                  "format": "uri-reference",
                   "examples": [
                     "https://my-app.com/kratos-error"
                   ],

--- a/contrib/quickstart/kratos/email-password/kratos.yml
+++ b/contrib/quickstart/kratos/email-password/kratos.yml
@@ -40,7 +40,7 @@ selfservice:
         default_browser_return_url: http://127.0.0.1:4455/auth/login
 
     login:
-      ui_url: http://127.0.0.1:4455/auth/login
+      ui_url: /auth/login
       request_lifespan: 10m
 
     registration:

--- a/contrib/quickstart/kratos/email-password/kratos.yml
+++ b/contrib/quickstart/kratos/email-password/kratos.yml
@@ -4,7 +4,7 @@ dsn: memory
 
 serve:
   public:
-    base_url: http://127.0.0.1:4455/.ory/kratos/public/
+    base_url: /.ory/kratos/public/
   admin:
     base_url: http://kratos:4434/
 
@@ -49,8 +49,7 @@ selfservice:
       after:
         password:
           hooks:
-            -
-              hook: session
+            - hook: session
 
 log:
   level: debug

--- a/contrib/quickstart/kratos/email-password/kratos.yml
+++ b/contrib/quickstart/kratos/email-password/kratos.yml
@@ -4,7 +4,7 @@ dsn: memory
 
 serve:
   public:
-    base_url: /.ory/kratos/public/
+    base_url: http://127.0.0.1:4455/.ory/kratos/public/
   admin:
     base_url: http://kratos:4434/
 
@@ -40,7 +40,7 @@ selfservice:
         default_browser_return_url: http://127.0.0.1:4455/auth/login
 
     login:
-      ui_url: /auth/login
+      ui_url: http://127.0.0.1:4455/auth/login
       request_lifespan: 10m
 
     registration:
@@ -49,7 +49,8 @@ selfservice:
       after:
         password:
           hooks:
-            - hook: session
+            -
+              hook: session
 
 log:
   level: debug

--- a/x/http_secure_redirect_test.go
+++ b/x/http_secure_redirect_test.go
@@ -166,7 +166,7 @@ func TestSecureRedirectTo(t *testing.T) {
 	})
 
 	t.Run("case=return to another domain fails if path mismatches", func(t *testing.T) {
-		s := newServer(t, false false,, true, func(ts *httptest.Server) []x.SecureRedirectOption {
+		s := newServer(t, false, false, true, func(ts *httptest.Server) []x.SecureRedirectOption {
 			return []x.SecureRedirectOption{x.SecureRedirectAllowURLs([]url.URL{*urlx.ParseOrPanic("https://www.ory.sh/not-kratos")})}
 		})
 		_, body := makeRequest(t, s, "?return_to=https://www.ory.sh/kratos")
@@ -174,7 +174,7 @@ func TestSecureRedirectTo(t *testing.T) {
 	})
 
 	t.Run("case=return to another domain fails if scheme mismatches", func(t *testing.T) {
-		s := newServer(t, false false,, true, func(ts *httptest.Server) []x.SecureRedirectOption {
+		s := newServer(t, false, false, true, func(ts *httptest.Server) []x.SecureRedirectOption {
 			return []x.SecureRedirectOption{x.SecureRedirectAllowURLs([]url.URL{*urlx.ParseOrPanic("http://www.ory.sh/")})}
 		})
 		_, body := makeRequest(t, s, "?return_to=https://www.ory.sh/kratos")

--- a/x/http_secure_redirect_test.go
+++ b/x/http_secure_redirect_test.go
@@ -142,7 +142,7 @@ func TestSecureRedirectTo(t *testing.T) {
 	})
 
 	t.Run("case=return to a fully qualified domain is forbidden if whitelist is relative", func(t *testing.T) {
-		s := newServer(t, false true,, true, func(ts *httptest.Server) []x.SecureRedirectOption {
+		s := newServer(t, false, true, true, func(ts *httptest.Server) []x.SecureRedirectOption {
 			return []x.SecureRedirectOption{x.SecureRedirectAllowURLs([]url.URL{*urlx.ParseOrPanic("/foo")})}
 		})
 		_, body := makeRequest(t, s, "?return_to=https://www.ory.sh/foo/kratos")
@@ -158,7 +158,7 @@ func TestSecureRedirectTo(t *testing.T) {
 	})
 
 	t.Run("case=return to another domain fails if host mismatches", func(t *testing.T) {
-		s := newServer(t, false false,, true, func(ts *httptest.Server) []x.SecureRedirectOption {
+		s := newServer(t, false, false, true, func(ts *httptest.Server) []x.SecureRedirectOption {
 			return []x.SecureRedirectOption{x.SecureRedirectAllowURLs([]url.URL{*urlx.ParseOrPanic("https://www.not-ory.sh/")})}
 		})
 		_, body := makeRequest(t, s, "?return_to=https://www.ory.sh/kratos")


### PR DESCRIPTION
Currently ui_url for each of the flows is a `uri`. This means that we have to generate a new config file for each developer's cluster, and another one for production as they are each served from a different domain.

We are hosting kratos and our webserver behind an nginx proxy, so specifying a relative uri like `/auth/login` would solve this problem for us..

How do people feel about allowing relative urls like `/auth/login` to be specified as the ui_urls? If nobody can think of a security reason against this, I will happily continue with this PR, as it would save us a bunch of hassle generating config files.

- [x] I have manually checked that my other changes work by running the quickstart app on a different port
- [x] I still need to check that my change to `whitelisted_return_urls` works as expected.

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
