### PR TITLE
docs: fix url of admin-api /recovery/link

### DIFF
--- a/docs/docs/admin/managing-users-identities.mdx
+++ b/docs/docs/admin/managing-users-identities.mdx
@@ -82,7 +82,7 @@ $ curl --request POST -sL \
   "expires_in": "12h",
   "identity_id": "954f7f59-16a5-4152-8ce7-ad7c73bb124a"
 }' \
-    http://127.0.0.1:4434/flows/recovery/link
+    http://127.0.0.1:4434/recovery/link
 
 {
   "expires_at": "2020-07-27T10:47:45.806Z",


### PR DESCRIPTION

## Proposed changes

I was talking to aeneas in #kratos and he pointed out that this endpoint was recently merged. I tried it out on my own infrastructure and noticed that the url was wrong https://github.com/FutureNHS/futurenhs-platform/pull/103/files ( infrastructure/scripts/new-kratos-user.sh )

## Checklist

- [x] I have added or changed [the documentation](docs/docs).

