### PR TITLE
feat: add version schema generation step to release automation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       -
         image: circleci/golang:1.14
         environment:
-          GO111MODULE: on
+          GO111MODULE: "on"
           TEST_MAILHOG_SMTP: smtp://test:test@127.0.0.1:1025
           TEST_MAILHOG_API: http://127.0.0.1:8025
           TEST_SELFSERVICE_OIDC_HYDRA_ADMIN: http://127.0.0.1:4445
@@ -79,7 +79,7 @@ jobs:
     docker:
       - image: oryd/e2e-env:latest
         environment:
-          GO111MODULE: on
+          GO111MODULE: "on"
           TEST_DATABASE_MYSQL: mysql://root:test@(localhost:3306)/mysql?parseTime=true&multiStatements=true
           TEST_DATABASE_COCKROACHDB: cockroach://root@localhost:26257/defaultdb?sslmode=disable
           TEST_DATABASE_POSTGRESQL: postgres://test:test@localhost:5432/kratos?sslmode=disable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   changelog: ory/changelog@0.1.3
-  goreleaser: ory/goreleaser@0.1.13
+  goreleaser: ory/goreleaser@0.1.15
   slack: circleci/slack@3.4.2
   sdk: ory/sdk@0.1.37
   nancy: ory/nancy@0.0.12
@@ -15,38 +15,38 @@ jobs:
       -
         image: circleci/golang:1.14
         environment:
-          - GO111MODULE=on
-          - TEST_MAILHOG_SMTP=smtp://test:test@127.0.0.1:1025
-          - TEST_MAILHOG_API=http://127.0.0.1:8025
-          - TEST_SELFSERVICE_OIDC_HYDRA_ADMIN=http://127.0.0.1:4445
-          - TEST_SELFSERVICE_OIDC_HYDRA_PUBLIC=http://127.0.0.1:4444
-          - TEST_SELFSERVICE_OIDC_HYDRA_INTEGRATION_ADDR=http://127.0.0.1:4499
-          - TEST_DATABASE_POSTGRESQL=postgres://test:test@localhost:5432/postgres?sslmode=disable
-          - TEST_DATABASE_MYSQL=mysql://root:test@(localhost:3306)/mysql?parseTime=true&multiStatements=true
-          - TEST_DATABASE_COCKROACHDB=cockroach://root@localhost:26257/defaultdb?sslmode=disable
+          GO111MODULE: on
+          TEST_MAILHOG_SMTP: smtp://test:test@127.0.0.1:1025
+          TEST_MAILHOG_API: http://127.0.0.1:8025
+          TEST_SELFSERVICE_OIDC_HYDRA_ADMIN: http://127.0.0.1:4445
+          TEST_SELFSERVICE_OIDC_HYDRA_PUBLIC: http://127.0.0.1:4444
+          TEST_SELFSERVICE_OIDC_HYDRA_INTEGRATION_ADDR: http://127.0.0.1:4499
+          TEST_DATABASE_POSTGRESQL: postgres://test:test@localhost:5432/postgres?sslmode=disable
+          TEST_DATABASE_MYSQL: mysql://root:test@(localhost:3306)/mysql?parseTime=true&multiStatements=true
+          TEST_DATABASE_COCKROACHDB: cockroach://root@localhost:26257/defaultdb?sslmode=disable
       -
         image: mailhog/mailhog:v1.0.0
         command: MailHog -invite-jim -jim-linkspeed-affect=0.25 -jim-reject-auth=0.25 -jim-reject-recipient=0.25 -jim-reject-sender=0.25 -jim-disconnect=0.25 -jim-linkspeed-min=1250 -jim-linkspeed-max=12500
       -
         image: postgres:9.6
         environment:
-          - POSTGRES_USER=test
-          - POSTGRES_PASSWORD=test
-          - POSTGRES_DB=postgres
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: postgres
       -
         image: mysql:5.7
         environment:
-          - MYSQL_ROOT_PASSWORD=test
+          MYSQL_ROOT_PASSWORD: test
       -
         image: cockroachdb/cockroach:v19.2.0
         command: start --insecure
       -
         image: oryd/hydra:v1.4.10
         environment:
-          - DSN=memory
-          - URLS_SELF_ISSUER=http://127.0.0.1:4444/
-          - URLS_LOGIN=http://127.0.0.1:4499/login
-          - URLS_CONSENT=http://127.0.0.1:4499/consent
+          DSN: memory
+          URLS_SELF_ISSUER: http://127.0.0.1:4444/
+          URLS_LOGIN: http://127.0.0.1:4499/login
+          URLS_CONSENT: http://127.0.0.1:4499/consent
         command: serve all --dangerous-force-http
     working_directory: /go/src/github.com/ory/kratos
     steps:
@@ -79,20 +79,20 @@ jobs:
     docker:
       - image: oryd/e2e-env:latest
         environment:
-          - GO111MODULE=on
-          - TEST_DATABASE_MYSQL=mysql://root:test@(localhost:3306)/mysql?parseTime=true&multiStatements=true
-          - TEST_DATABASE_COCKROACHDB=cockroach://root@localhost:26257/defaultdb?sslmode=disable
-          - TEST_DATABASE_POSTGRESQL=postgres://test:test@localhost:5432/kratos?sslmode=disable
+          GO111MODULE: on
+          TEST_DATABASE_MYSQL: mysql://root:test@(localhost:3306)/mysql?parseTime=true&multiStatements=true
+          TEST_DATABASE_COCKROACHDB: cockroach://root@localhost:26257/defaultdb?sslmode=disable
+          TEST_DATABASE_POSTGRESQL: postgres://test:test@localhost:5432/kratos?sslmode=disable
       - image: postgres:9.6
         environment:
-          - POSTGRES_USER=test
-          - POSTGRES_PASSWORD=test
-          - POSTGRES_DB=kratos
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: kratos
       - image: cockroachdb/cockroach:v2.1.6
         command: start --insecure
       - image: mysql:5.7
         environment:
-          - MYSQL_ROOT_PASSWORD=test
+          MYSQL_ROOT_PASSWORD: test
       - image: oryd/mailslurper:latest-smtps
     working_directory: /go/src/github.com/ory/kratos
     steps:
@@ -241,6 +241,13 @@ workflows:
           filters:
             branches:
               ignore: /.*/
+            tags:
+              only: /.*/
+      -
+        goreleaser/render-version-schema:
+          requires:
+            - goreleaser/release
+          filters:
             tags:
               only: /.*/
       -


### PR DESCRIPTION
## Proposed changes

This adds the version schema step to the release automation. Note that I also converted all `environment:` configurations to use key/value maps instead of an array. I noted this issue because of the JSON schema for cci. Here are the corresponding docs: https://circleci.com/docs/reference-2-1/#jobs

