### PR TITLE
refactor(config): rename request_lifespan to lifespan #666

### DIFF
--- a/.schema/api.swagger.json
+++ b/.schema/api.swagger.json
@@ -322,7 +322,7 @@
     },
     "/metrics/prometheus": {
       "get": {
-        "description": "```\nmetadata:\nannotations:\nprometheus.io/port: \"4445\"\nprometheus.io/path: \"/metrics/prometheus\"\n```",
+        "description": "```\nmetadata:\nannotations:\nprometheus.io/port: \"4434\"\nprometheus.io/path: \"/metrics/prometheus\"\n```",
         "produces": [
           "plain/text"
         ],
@@ -367,7 +367,7 @@
               ],
               "properties": {
                 "expires_in": {
-                  "description": "Link Expires In\n\nThe recovery link will expire at that point in time. Defaults to the configuration value of\n`selfservice.flows.recovery.request_lifespan`.",
+                  "description": "Link Expires In\n\nThe recovery link will expire at that point in time. Defaults to the configuration value of\n`selfservice.flows.recovery.lifespan`.",
                   "type": "string",
                   "pattern": "^[0-9]+(ns|us|ms|s|m|h)$"
                 },

--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -304,7 +304,7 @@
                   ],
                   "default": "https://www.ory.sh/kratos/docs/fallback/settings"
                 },
-                "request_lifespan": {
+                "lifespan": {
                   "type": "string",
                   "pattern": "^[0-9]+(ns|us|ms|s|m|h)$",
                   "default": "1h",
@@ -358,7 +358,7 @@
                   ],
                   "default": "https://www.ory.sh/kratos/docs/fallback/registration"
                 },
-                "request_lifespan": {
+                "lifespan": {
                   "type": "string",
                   "pattern": "^[0-9]+(ns|us|ms|s|m|h)$",
                   "default": "1h",
@@ -387,7 +387,7 @@
                   ],
                   "default": "https://www.ory.sh/kratos/docs/fallback/login"
                 },
-                "request_lifespan": {
+                "lifespan": {
                   "type": "string",
                   "pattern": "^[0-9]+(ns|us|ms|s|m|h)$",
                   "default": "1h",
@@ -432,7 +432,7 @@
                   },
                   "additionalProperties": false
                 },
-                "request_lifespan": {
+                "lifespan": {
                   "title": "Self-Service Verification Request Lifespan",
                   "description": "Sets how long the verification request (for the UI interaction) is valid.",
                   "type": "string",
@@ -476,7 +476,7 @@
                   },
                   "additionalProperties": false
                 },
