### PR TITLE
fix: keep HTML form type on registration error

### DIFF
--- a/selfservice/form/html_form.go
+++ b/selfservice/form/html_form.go
@@ -285,7 +285,6 @@ func (c *HTMLForm) SetValue(name string, value interface{}) {
 
 	if f := c.getField(name); f != nil {
 		f.Value = value
-		f.Type = toFormType(name, value)
 		return
 	}
 	c.Fields = append(c.Fields, Field{

--- a/selfservice/strategy/password/registration.go
+++ b/selfservice/strategy/password/registration.go
@@ -58,7 +58,8 @@ func (s *Strategy) handleRegistrationError(w http.ResponseWriter, r *http.Reques
 
 			if p != nil {
 				for _, field := range form.NewHTMLFormFromJSON("", p.Traits, "traits").Fields {
-					method.Config.SetField(field)
+					// we only set the value and not the whole field because we want to keep types from the initial form generation
+					method.Config.SetValue(field.Name, field.Value)
 				}
 			}
 

--- a/selfservice/strategy/password/registration_test.go
+++ b/selfservice/strategy/password/registration_test.go
@@ -104,6 +104,9 @@ func TestRegistration(t *testing.T) {
 		})
 
 		t.Run("case=should show the error ui because the request payload is malformed", func(t *testing.T) {
+			viper.Set(configuration.ViperKeyDefaultIdentitySchemaURL, "file://./stub/profile.schema.json")
+			defer viper.Set(configuration.ViperKeyDefaultIdentitySchemaURL, "file://./stub/registration.schema.json")
+
 			t.Run("type=api", func(t *testing.T) {
 				f := testhelpers.InitializeRegistrationFlowViaAPI(t, apiClient, publicTS)
 				c := testhelpers.GetRegistrationFlowMethodConfig(t, f.Payload, identity.CredentialsTypePassword.String())
@@ -121,6 +124,7 @@ func TestRegistration(t *testing.T) {
 				assert.Contains(t, res.Request.URL.String(), uiTS.URL+"/registration-ts")
 				assert.NotEmpty(t, gjson.Get(body, "id").String(), "%s", body)
 				assert.Contains(t, gjson.Get(body, "methods.password.config.messages.0.text").String(), "invalid URL escape", "%s", body)
+				assert.Equal(t, "email", gjson.Get(body, "methods.password.config.fields.#(name==\"traits.email\").type").String(), "%s", body)
 			})
 		})
 

--- a/selfservice/strategy/password/stub/profile.schema.json
+++ b/selfservice/strategy/password/stub/profile.schema.json
@@ -7,17 +7,18 @@
     "traits": {
       "type": "object",
       "properties": {
-    "email": {
-      "type": "string",
-      "ory.sh/kratos": {
-        "credentials": {
-          "password": {
-            "identifier": true
+        "email": {
+          "type": "string",
+          "format": "email",
+          "ory.sh/kratos": {
+            "credentials": {
+              "password": {
+                "identifier": true
+              }
+            }
           }
         }
       }
-    }
-    }
     }
   },
   "additionalProperties": false


### PR DESCRIPTION

## Related issue
closes #670

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes
Only set the value and not the whole field when generating the registration form with error messages.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->


