### PR TITLE
fix: tell tls what the smtps server name is

### DIFF
--- a/courier/courier.go
+++ b/courier/courier.go
@@ -49,7 +49,7 @@ func NewSMTP(d smtpDependencies, c configuration.Provider) *Courier {
 		ssl = true
 		sslSkipVerify, _ := strconv.ParseBool(uri.Query().Get("skip_ssl_verify"))
 		// #nosec G402 This is ok (and required!) because it is configurable and disabled by default.
-		tlsConfig = &tls.Config{InsecureSkipVerify: sslSkipVerify}
+		tlsConfig = &tls.Config{InsecureSkipVerify: sslSkipVerify, ServerName: uri.Hostname()}
 	}
 
 	return &Courier{


### PR DESCRIPTION
## Related issue

As discussed with @aeneasr via email.

Previously there was no way to use smtps to send email without adding `?skip_ssl_verify=true` to the end of the courier.smtp.connection_uri. In practice this means that anyone with the ability to poison DNS records (for any kratos installation that supports password reset emails) will be able to register an ssl certificate for any-old-domain and receive all password reset emails (since there is no way to configure kratos to verify the ssl server name for the email provider).

> thank you for the disclosure! Given that misconfiguration results in an error (or enforces TLS verification skipping which results in raised eyebrows :) ) I would not classify this as a security vulnerability. Hence, it is ok (and encouraged) to just open a public PR for this. Thank you!


## Proposed changes

Allow the tls module to correctly validate the hostname of the smtp server, by telling it what hostname you're expecting to connect to.


## Checklist


- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

Once this patch is applied, it is possible to send mail via `smtps://...@smtp.sendgrid.net:465/` without any warnings or errors (using their free tier). I'm not sure what other tests or documentation changes would be valuable. 