-                "request_lifespan": {
+                "lifespan": {
                   "title": "Self-Service Recovery Request Lifespan",
                   "description": "Sets how long the recovery request is valid. If expired, the user has to redo the flow.",
                   "type": "string",

--- a/contrib/quickstart/kratos/email-password/kratos.yml
+++ b/contrib/quickstart/kratos/email-password/kratos.yml
@@ -41,10 +41,10 @@ selfservice:
 
     login:
       ui_url: http://127.0.0.1:4455/auth/login
-      request_lifespan: 10m
+      lifespan: 10m
 
     registration:
-      request_lifespan: 10m
+      lifespan: 10m
       ui_url: http://127.0.0.1:4455/auth/registration
       after:
         password:

--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -151,7 +151,7 @@ selfservice:
       #
       ui_url: https://www.ory.sh/kratos/docs/fallback/settings
 
-      ## request_lifespan ##
+      ## lifespan ##
       #
       # Default value: 1h
       #
@@ -162,11 +162,11 @@ selfservice:
       #
       # Set this value using environment variables on
       # - Linux/macOS:
-      #    $ export SELFSERVICE_FLOWS_SETTINGS_REQUEST_LIFESPAN=<value>
+      #    $ export SELFSERVICE_FLOWS_SETTINGS_LIFESPAN=<value>
       # - Windows Command Line (CMD):
-      #    > set SELFSERVICE_FLOWS_SETTINGS_REQUEST_LIFESPAN=<value>
+      #    > set SELFSERVICE_FLOWS_SETTINGS_LIFESPAN=<value>
       #
-      request_lifespan: 1h
+      lifespan: 1h
 
       ## privileged_session_max_age ##
       #
@@ -302,7 +302,7 @@ selfservice:
       #
       ui_url: https://www.ory.sh/kratos/docs/fallback/registration
 
-      ## request_lifespan ##
+      ## lifespan ##
       #
       # Default value: 1h
       #
@@ -313,11 +313,11 @@ selfservice:
       #
       # Set this value using environment variables on
       # - Linux/macOS:
-      #    $ export SELFSERVICE_FLOWS_REGISTRATION_REQUEST_LIFESPAN=<value>
+      #    $ export SELFSERVICE_FLOWS_REGISTRATION_LIFESPAN=<value>
       # - Windows Command Line (CMD):
-      #    > set SELFSERVICE_FLOWS_REGISTRATION_REQUEST_LIFESPAN=<value>
+      #    > set SELFSERVICE_FLOWS_REGISTRATION_LIFESPAN=<value>
       #
-      request_lifespan: 1m
+      lifespan: 1m
 
       ## after ##
       #
@@ -415,7 +415,7 @@ selfservice:
       #
       ui_url: https://my-app.com/login
 
-      ## request_lifespan ##
+      ## lifespan ##
       #
       # Default value: 1h
       #
@@ -426,11 +426,11 @@ selfservice:
       #
       # Set this value using environment variables on
       # - Linux/macOS:
-      #    $ export SELFSERVICE_FLOWS_LOGIN_REQUEST_LIFESPAN=<value>
+      #    $ export SELFSERVICE_FLOWS_LOGIN_LIFESPAN=<value>
       # - Windows Command Line (CMD):
-      #    > set SELFSERVICE_FLOWS_LOGIN_REQUEST_LIFESPAN=<value>
+      #    > set SELFSERVICE_FLOWS_LOGIN_LIFESPAN=<value>
       #
-      request_lifespan: 1h
+      lifespan: 1h
 
       ## after ##
       #
@@ -573,11 +573,11 @@ selfservice:
       #
       # Set this value using environment variables on
       # - Linux/macOS:
-      #    $ export SELFSERVICE_FLOWS_VERIFICATION_REQUEST_LIFESPAN=<value>
+      #    $ export SELFSERVICE_FLOWS_VERIFICATION_LIFESPAN=<value>
       # - Windows Command Line (CMD):
-      #    > set SELFSERVICE_FLOWS_VERIFICATION_REQUEST_LIFESPAN=<value>
+      #    > set SELFSERVICE_FLOWS_VERIFICATION_LIFESPAN=<value>
       #
-      request_lifespan: 1m
+      lifespan: 1m
 
     ## Account Recovery Configuration ##
     #
@@ -644,11 +644,11 @@ selfservice:
       #
       # Set this value using environment variables on
       # - Linux/macOS:
-      #    $ export SELFSERVICE_FLOWS_RECOVERY_REQUEST_LIFESPAN=<value>
+      #    $ export SELFSERVICE_FLOWS_RECOVERY_LIFESPAN=<value>
       # - Windows Command Line (CMD):
-      #    > set SELFSERVICE_FLOWS_RECOVERY_REQUEST_LIFESPAN=<value>
+      #    > set SELFSERVICE_FLOWS_RECOVERY_LIFESPAN=<value>
       #
-      request_lifespan: 1s
+      lifespan: 1s
 
     ## error ##
     #

--- a/driver/configuration/provider_viper.go
+++ b/driver/configuration/provider_viper.go
@@ -67,12 +67,12 @@ const (
 	ViperKeyURLsWhitelistedReturnToDomains    = "selfservice.whitelisted_return_urls"
 
 	ViperKeySelfServiceRegistrationUI              = "selfservice.flows.registration.ui_url"
-	ViperKeySelfServiceRegistrationRequestLifespan = "selfservice.flows.registration.request_lifespan"
+	ViperKeySelfServiceRegistrationRequestLifespan = "selfservice.flows.registration.lifespan"
 	ViperKeySelfServiceRegistrationAfter           = "selfservice.flows.registration.after"
 	ViperKeySelfServiceRegistrationBeforeHooks     = "selfservice.flows.registration.before.hooks"
 
 	ViperKeySelfServiceLoginUI              = "selfservice.flows.login.ui_url"
-	ViperKeySelfServiceLoginRequestLifespan = "selfservice.flows.login.request_lifespan"
+	ViperKeySelfServiceLoginRequestLifespan = "selfservice.flows.login.lifespan"
 	ViperKeySelfServiceLoginAfter           = "selfservice.flows.login.after"
 	ViperKeySelfServiceLoginBeforeHooks     = "selfservice.flows.login.before.hooks"
 
@@ -82,17 +82,17 @@ const (
 
 	ViperKeySelfServiceSettingsURL                           = "selfservice.flows.settings.ui_url"
 	ViperKeySelfServiceSettingsAfter                         = "selfservice.flows.settings.after"
-	ViperKeySelfServiceSettingsRequestLifespan               = "selfservice.flows.settings.request_lifespan"
+	ViperKeySelfServiceSettingsRequestLifespan               = "selfservice.flows.settings.lifespan"
 	ViperKeySelfServiceSettingsPrivilegedAuthenticationAfter = "selfservice.flows.settings.privileged_session_max_age"
 
 	ViperKeySelfServiceRecoveryEnabled                = "selfservice.flows.recovery.enabled"
 	ViperKeySelfServiceRecoveryUI                     = "selfservice.flows.recovery.ui_url"
-	ViperKeySelfServiceRecoveryRequestLifespan        = "selfservice.flows.recovery.request_lifespan"
+	ViperKeySelfServiceRecoveryRequestLifespan        = "selfservice.flows.recovery.lifespan"
 	ViperKeySelfServiceRecoveryBrowserDefaultReturnTo = "selfservice.flows.recovery.after." + DefaultBrowserReturnURL
 
 	ViperKeySelfServiceVerificationEnabled                = "selfservice.flows.verification.enabled"
 	ViperKeySelfServiceVerificationUI                     = "selfservice.flows.verification.ui_url"
-	ViperKeySelfServiceVerificationRequestLifespan        = "selfservice.flows.verification.request_lifespan"
+	ViperKeySelfServiceVerificationRequestLifespan        = "selfservice.flows.verification.lifespan"
 	ViperKeySelfServiceVerificationBrowserDefaultReturnTo = "selfservice.flows.verification.after." + DefaultBrowserReturnURL
 
 	ViperKeyDefaultIdentitySchemaURL = "identity.default_schema_url"

--- a/driver/configuration/stub/.defaults-verification.yml
+++ b/driver/configuration/stub/.defaults-verification.yml
@@ -9,7 +9,7 @@ selfservice:
 
     verification:
       enabled: true
-      request_lifespan: 5s
+      lifespan: 5s
       after:
         default_browser_return_url: http://127.0.0.1:4455/
 

--- a/internal/.kratos.yaml
+++ b/internal/.kratos.yaml
@@ -65,20 +65,20 @@ selfservice:
     recovery:
       enabled: true
       ui_url: http://test.kratos.ory.sh/recovery
-      request_lifespan: 98m
+      lifespan: 98m
       after:
         default_browser_return_url: http://test.kratos.ory.sh/dashboard
 
     verification:
       enabled: true
-      request_lifespan: 97m
+      lifespan: 97m
       ui_url: http://test.kratos.ory.sh/verification
       after:
         default_browser_return_url: http://test.kratos.ory.sh/dashboard
 
     settings:
       ui_url:  http://test.kratos.ory.sh/settings
-      request_lifespan: 99m
+      lifespan: 99m
       privileged_session_max_age: 5m
       after:
         default_browser_return_url: https://self-service/settings/return_to
@@ -86,7 +86,7 @@ selfservice:
           default_browser_return_url: https://self-service/settings/password/return_to
     login:
       ui_url: http://test.kratos.ory.sh/login
-      request_lifespan: 99m
+      lifespan: 99m
       after:
         default_browser_return_url: https://self-service/login/return_to
         password:
@@ -100,7 +100,7 @@ selfservice:
               hook: revoke_active_sessions
     registration:
       ui_url: http://test.kratos.ory.sh/register
-      request_lifespan: 98m
+      lifespan: 98m
       after:
         default_browser_return_url: https://self-service/registration/return_to
         password:

--- a/internal/httpclient/client/admin/admin_client.go
+++ b/internal/httpclient/client/admin/admin_client.go
@@ -240,7 +240,7 @@ func (a *Client) ListIdentities(params *ListIdentitiesParams) (*ListIdentitiesOK
   ```
 metadata:
 annotations:
-prometheus.io/port: "4445"
+prometheus.io/port: "4434"
 prometheus.io/path: "/metrics/prometheus"
 ```
 */

--- a/internal/httpclient/client/admin/create_recovery_link_responses.go
+++ b/internal/httpclient/client/admin/create_recovery_link_responses.go
@@ -196,7 +196,7 @@ type CreateRecoveryLinkBody struct {
 	// Link Expires In
 	//
 	// The recovery link will expire at that point in time. Defaults to the configuration value of
-	// `selfservice.flows.recovery.request_lifespan`.
+	// `selfservice.flows.recovery.lifespan`.
 	// Pattern: ^[0-9]+(ns|us|ms|s|m|h)$
 	ExpiresIn string `json:"expires_in,omitempty"`
 

--- a/selfservice/strategy/recoverytoken/strategy.go
+++ b/selfservice/strategy/recoverytoken/strategy.go
@@ -130,7 +130,7 @@ type createRecoveryLinkParams struct {
 		// Link Expires In
 		//
 		// The recovery link will expire at that point in time. Defaults to the configuration value of
-		// `selfservice.flows.recovery.request_lifespan`.
+		// `selfservice.flows.recovery.lifespan`.
 		//
 		//
 		// pattern: ^[0-9]+(ns|us|ms|s|m|h)$

--- a/test/e2e/profiles/recovery/.kratos.yml
+++ b/test/e2e/profiles/recovery/.kratos.yml
@@ -9,7 +9,7 @@ selfservice:
 
     recovery:
       enabled: true
-      request_lifespan: 5s
+      lifespan: 5s
 
     logout:
       after:

--- a/test/e2e/profiles/verification/.kratos.yml
+++ b/test/e2e/profiles/verification/.kratos.yml
@@ -9,7 +9,7 @@ selfservice:
 
     verification:
       enabled: true
-      request_lifespan: 5s
+      lifespan: 5s
       after:
         default_browser_return_url: http://127.0.0.1:4455/
 

--- a/test/schema/fixtures/config.schema.test.failure/wrongTypes.main.yaml
+++ b/test/schema/fixtures/config.schema.test.failure/wrongTypes.main.yaml
@@ -13,15 +13,15 @@ selfservice:
     redirect_to: 0
 
   profile:
-    request_lifespan: 10
+    lifespan: 10
 
   login:
-    request_lifespan: 10
+    lifespan: 10
     before: foo
     after: foo
 
   registration:
-    request_lifespan: 10
+    lifespan: 10
     before:
       - foo
     after: foo

--- a/test/schema/fixtures/config.schema.test.success/allKeys.main.yaml
+++ b/test/schema/fixtures/config.schema.test.success/allKeys.main.yaml
@@ -13,7 +13,7 @@ selfservice:
     redirect_to: https://example.com
 
   profile:
-    request_lifespan: 10m
+    lifespan: 10m
     after:
       profile:
         hooks: "#/definitions/selfServiceAfterLoginStrategy"
@@ -21,7 +21,7 @@ selfservice:
         hooks: "#/definitions/selfServiceAfterLoginStrategy"
 
   login:
-    request_lifespan: 10m
+    lifespan: 10m
     before:
       hooks: "#/definitions/selfServiceBefore"
     after:
@@ -31,7 +31,7 @@ selfservice:
         hooks: "#/definitions/selfServiceAfterLoginStrategy"
 
   registration:
-    request_lifespan: 10m
+    lifespan: 10m
     before:
       hooks: "#/definitions/selfServiceBefore"
     after:


### PR DESCRIPTION
BREAKING CHANGE: Configuration option request_lifespan changed to lifespan

## Related issue

Closes #666 

## Proposed changes

Rename `request_lifespan` to `lifespan`

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments

Maybe, all occurrences of the "RequestLifespan" in function names should also be replaced with "Lifespan".