### PR TITLE
ci: add closed reference notifier action

### DIFF
--- a/.github/workflows/closed_references.yml
+++ b/.github/workflows/closed_references.yml
@@ -1,0 +1,16 @@
+on:
+  schedule:
+    - cron: '0 7 * * *'
+
+jobs:
+  find_closed_references:
+    runs-on: ubuntu-latest
+    name: Find closed references
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ory/closed-reference-notifier@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ignore: .git,**/node_modules,docs,CHANGELOG.md,.bin
+          issueLabels: upstream
+          issueLimit: 5


### PR DESCRIPTION
## Related issue

This adds our https://github.com/ory/closed-reference-notifier GitHub action. It runs every day at 7am.

When running locally it found the following references, which seems legit to me (not all are closed):

```
Found reference "github.com/ory/x/issues/169" in file driver/configuration/provider_viper.go
Found reference "github.com/gobuffalo/pop/issues/574" in file persistence/sql/persister.go
Found reference "github.com/gobuffalo/pop/issues/574" in file persistence/sql/persister.go
Found reference "github.com/gobuffalo/pop/pull/481" in file persistence/sql/persister_test.go
Found reference "github.com/ory/kratos/issues/347" in file test/schema/schema_test.go
Found reference "github.com/gobuffalo/pop/issues/538" in file persistence/sql/migratest/migration_test.go
Found reference "github.com/gobuffalo/pop/pull/478" in file selfservice/flow/login/request_method.go
Found reference "github.com/gobuffalo/pop/pull/478" in file selfservice/flow/recovery/request_method.go
Found reference "github.com/gobuffalo/pop/pull/478" in file selfservice/flow/registration/request_method.go
Found reference "github.com/gobuffalo/pop/pull/478" in file selfservice/flow/settings/request_method.go
Found reference "github.com/gobuffalo/fizz/issues/45" in file persistence/sql/migrations/templates/20191100000011_courier_body_type.down.fizz
Found reference "github.com/ory/kratos/issues/91" in file test/e2e/cypress/integration/profiles/email/login/error.spec.js
Found reference "github.com/ory/kratos/issues/91" in file test/e2e/cypress/integration/profiles/email/registration/errors.spec.js
Found reference "github.com/ory/kratos/issues/368" in file test/e2e/cypress/integration/profiles/email/registration/errors.spec.js
Found reference "github.com/ory/kratos/issues/91" in file test/e2e/cypress/integration/profiles/email/settings/errors.spec.js
Found reference "github.com/ory/kratos/issues/133" in file test/e2e/cypress/integration/profiles/verification/registration/success.spec.js
Found reference "github.com/ory/kratos/issues/292" in file test/e2e/cypress/integration/profiles/verification/settings/error.spec.js
Found reference "github.com/ory/kratos/issues/292" in file test/e2e/cypress/integration/profiles/verification/settings/success.spec.js
```