### PR TITLE
fix: escape jsx characters in api documentation

### DIFF
--- a/.schema/api.swagger.json
+++ b/.schema/api.swagger.json
@@ -2115,7 +2115,7 @@
           "$ref": "#/definitions/session"
         },
         "session_token": {
-          "description": "The Session Token\n\nA session token is equivalent to a session cookie, but it can be sent in the HTTP Authorization\nHeader:\n\nAuthorization: bearer \u003csession-token\u003e\n\nThe session token is only issued for API flows, not for Browser flows!",
+          "description": "The Session Token\n\nA session token is equivalent to a session cookie, but it can be sent in the HTTP Authorization\nHeader:\n\nAuthorization: bearer ${session-token}\n\nThe session token is only issued for API flows, not for Browser flows!",
           "type": "string"
         }
       }
@@ -2327,7 +2327,7 @@
           "$ref": "#/definitions/session"
         },
         "session_token": {
-          "description": "The Session Token\n\nThis field is only set when the session hook is configured as a post-registration hook.\n\nA session token is equivalent to a session cookie, but it can be sent in the HTTP Authorization\nHeader:\n\nAuthorization: bearer \u003csession-token\u003e\n\nThe session token is only issued for API flows, not for Browser flows!",
+          "description": "The Session Token\n\nThis field is only set when the session hook is configured as a post-registration hook.\n\nA session token is equivalent to a session cookie, but it can be sent in the HTTP Authorization\nHeader:\n\nAuthorization: bearer ${session-token}\n\nThe session token is only issued for API flows, not for Browser flows!",
           "type": "string"
         }
       }

--- a/docs/docs/reference/api.mdx
+++ b/docs/docs/reference/api.mdx
@@ -3,6 +3,8 @@ title: REST API
 id: api
 ---
 
+
+
 Welcome to the ORY Kratos HTTP API documentation!
 
 import Tabs from '@theme/Tabs'
@@ -10,19 +12,21 @@ import TabItem from '@theme/TabItem'
 
 :::info
 
-You are viewing REST API documentation. This documentation is auto-generated
-from a swagger specification which itself is generated from annotations in the
-source code of the project. It is possible that this documentation includes bugs
-and that code samples are incomplete or wrong.
+You are viewing REST API documentation. This documentation is auto-generated from a swagger specification which
+itself is generated from annotations in the source code of the project. It is possible that this documentation includes
+bugs and that code samples are incomplete or wrong.
 
 If you find issues in the respective documentation, please do not edit the
-Markdown files directly (as they are generated) but raise an issue on the
-project's GitHub presence instead. This documentation will improve over time
-with your help! If you have ideas how to improve this part of the documentation,
-feel free to share them in a
-[GitHub issue](https://github.com/ory/docs/issues/new) any time.
+Markdown files directly (as they are generated) but raise an issue on the project's GitHub presence instead. This documentation
+will improve over time with your help! If you have ideas how to improve this part of the documentation, feel free to
+share them in a [GitHub issue](https://github.com/ory/docs/issues/new) any time.
 
 :::
+
+## Authentication
+
+* API Key (sessionToken)
+    - Parameter Name: **Authorization**, in: header. 
 
 <a id="ory-kratos-health"></a>
 
@@ -38,15 +42,14 @@ Accept: application/json
 
 ```
 
-This endpoint returns a 200 status code when the HTTP server is up running. This
-status does currently not include checks whether the database connection is
-working.
+This endpoint returns a 200 status code when the HTTP server is up running.
+This status does currently not include checks whether the database connection is working.
 
 If the service supports TLS Edge Termination, this endpoint does not require the
 `X-Forwarded-Proto` header to be set.
 
-Be aware that if you are running multiple nodes of this service, the health
-status will never refer to the cluster state, only to a single instance.
+Be aware that if you are running multiple nodes of this service, the health status will never
+refer to the cluster state, only to a single instance.
 
 #### Responses
 
@@ -54,10 +57,10 @@ status will never refer to the cluster state, only to a single instance.
 
 ##### Overview
 
-| Status | Meaning                                                                    | Description  | Schema                              |
-| ------ | -------------------------------------------------------------------------- | ------------ | ----------------------------------- |
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)                    | healthStatus | [healthStatus](#schemahealthstatus) |
-| 500    | [Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1) | genericError | [genericError](#schemagenericerror) |
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|healthStatus|[healthStatus](#schemahealthstatus)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
 
 ##### Examples
 
@@ -69,7 +72,9 @@ status will never refer to the cluster state, only to a single instance.
 }
 ```
 
-<aside class="success">This operation does not require authentication</aside>
+<aside class="success">
+This operation does not require authentication
+</aside>
 
 #### Code samples
 
@@ -95,7 +100,7 @@ import (
 )
 
 func main() {
-    headers := map[string][]string{
+    headers := map[string][]string{ 
         "Accept": []string{"application/json"},
     }
 
@@ -115,20 +120,20 @@ func main() {
 <TabItem value="node">
 
 ```javascript
-const fetch = require('node-fetch')
+const fetch = require('node-fetch');
 
 const headers = {
-  Accept: 'application/json'
+  'Accept': 'application/json'
 }
 
 fetch('/health/alive', {
   method: 'GET',
   headers
 })
-  .then((r) => r.json())
-  .then((body) => {
+.then(r => r.json())
+.then((body) => {
     console.log(body)
-  })
+})
 ```
 
 </TabItem>
@@ -205,14 +210,14 @@ Accept: application/json
 
 ```
 
-This endpoint returns a 200 status code when the HTTP server is up running and
-the environment dependencies (e.g. the database) are responsive as well.
+This endpoint returns a 200 status code when the HTTP server is up running and the environment dependencies (e.g.
+the database) are responsive as well.
 
 If the service supports TLS Edge Termination, this endpoint does not require the
 `X-Forwarded-Proto` header to be set.
 
-Be aware that if you are running multiple nodes of this service, the health
-status will never refer to the cluster state, only to a single instance.
+Be aware that if you are running multiple nodes of this service, the health status will never
+refer to the cluster state, only to a single instance.
 
 #### Responses
 
@@ -220,10 +225,10 @@ status will never refer to the cluster state, only to a single instance.
 
 ##### Overview
 
-| Status | Meaning                                                                  | Description          | Schema                                              |
-| ------ | ------------------------------------------------------------------------ | -------------------- | --------------------------------------------------- |
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)                  | healthStatus         | [healthStatus](#schemahealthstatus)                 |
-| 503    | [Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4) | healthNotReadyStatus | [healthNotReadyStatus](#schemahealthnotreadystatus) |
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|healthStatus|[healthStatus](#schemahealthstatus)|
+|503|[Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4)|healthNotReadyStatus|[healthNotReadyStatus](#schemahealthnotreadystatus)|
 
 ##### Examples
 
@@ -235,7 +240,9 @@ status will never refer to the cluster state, only to a single instance.
 }
 ```
 
-<aside class="success">This operation does not require authentication</aside>
+<aside class="success">
+This operation does not require authentication
+</aside>
 
 #### Code samples
 
@@ -261,7 +268,7 @@ import (
 )
 
 func main() {
-    headers := map[string][]string{
+    headers := map[string][]string{ 
         "Accept": []string{"application/json"},
     }
 
@@ -281,20 +288,20 @@ func main() {
 <TabItem value="node">
 
 ```javascript
-const fetch = require('node-fetch')
+const fetch = require('node-fetch');
 
 const headers = {
-  Accept: 'application/json'
+  'Accept': 'application/json'
 }
 
 fetch('/health/ready', {
   method: 'GET',
   headers
 })
-  .then((r) => r.json())
-  .then((body) => {
+.then(r => r.json())
+.then((body) => {
     console.log(body)
-  })
+})
 ```
 
 </TabItem>
@@ -367,7 +374,7 @@ p JSON.parse(result)
 
 <a id="opIdlistIdentities"></a>
 
-### List all identities in the system
+### List Identities
 
 ```
 GET /identities HTTP/1.1
@@ -375,46 +382,60 @@ Accept: application/json
 
 ```
 
-This endpoint returns a login request's context with, for example, error details
-and other information.
+Lists all identities. Does not support search at the moment.
 
-Learn how identities work in
-[ORY Kratos' User And Identity Model Documentation](https://www.ory.sh/docs/next/kratos/concepts/identity-user-model).
+Learn how identities work in [ORY Kratos' User And Identity Model Documentation](https://www.ory.sh/docs/next/kratos/concepts/identity-user-model).
+
+<a id="list-identities-parameters"></a>
+
+#### Parameters
+
+|Parameter|In|Type|Required|Description|
+|---|---|---|---|---|
+|per_page|query|integer(int64)|false|Items per Page|
+|page|query|integer(int64)|false|Pagination Page|
+
+##### Detailed descriptions
+
+**per_page**: Items per Page
+
+This is the number of items per page.
 
 #### Responses
 
-<a id="list-all-identities-in-the-system-responses"></a>
+<a id="list-identities-responses"></a>
 
 ##### Overview
 
-| Status | Meaning                                                                    | Description           | Schema                              |
-| ------ | -------------------------------------------------------------------------- | --------------------- | ----------------------------------- |
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)                    | A list of identities. | Inline                              |
-| 500    | [Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1) | genericError          | [genericError](#schemagenericerror) |
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A list of identities.|Inline|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
 
-<a id="list-all-identities-in-the-system-responseschema"></a>
+<a id="list-identities-responseschema"></a>
+
 ##### Response Schema
 
 Status Code **200**
 
-| Name                   | Type                                                  | Required | Restrictions | Description                                                                                              |
-| ---------------------- | ----------------------------------------------------- | -------- | ------------ | -------------------------------------------------------------------------------------------------------- |
-| _anonymous_            | [[Identity](#schemaidentity)]                         | false    | none         | none                                                                                                     |
-| » id                   | [UUID](#schemauuid)(uuid4)                            | true     | none         | none                                                                                                     |
-| » recovery_addresses   | [[RecoveryAddress](#schemarecoveryaddress)]           | false    | none         | RecoveryAddresses contains all the addresses that can be used to recover an identity.                    |
-| »» id                  | [UUID](#schemauuid)(uuid4)                            | true     | none         | none                                                                                                     |
-| »» value               | string                                                | true     | none         | none                                                                                                     |
-| »» via                 | [RecoveryAddressType](#schemarecoveryaddresstype)     | true     | none         | none                                                                                                     |
-| » schema_id            | string                                                | true     | none         | SchemaID is the ID of the JSON Schema to be used for validating the identity's traits.                   |
-| » schema_url           | string                                                | false    | none         | SchemaURL is the URL of the endpoint where the identity's traits schema can be fetched from. format: url |
-| » traits               | [Traits](#schematraits)                               | true     | none         | none                                                                                                     |
-| » verifiable_addresses | [[VerifiableAddress](#schemaverifiableaddress)]       | false    | none         | VerifiableAddresses contains all the addresses that can be verified by the user.                         |
-| »» expires_at          | string(date-time)                                     | true     | none         | none                                                                                                     |
-| »» id                  | [UUID](#schemauuid)(uuid4)                            | true     | none         | none                                                                                                     |
-| »» value               | string                                                | true     | none         | none                                                                                                     |
-| »» verified            | boolean                                               | true     | none         | none                                                                                                     |
-| »» verified_at         | string(date-time)                                     | false    | none         | none                                                                                                     |
-| »» via                 | [VerifiableAddressType](#schemaverifiableaddresstype) | true     | none         | none                                                                                                     |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|[[Identity](#schemaidentity)]|false|none|none|
+|» id|[UUID](#schemauuid)(uuid4)|true|none|none|
+|» recovery_addresses|[[RecoveryAddress](#schemarecoveryaddress)]|false|none|RecoveryAddresses contains all the addresses that can be used to recover an identity.|
+|»» id|[UUID](#schemauuid)(uuid4)|true|none|none|
+|»» value|string|true|none|none|
+|»» via|[RecoveryAddressType](#schemarecoveryaddresstype)|true|none|none|
+|» schema_id|string|true|none|SchemaID is the ID of the JSON Schema to be used for validating the identity's traits.|
+|» schema_url|string|false|none|SchemaURL is the URL of the endpoint where the identity's traits schema can be fetched from.<br><br>format: url|
+|» traits|[Traits](#schematraits)|true|none|none|
+|» verifiable_addresses|[[VerifiableAddress](#schemaverifiableaddress)]|false|none|VerifiableAddresses contains all the addresses that can be verified by the user.|
+|»» id|[UUID](#schemauuid)(uuid4)|true|none|none|
+|»» status|[VerifiableAddressStatus](#schemaverifiableaddressstatus)|true|none|none|
+|»» value|string|true|none|none|
+|»» verified|boolean|true|none|none|
+|»» verified_at|[NullTime](#schemanulltime)(date-time)|false|none|none|
+|»» via|[VerifiableAddressType](#schemaverifiableaddresstype)|true|none|none|
 
 ##### Examples
 
@@ -436,8 +457,8 @@ Status Code **200**
     "traits": {},
     "verifiable_addresses": [
       {
-        "expires_at": "2019-08-24T14:15:22Z",
         "id": "string",
+        "status": "string",
         "value": "string",
         "verified": true,
         "verified_at": "2019-08-24T14:15:22Z",
@@ -448,7 +469,9 @@ Status Code **200**
 ]
 ```
 
-<aside class="success">This operation does not require authentication</aside>
+<aside class="success">
+This operation does not require authentication
+</aside>
 
 #### Code samples
 
@@ -474,7 +497,7 @@ import (
 )
 
 func main() {
-    headers := map[string][]string{
+    headers := map[string][]string{ 
         "Accept": []string{"application/json"},
     }
 
@@ -494,20 +517,20 @@ func main() {
 <TabItem value="node">
 
 ```javascript
-const fetch = require('node-fetch')
+const fetch = require('node-fetch');
 
 const headers = {
-  Accept: 'application/json'
+  'Accept': 'application/json'
 }
 
 fetch('/identities', {
   method: 'GET',
   headers
 })
-  .then((r) => r.json())
-  .then((body) => {
+.then(r => r.json())
+.then((body) => {
     console.log(body)
-  })
+})
 ```
 
 </TabItem>
@@ -576,7 +599,7 @@ p JSON.parse(result)
 
 <a id="opIdcreateIdentity"></a>
 
-### Create an identity
+### Create an Identity
 
 ```
 POST /identities HTTP/1.1
@@ -585,38 +608,17 @@ Accept: application/json
 
 ```
 
-This endpoint creates an identity. It is NOT possible to set an identity's
-credentials (password, ...) using this method! A way to achieve that will be
-introduced in the future.
+This endpoint creates an identity. It is NOT possible to set an identity's credentials (password, ...)
+using this method! A way to achieve that will be introduced in the future.
 
-Learn how identities work in
-[ORY Kratos' User And Identity Model Documentation](https://www.ory.sh/docs/next/kratos/concepts/identity-user-model).
+Learn how identities work in [ORY Kratos' User And Identity Model Documentation](https://www.ory.sh/docs/next/kratos/concepts/identity-user-model).
 
 #### Request body
 
 ```json
 {
-  "id": "string",
-  "recovery_addresses": [
-    {
-      "id": "string",
-      "value": "string",
-      "via": "string"
-    }
-  ],
   "schema_id": "string",
-  "schema_url": "string",
-  "traits": {},
-  "verifiable_addresses": [
-    {
-      "expires_at": "2019-08-24T14:15:22Z",
-      "id": "string",
-      "value": "string",
-      "verified": true,
-      "verified_at": "2019-08-24T14:15:22Z",
-      "via": "string"
-    }
-  ]
+  "traits": {}
 }
 ```
 
@@ -624,9 +626,9 @@ Learn how identities work in
 
 #### Parameters
 
-| Parameter | In   | Type                        | Required | Description |
-| --------- | ---- | --------------------------- | -------- | ----------- |
-| body      | body | [Identity](#schemaidentity) | true     | none        |
+|Parameter|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[CreateIdentity](#schemacreateidentity)|false|none|
 
 #### Responses
 
@@ -634,11 +636,11 @@ Learn how identities work in
 
 ##### Overview
 
-| Status | Meaning                                                                    | Description        | Schema                              |
-| ------ | -------------------------------------------------------------------------- | ------------------ | ----------------------------------- |
-| 201    | [Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)               | A single identity. | [Identity](#schemaidentity)         |
-| 400    | [Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)           | genericError       | [genericError](#schemagenericerror) |
-| 500    | [Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1) | genericError       | [genericError](#schemagenericerror) |
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|A single identity.|[Identity](#schemaidentity)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|genericError|[genericError](#schemagenericerror)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
 
 ##### Examples
 
@@ -659,8 +661,8 @@ Learn how identities work in
   "traits": {},
   "verifiable_addresses": [
     {
-      "expires_at": "2019-08-24T14:15:22Z",
       "id": "string",
+      "status": "string",
       "value": "string",
       "verified": true,
       "verified_at": "2019-08-24T14:15:22Z",
@@ -670,7 +672,9 @@ Learn how identities work in
 }
 ```
 
-<aside class="success">This operation does not require authentication</aside>
+<aside class="success">
+This operation does not require authentication
+</aside>
 
 #### Code samples
 
@@ -696,7 +700,7 @@ import (
 )
 
 func main() {
-    headers := map[string][]string{
+    headers := map[string][]string{ 
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
     }
@@ -719,27 +723,8 @@ func main() {
 ```javascript
 const fetch = require('node-fetch');
 const input = '{
-  "id": "string",
-  "recovery_addresses": [
-    {
-      "id": "string",
-      "value": "string",
-      "via": "string"
-    }
-  ],
   "schema_id": "string",
-  "schema_url": "string",
-  "traits": {},
-  "verifiable_addresses": [
-    {
-      "expires_at": "2019-08-24T14:15:22Z",
-      "id": "string",
-      "value": "string",
-      "verified": true,
-      "verified_at": "2019-08-24T14:15:22Z",
-      "via": "string"
-    }
-  ]
+  "traits": {}
 }';
 const headers = {
   'Content-Type': 'application/json',  'Accept': 'application/json'
@@ -824,7 +809,7 @@ p JSON.parse(result)
 
 <a id="opIdgetIdentity"></a>
 
-### Get an identity
+### Get an Identity
 
 ```
 GET /identities/{id} HTTP/1.1
@@ -832,16 +817,15 @@ Accept: application/json
 
 ```
 
-Learn how identities work in
-[ORY Kratos' User And Identity Model Documentation](https://www.ory.sh/docs/next/kratos/concepts/identity-user-model).
+Learn how identities work in [ORY Kratos' User And Identity Model Documentation](https://www.ory.sh/docs/next/kratos/concepts/identity-user-model).
 
 <a id="get-an-identity-parameters"></a>
 
 #### Parameters
 
-| Parameter | In   | Type   | Required | Description                                          |
-| --------- | ---- | ------ | -------- | ---------------------------------------------------- |
-| id        | path | string | true     | ID must be set to the ID of identity you want to get |
+|Parameter|In|Type|Required|Description|
+|---|---|---|---|---|
+|id|path|string|true|ID must be set to the ID of identity you want to get|
 
 #### Responses
 
@@ -849,11 +833,11 @@ Learn how identities work in
 
 ##### Overview
 
-| Status | Meaning                                                                    | Description        | Schema                              |
-| ------ | -------------------------------------------------------------------------- | ------------------ | ----------------------------------- |
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)                    | A single identity. | [Identity](#schemaidentity)         |
-| 400    | [Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)           | genericError       | [genericError](#schemagenericerror) |
-| 500    | [Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1) | genericError       | [genericError](#schemagenericerror) |
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A single identity.|[Identity](#schemaidentity)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|genericError|[genericError](#schemagenericerror)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
 
 ##### Examples
 
@@ -874,8 +858,8 @@ Learn how identities work in
   "traits": {},
   "verifiable_addresses": [
     {
-      "expires_at": "2019-08-24T14:15:22Z",
       "id": "string",
+      "status": "string",
       "value": "string",
       "verified": true,
       "verified_at": "2019-08-24T14:15:22Z",
@@ -885,7 +869,9 @@ Learn how identities work in
 }
 ```
 
-<aside class="success">This operation does not require authentication</aside>
+<aside class="success">
+This operation does not require authentication
+</aside>
 
 #### Code samples
 
@@ -911,7 +897,7 @@ import (
 )
 
 func main() {
-    headers := map[string][]string{
+    headers := map[string][]string{ 
         "Accept": []string{"application/json"},
     }
 
@@ -931,20 +917,20 @@ func main() {
 <TabItem value="node">
 
 ```javascript
-const fetch = require('node-fetch')
+const fetch = require('node-fetch');
 
 const headers = {
-  Accept: 'application/json'
+  'Accept': 'application/json'
 }
 
 fetch('/identities/{id}', {
   method: 'GET',
   headers
 })
-  .then((r) => r.json())
-  .then((body) => {
+.then(r => r.json())
+.then((body) => {
     console.log(body)
-  })
+})
 ```
 
 </TabItem>
@@ -1013,7 +999,7 @@ p JSON.parse(result)
 
 <a id="opIdupdateIdentity"></a>
 
-### Update an identity
+### Update an Identity
 
 ```
 PUT /identities/{id} HTTP/1.1
@@ -1022,41 +1008,19 @@ Accept: application/json
 
 ```
 
-This endpoint updates an identity. It is NOT possible to set an identity's
-credentials (password, ...) using this method! A way to achieve that will be
-introduced in the future.
+This endpoint updates an identity. It is NOT possible to set an identity's credentials (password, ...)
+using this method! A way to achieve that will be introduced in the future.
 
-The full identity payload (except credentials) is expected. This endpoint does
-not support patching.
+The full identity payload (except credentials) is expected. This endpoint does not support patching.
 
-Learn how identities work in
-[ORY Kratos' User And Identity Model Documentation](https://www.ory.sh/docs/next/kratos/concepts/identity-user-model).
+Learn how identities work in [ORY Kratos' User And Identity Model Documentation](https://www.ory.sh/docs/next/kratos/concepts/identity-user-model).
 
 #### Request body
 
 ```json
 {
-  "id": "string",
-  "recovery_addresses": [
-    {
-      "id": "string",
-      "value": "string",
-      "via": "string"
-    }
-  ],
   "schema_id": "string",
-  "schema_url": "string",
-  "traits": {},
-  "verifiable_addresses": [
-    {
-      "expires_at": "2019-08-24T14:15:22Z",
-      "id": "string",
-      "value": "string",
-      "verified": true,
-      "verified_at": "2019-08-24T14:15:22Z",
-      "via": "string"
-    }
-  ]
+  "traits": {}
 }
 ```
 
@@ -1064,10 +1028,10 @@ Learn how identities work in
 
 #### Parameters
 
-| Parameter | In   | Type                        | Required | Description                                             |
-| --------- | ---- | --------------------------- | -------- | ------------------------------------------------------- |
-| id        | path | string                      | true     | ID must be set to the ID of identity you want to update |
-| body      | body | [Identity](#schemaidentity) | true     | none                                                    |
+|Parameter|In|Type|Required|Description|
+|---|---|---|---|---|
+|id|path|string|true|ID must be set to the ID of identity you want to update|
+|body|body|[UpdateIdentity](#schemaupdateidentity)|false|none|
 
 #### Responses
 
@@ -1075,12 +1039,12 @@ Learn how identities work in
 
 ##### Overview
 
-| Status | Meaning                                                                    | Description        | Schema                              |
-| ------ | -------------------------------------------------------------------------- | ------------------ | ----------------------------------- |
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)                    | A single identity. | [Identity](#schemaidentity)         |
-| 400    | [Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)           | genericError       | [genericError](#schemagenericerror) |
-| 404    | [Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)             | genericError       | [genericError](#schemagenericerror) |
-| 500    | [Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1) | genericError       | [genericError](#schemagenericerror) |
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A single identity.|[Identity](#schemaidentity)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|genericError|[genericError](#schemagenericerror)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|genericError|[genericError](#schemagenericerror)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
 
 ##### Examples
 
@@ -1101,8 +1065,8 @@ Learn how identities work in
   "traits": {},
   "verifiable_addresses": [
     {
-      "expires_at": "2019-08-24T14:15:22Z",
       "id": "string",
+      "status": "string",
       "value": "string",
       "verified": true,
       "verified_at": "2019-08-24T14:15:22Z",
@@ -1112,7 +1076,9 @@ Learn how identities work in
 }
 ```
 
-<aside class="success">This operation does not require authentication</aside>
+<aside class="success">
+This operation does not require authentication
+</aside>
 
 #### Code samples
 
@@ -1138,7 +1104,7 @@ import (
 )
 
 func main() {
-    headers := map[string][]string{
+    headers := map[string][]string{ 
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
     }
@@ -1161,27 +1127,8 @@ func main() {
 ```javascript
 const fetch = require('node-fetch');
 const input = '{
-  "id": "string",
-  "recovery_addresses": [
-    {
-      "id": "string",
-      "value": "string",
-      "via": "string"
-    }
-  ],
   "schema_id": "string",
-  "schema_url": "string",
-  "traits": {},
-  "verifiable_addresses": [
-    {
-      "expires_at": "2019-08-24T14:15:22Z",
-      "id": "string",
-      "value": "string",
-      "verified": true,
-      "verified_at": "2019-08-24T14:15:22Z",
-      "via": "string"
-    }
-  ]
+  "traits": {}
 }';
 const headers = {
   'Content-Type': 'application/json',  'Accept': 'application/json'
@@ -1266,7 +1213,7 @@ p JSON.parse(result)
 
 <a id="opIddeleteIdentity"></a>
 
-### Delete an identity
+### Delete an Identity
 
 ```
 DELETE /identities/{id} HTTP/1.1
@@ -1274,18 +1221,19 @@ Accept: application/json
 
 ```
 
-This endpoint deletes an identity. This can not be undone.
+Calling this endpoint irrecoverably and permanently deletes the identity given its ID. This action can not be undone.
+This endpoint returns 204 when the identity was deleted or when the identity was not found, in which case it is
+assumed that is has been deleted already.
 
-Learn how identities work in
-[ORY Kratos' User And Identity Model Documentation](https://www.ory.sh/docs/next/kratos/concepts/identity-user-model).
+Learn how identities work in [ORY Kratos' User And Identity Model Documentation](https://www.ory.sh/docs/next/kratos/concepts/identity-user-model).
 
 <a id="delete-an-identity-parameters"></a>
 
 #### Parameters
 
-| Parameter | In   | Type   | Required | Description              |
-| --------- | ---- | ------ | -------- | ------------------------ |
-| id        | path | string | true     | ID is the identity's ID. |
+|Parameter|In|Type|Required|Description|
+|---|---|---|---|---|
+|id|path|string|true|ID is the identity's ID.|
 
 #### Responses
 
@@ -1293,16 +1241,15 @@ Learn how identities work in
 
 ##### Overview
 
-| Status         | Meaning                                                                    | Description                                                                                                    | Schema                              |
-| -------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| 204            | [No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)            | Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is |
-| typically 201. | None                                                                       |
-| 404            | [Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)             | genericError                                                                                                   | [genericError](#schemagenericerror) |
-| 500            | [Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1) | genericError                                                                                                   | [genericError](#schemagenericerror) |
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
+typically 201.|None|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
 
 ##### Examples
 
-###### 404 response
+###### 500 response
 
 ```json
 {
@@ -1318,7 +1265,9 @@ Learn how identities work in
 }
 ```
 
-<aside class="success">This operation does not require authentication</aside>
+<aside class="success">
+This operation does not require authentication
+</aside>
 
 #### Code samples
 
@@ -1344,7 +1293,7 @@ import (
 )
 
 func main() {
-    headers := map[string][]string{
+    headers := map[string][]string{ 
         "Accept": []string{"application/json"},
     }
 
@@ -1364,20 +1313,20 @@ func main() {
 <TabItem value="node">
 
 ```javascript
-const fetch = require('node-fetch')
+const fetch = require('node-fetch');
 
 const headers = {
-  Accept: 'application/json'
+  'Accept': 'application/json'
 }
 
 fetch('/identities/{id}', {
   method: 'DELETE',
   headers
 })
-  .then((r) => r.json())
-  .then((body) => {
+.then(r => r.json())
+.then((body) => {
     console.log(body)
-  })
+})
 ```
 
 </TabItem>
@@ -1444,6 +1393,336 @@ p JSON.parse(result)
 </TabItem>
 </Tabs>
 
+<a id="opIdprometheus"></a>
+
+### Get snapshot metrics from the Hydra service. If you're using k8s, you can then add annotations to
+your deployment like so:
+
+```
+GET /metrics/prometheus HTTP/1.1
+
+```
+
+```
+metadata:
+annotations:
+prometheus.io/port: "4434"
+prometheus.io/path: "/metrics/prometheus"
+```
+
+#### Responses
+
+<a id="get-snapshot-metrics-from-the-hydra-service.-if-you're-using-k8s,-you-can-then-add-annotations-to
+your-deployment-like-so:-responses"></a>
+
+##### Overview
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
+typically 201.|None|
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+#### Code samples
+
+<Tabs groupId="code-samples" defaultValue="shell"
+  values={[{label: 'Shell', value: 'shell'}, {label: 'Go', value: 'go'}, {label: 'Node', value: 'node'},
+    {label: 'Java', value: 'java'}, {label: 'Python', value: 'python'}, {label: 'Ruby', value: 'ruby'}]}>
+<TabItem value="shell">
+
+```shell
+curl -X GET /metrics/prometheus
+
+```
+
+</TabItem>
+<TabItem value="go">
+
+```go
+package main
+
+import (
+    "bytes"
+    "net/http"
+)
+
+func main() {
+
+    var body []byte
+    // body = ...
+
+    req, err := http.NewRequest("GET", "/metrics/prometheus", bytes.NewBuffer(body))
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+```
+
+</TabItem>
+<TabItem value="node">
+
+```javascript
+const fetch = require('node-fetch');
+
+fetch('/metrics/prometheus', {
+  method: 'GET'
+})
+.then(r => r.json())
+.then((body) => {
+    console.log(body)
+})
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+// This sample needs improvement.
+URL obj = new URL("/metrics/prometheus");
+
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+
+int responseCode = con.getResponseCode();
+
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream())
+);
+
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+
+System.out.println(response.toString());
+```
+
+</TabItem>
+<TabItem value="python">
+
+```python
+import requests
+
+r = requests.get(
+  '/metrics/prometheus',
+  params={)
+
+print r.json()
+```
+
+</TabItem>
+<TabItem value="ruby">
+
+```ruby
+require 'rest-client'
+require 'json'
+
+result = RestClient.get '/metrics/prometheus',
+  params: {}
+
+p JSON.parse(result)
+```
+
+</TabItem>
+</Tabs>
+
+<a id="opIdcreateRecoveryLink"></a>
+
+### Create a Recovery Link
+
+```
+POST /recovery/link HTTP/1.1
+Content-Type: application/json
+Accept: application/json
+
+```
+
+This endpoint creates a recovery link which should be given to the user in order for them to recover
+(or activate) their account.
+
+#### Request body
+
+```json
+{
+  "expires_in": "string",
+  "identity_id": "string"
+}
+```
+
+<a id="create-a-recovery-link-parameters"></a>
+
+#### Parameters
+
+|Parameter|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[CreateRecoveryLink](#schemacreaterecoverylink)|false|none|
+
+#### Responses
+
+<a id="create-a-recovery-link-responses"></a>
+
+##### Overview
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|recoveryLink|[recoveryLink](#schemarecoverylink)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|genericError|[genericError](#schemagenericerror)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|genericError|[genericError](#schemagenericerror)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
+
+##### Examples
+
+###### 200 response
+
+```json
+{
+  "expires_at": "2019-08-24T14:15:22Z",
+  "recovery_link": "string"
+}
+```
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+#### Code samples
+
+<Tabs groupId="code-samples" defaultValue="shell"
+  values={[{label: 'Shell', value: 'shell'}, {label: 'Go', value: 'go'}, {label: 'Node', value: 'node'},
+    {label: 'Java', value: 'java'}, {label: 'Python', value: 'python'}, {label: 'Ruby', value: 'ruby'}]}>
+<TabItem value="shell">
+
+```shell
+curl -X POST /recovery/link \
+  -H 'Content-Type: application/json' \  -H 'Accept: application/json'
+```
+
+</TabItem>
+<TabItem value="go">
+
+```go
+package main
+
+import (
+    "bytes"
+    "net/http"
+)
+
+func main() {
+    headers := map[string][]string{ 
+        "Content-Type": []string{"application/json"},
+        "Accept": []string{"application/json"},
+    }
+
+    var body []byte
+    // body = ...
+
+    req, err := http.NewRequest("POST", "/recovery/link", bytes.NewBuffer(body))
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+```
+
+</TabItem>
+<TabItem value="node">
+
+```javascript
+const fetch = require('node-fetch');
+const input = '{
+  "expires_in": "string",
+  "identity_id": "string"
+}';
+const headers = {
+  'Content-Type': 'application/json',  'Accept': 'application/json'
+}
+
+fetch('/recovery/link', {
+  method: 'POST',
+  body: input,
+  headers
+})
+.then(r => r.json())
+.then((body) => {
+    console.log(body)
+})
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+// This sample needs improvement.
+URL obj = new URL("/recovery/link");
+
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("POST");
+
+int responseCode = con.getResponseCode();
+
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream())
+);
+
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+
+System.out.println(response.toString());
+```
+
+</TabItem>
+<TabItem value="python">
+
+```python
+import requests
+
+headers = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json'
+}
+
+r = requests.post(
+  '/recovery/link',
+  params={},
+  headers = headers)
+
+print r.json()
+```
+
+</TabItem>
+<TabItem value="ruby">
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Content-Type' => 'application/json',
+  'Accept' => 'application/json'
+}
+
+result = RestClient.post '/recovery/link',
+  params: {}, headers: headers
+
+p JSON.parse(result)
+```
+
+</TabItem>
+</Tabs>
+
 <a id="ory-kratos-common"></a>
 
 ## common
@@ -1458,15 +1737,15 @@ Accept: application/json
 
 ```
 
-Get a traits schema definition
+Get a Traits Schema Definition
 
 <a id="getschema-parameters"></a>
 
 #### Parameters
 
-| Parameter | In   | Type   | Required | Description                                        |
-| --------- | ---- | ------ | -------- | -------------------------------------------------- |
-| id        | path | string | true     | ID must be set to the ID of schema you want to get |
+|Parameter|In|Type|Required|Description|
+|---|---|---|---|---|
+|id|path|string|true|ID must be set to the ID of schema you want to get|
 
 #### Responses
 
@@ -1474,13 +1753,14 @@ Get a traits schema definition
 
 ##### Overview
 
-| Status | Meaning                                                                    | Description                    | Schema                              |
-| ------ | -------------------------------------------------------------------------- | ------------------------------ | ----------------------------------- |
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)                    | The raw identity traits schema | Inline                              |
-| 404    | [Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)             | genericError                   | [genericError](#schemagenericerror) |
-| 500    | [Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1) | genericError                   | [genericError](#schemagenericerror) |
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|The raw identity traits schema|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|genericError|[genericError](#schemagenericerror)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
 
 <a id="getschema-responseschema"></a>
+
 ##### Response Schema
 
 ##### Examples
@@ -1491,7 +1771,9 @@ Get a traits schema definition
 {}
 ```
 
-<aside class="success">This operation does not require authentication</aside>
+<aside class="success">
+This operation does not require authentication
+</aside>
 
 #### Code samples
 
@@ -1517,7 +1799,7 @@ import (
 )
 
 func main() {
-    headers := map[string][]string{
+    headers := map[string][]string{ 
         "Accept": []string{"application/json"},
     }
 
@@ -1537,20 +1819,20 @@ func main() {
 <TabItem value="node">
 
 ```javascript
-const fetch = require('node-fetch')
+const fetch = require('node-fetch');
 
 const headers = {
-  Accept: 'application/json'
+  'Accept': 'application/json'
 }
 
 fetch('/schemas/{id}', {
   method: 'GET',
   headers
 })
-  .then((r) => r.json())
-  .then((body) => {
+.then(r => r.json())
+.then((body) => {
     console.log(body)
-  })
+})
 ```
 
 </TabItem>
@@ -1617,54 +1899,231 @@ p JSON.parse(result)
 </TabItem>
 </Tabs>
 
-<a id="opIdgetSelfServiceBrowserLoginRequest"></a>
+<a id="opIdgetSelfServiceError"></a>
 
-### Get the request context of browser-based login user flows
+### Get User-Facing Self-Service Errors
 
 ```
-GET /self-service/browser/flows/requests/login?request=string HTTP/1.1
+GET /self-service/errors?error=string HTTP/1.1
 Accept: application/json
 
 ```
 
-This endpoint returns a login request's context with, for example, error details
-and other information.
+This endpoint returns the error associated with a user-facing self service errors.
 
-When accessing this endpoint through ORY Kratos' Public API, ensure that cookies
-are set as they are required for CSRF to work. To prevent token scanning
-attacks, the public endpoint does not return 404 status codes.
+When accessing this endpoint through ORY Kratos' Public API, ensure that cookies are set as they are required for CSRF to work. To prevent
+token scanning attacks, the public endpoint does not return 404 status codes.
 
-More information can be found at
-[ORY Kratos User Login and User Registration Documentation](https://www.ory.sh/docs/next/kratos/self-service/flows/user-login-user-registration).
+This endpoint supports stub values to help you implement the error UI:
 
-<a id="get-the-request-context-of-browser-based-login-user-flows-parameters"></a>
+`?error=stub:500` - returns a stub 500 (Internal Server Error) error.
+
+More information can be found at [ORY Kratos User User Facing Error Documentation](https://www.ory.sh/docs/kratos/self-service/flows/user-facing-errors).
+
+<a id="get-user-facing-self-service-errors-parameters"></a>
 
 #### Parameters
 
-| Parameter | In    | Type   | Required | Description                     |
-| --------- | ----- | ------ | -------- | ------------------------------- |
-| request   | query | string | true     | Request is the Login Request ID |
-
-##### Detailed descriptions
-
-**request**: Request is the Login Request ID
-
-The value for this parameter comes from `request` URL Query parameter sent to
-your application (e.g. `/login?request=abcde`).
+|Parameter|In|Type|Required|Description|
+|---|---|---|---|---|
+|error|query|string|true|Error is the container's ID|
 
 #### Responses
 
-<a id="get-the-request-context-of-browser-based-login-user-flows-responses"></a>
+<a id="get-user-facing-self-service-errors-responses"></a>
 
 ##### Overview
 
-| Status | Meaning                                                                    | Description  | Schema                              |
-| ------ | -------------------------------------------------------------------------- | ------------ | ----------------------------------- |
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)                    | loginRequest | [loginRequest](#schemaloginrequest) |
-| 403    | [Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)             | genericError | [genericError](#schemagenericerror) |
-| 404    | [Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)             | genericError | [genericError](#schemagenericerror) |
-| 410    | [Gone](https://tools.ietf.org/html/rfc7231#section-6.5.9)                  | genericError | [genericError](#schemagenericerror) |
-| 500    | [Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1) | genericError | [genericError](#schemagenericerror) |
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|User-facing error response|[errorContainer](#schemaerrorcontainer)|
+|403|[Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)|genericError|[genericError](#schemagenericerror)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|genericError|[genericError](#schemagenericerror)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
+
+##### Examples
+
+###### 200 response
+
+```json
+{
+  "errors": {},
+  "id": "string"
+}
+```
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+#### Code samples
+
+<Tabs groupId="code-samples" defaultValue="shell"
+  values={[{label: 'Shell', value: 'shell'}, {label: 'Go', value: 'go'}, {label: 'Node', value: 'node'},
+    {label: 'Java', value: 'java'}, {label: 'Python', value: 'python'}, {label: 'Ruby', value: 'ruby'}]}>
+<TabItem value="shell">
+
+```shell
+curl -X GET /self-service/errors?error=string \
+  -H 'Accept: application/json'
+```
+
+</TabItem>
+<TabItem value="go">
+
+```go
+package main
+
+import (
+    "bytes"
+    "net/http"
+)
+
+func main() {
+    headers := map[string][]string{ 
+        "Accept": []string{"application/json"},
+    }
+
+    var body []byte
+    // body = ...
+
+    req, err := http.NewRequest("GET", "/self-service/errors", bytes.NewBuffer(body))
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+```
+
+</TabItem>
+<TabItem value="node">
+
+```javascript
+const fetch = require('node-fetch');
+
+const headers = {
+  'Accept': 'application/json'
+}
+
+fetch('/self-service/errors?error=string', {
+  method: 'GET',
+  headers
+})
+.then(r => r.json())
+.then((body) => {
+    console.log(body)
+})
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+// This sample needs improvement.
+URL obj = new URL("/self-service/errors?error=string");
+
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+
+int responseCode = con.getResponseCode();
+
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream())
+);
+
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+
+System.out.println(response.toString());
+```
+
+</TabItem>
+<TabItem value="python">
+
+```python
+import requests
+
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get(
+  '/self-service/errors',
+  params={
+    'error': 'string'},
+  headers = headers)
+
+print r.json()
+```
+
+</TabItem>
+<TabItem value="ruby">
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.get '/self-service/errors',
+  params: {
+    'error' => 'string'}, headers: headers
+
+p JSON.parse(result)
+```
+
+</TabItem>
+</Tabs>
+
+<a id="opIdgetSelfServiceLoginFlow"></a>
+
+### Get Login Flow
+
+```
+GET /self-service/login/flows?id=string HTTP/1.1
+Accept: application/json
+
+```
+
+This endpoint returns a login flow's context with, for example, error details and other information.
+
+More information can be found at [ORY Kratos User Login and User Registration Documentation](https://www.ory.sh/docs/next/kratos/self-service/flows/user-login-user-registration).
+
+<a id="get-login-flow-parameters"></a>
+
+#### Parameters
+
+|Parameter|In|Type|Required|Description|
+|---|---|---|---|---|
+|id|query|string|true|The Login Flow ID|
+
+##### Detailed descriptions
+
+**id**: The Login Flow ID
+
+The value for this parameter comes from `flow` URL Query parameter sent to your
+application (e.g. `/login?flow=abcde`).
+
+#### Responses
+
+<a id="get-login-flow-responses"></a>
+
+##### Overview
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|loginFlow|[loginFlow](#schemaloginflow)|
+|403|[Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)|genericError|[genericError](#schemagenericerror)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|genericError|[genericError](#schemagenericerror)|
+|410|[Gone](https://tools.ietf.org/html/rfc7231#section-6.5.9)|genericError|[genericError](#schemagenericerror)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
 
 ##### Examples
 
@@ -1789,11 +2248,14 @@ your application (e.g. `/login?request=abcde`).
       "method": "string"
     }
   },
-  "request_url": "string"
+  "request_url": "string",
+  "type": "string"
 }
 ```
 
-<aside class="success">This operation does not require authentication</aside>
+<aside class="success">
+This operation does not require authentication
+</aside>
 
 #### Code samples
 
@@ -1803,7 +2265,7 @@ your application (e.g. `/login?request=abcde`).
 <TabItem value="shell">
 
 ```shell
-curl -X GET /self-service/browser/flows/requests/login?request=string \
+curl -X GET /self-service/login/flows?id=string \
   -H 'Accept: application/json'
 ```
 
@@ -1819,14 +2281,14 @@ import (
 )
 
 func main() {
-    headers := map[string][]string{
+    headers := map[string][]string{ 
         "Accept": []string{"application/json"},
     }
 
     var body []byte
     // body = ...
 
-    req, err := http.NewRequest("GET", "/self-service/browser/flows/requests/login", bytes.NewBuffer(body))
+    req, err := http.NewRequest("GET", "/self-service/login/flows", bytes.NewBuffer(body))
     req.Header = headers
 
     client := &http.Client{}
@@ -1839,20 +2301,20 @@ func main() {
 <TabItem value="node">
 
 ```javascript
-const fetch = require('node-fetch')
+const fetch = require('node-fetch');
 
 const headers = {
-  Accept: 'application/json'
+  'Accept': 'application/json'
 }
 
-fetch('/self-service/browser/flows/requests/login?request=string', {
+fetch('/self-service/login/flows?id=string', {
   method: 'GET',
   headers
 })
-  .then((r) => r.json())
-  .then((body) => {
+.then(r => r.json())
+.then((body) => {
     console.log(body)
-  })
+})
 ```
 
 </TabItem>
@@ -1860,7 +2322,7 @@ fetch('/self-service/browser/flows/requests/login?request=string', {
 
 ```java
 // This sample needs improvement.
-URL obj = new URL("/self-service/browser/flows/requests/login?request=string");
+URL obj = new URL("/self-service/login/flows?id=string");
 
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("GET");
@@ -1892,9 +2354,9 @@ headers = {
 }
 
 r = requests.get(
-  '/self-service/browser/flows/requests/login',
+  '/self-service/login/flows',
   params={
-    'request': 'string'},
+    'id': 'string'},
   headers = headers)
 
 print r.json()
@@ -1911,9 +2373,9 @@ headers = {
   'Accept' => 'application/json'
 }
 
-result = RestClient.get '/self-service/browser/flows/requests/login',
+result = RestClient.get '/self-service/login/flows',
   params: {
-    'request' => 'string'}, headers: headers
+    'id' => 'string'}, headers: headers
 
 p JSON.parse(result)
 ```
@@ -1921,52 +2383,47 @@ p JSON.parse(result)
 </TabItem>
 </Tabs>
 
-<a id="opIdgetSelfServiceBrowserRecoveryRequest"></a>
+<a id="opIdgetSelfServiceRecoveryFlow"></a>
 
-### Get the request context of browser-based recovery flows
+### Get information about a recovery flow
 
 ```
-GET /self-service/browser/flows/requests/recovery?request=string HTTP/1.1
+GET /self-service/recovery/flows?id=string HTTP/1.1
 Accept: application/json
 
 ```
 
-When accessing this endpoint through ORY Kratos' Public API, ensure that cookies
-are set as they are required for checking the auth session. To prevent scanning
-attacks, the public endpoint does not return 404 status codes but instead 403
-or 500.
+This endpoint returns a recovery flow's context with, for example, error details and other information.
 
-More information can be found at
-[ORY Kratos Account Recovery Documentation](../self-service/flows/account-recovery.mdx).
+More information can be found at [ORY Kratos Account Recovery Documentation](../self-service/flows/account-recovery.mdx).
 
-<a id="get-the-request-context-of-browser-based-recovery-flows-parameters"></a>
+<a id="get-information-about-a-recovery-flow-parameters"></a>
 
 #### Parameters
 
-| Parameter | In    | Type   | Required | Description                     |
-| --------- | ----- | ------ | -------- | ------------------------------- |
-| request   | query | string | true     | Request is the Login Request ID |
+|Parameter|In|Type|Required|Description|
+|---|---|---|---|---|
+|id|query|string|true|The Flow ID|
 
 ##### Detailed descriptions
 
-**request**: Request is the Login Request ID
+**id**: The Flow ID
 
-The value for this parameter comes from `request` URL Query parameter sent to
-your application (e.g. `/recover?request=abcde`).
+The value for this parameter comes from `request` URL Query parameter sent to your
+application (e.g. `/recovery?flow=abcde`).
 
 #### Responses
 
-<a id="get-the-request-context-of-browser-based-recovery-flows-responses"></a>
+<a id="get-information-about-a-recovery-flow-responses"></a>
 
 ##### Overview
 
-| Status | Meaning                                                                    | Description     | Schema                                    |
-| ------ | -------------------------------------------------------------------------- | --------------- | ----------------------------------------- |
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)                    | recoveryRequest | [recoveryRequest](#schemarecoveryrequest) |
-| 403    | [Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)             | genericError    | [genericError](#schemagenericerror)       |
-| 404    | [Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)             | genericError    | [genericError](#schemagenericerror)       |
-| 410    | [Gone](https://tools.ietf.org/html/rfc7231#section-6.5.9)                  | genericError    | [genericError](#schemagenericerror)       |
-| 500    | [Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1) | genericError    | [genericError](#schemagenericerror)       |
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|recoveryFlow|[recoveryFlow](#schemarecoveryflow)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|genericError|[genericError](#schemagenericerror)|
+|410|[Gone](https://tools.ietf.org/html/rfc7231#section-6.5.9)|genericError|[genericError](#schemagenericerror)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
 
 ##### Examples
 
@@ -2055,11 +2512,14 @@ your application (e.g. `/recover?request=abcde`).
     }
   },
   "request_url": "string",
-  "state": "string"
+  "state": "string",
+  "type": "string"
 }
 ```
 
-<aside class="success">This operation does not require authentication</aside>
+<aside class="success">
+This operation does not require authentication
+</aside>
 
 #### Code samples
 
@@ -2069,7 +2529,7 @@ your application (e.g. `/recover?request=abcde`).
 <TabItem value="shell">
 
 ```shell
-curl -X GET /self-service/browser/flows/requests/recovery?request=string \
+curl -X GET /self-service/recovery/flows?id=string \
   -H 'Accept: application/json'
 ```
 
@@ -2085,14 +2545,14 @@ import (
 )
 
 func main() {
-    headers := map[string][]string{
+    headers := map[string][]string{ 
         "Accept": []string{"application/json"},
     }
 
     var body []byte
     // body = ...
 
-    req, err := http.NewRequest("GET", "/self-service/browser/flows/requests/recovery", bytes.NewBuffer(body))
+    req, err := http.NewRequest("GET", "/self-service/recovery/flows", bytes.NewBuffer(body))
     req.Header = headers
 
     client := &http.Client{}
@@ -2105,20 +2565,20 @@ func main() {
 <TabItem value="node">
 
 ```javascript
-const fetch = require('node-fetch')
+const fetch = require('node-fetch');
 
 const headers = {
-  Accept: 'application/json'
+  'Accept': 'application/json'
 }
 
-fetch('/self-service/browser/flows/requests/recovery?request=string', {
+fetch('/self-service/recovery/flows?id=string', {
   method: 'GET',
   headers
 })
-  .then((r) => r.json())
-  .then((body) => {
+.then(r => r.json())
+.then((body) => {
     console.log(body)
-  })
+})
 ```
 
 </TabItem>
@@ -2126,7 +2586,7 @@ fetch('/self-service/browser/flows/requests/recovery?request=string', {
 
 ```java
 // This sample needs improvement.
-URL obj = new URL("/self-service/browser/flows/requests/recovery?request=string");
+URL obj = new URL("/self-service/recovery/flows?id=string");
 
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("GET");
@@ -2158,9 +2618,9 @@ headers = {
 }
 
 r = requests.get(
-  '/self-service/browser/flows/requests/recovery',
+  '/self-service/recovery/flows',
   params={
-    'request': 'string'},
+    'id': 'string'},
   headers = headers)
 
 print r.json()
@@ -2177,9 +2637,9 @@ headers = {
   'Accept' => 'application/json'
 }
 
-result = RestClient.get '/self-service/browser/flows/requests/recovery',
+result = RestClient.get '/self-service/recovery/flows',
   params: {
-    'request' => 'string'}, headers: headers
+    'id' => 'string'}, headers: headers
 
 p JSON.parse(result)
 ```
@@ -2187,54 +2647,48 @@ p JSON.parse(result)
 </TabItem>
 </Tabs>
 
-<a id="opIdgetSelfServiceBrowserRegistrationRequest"></a>
+<a id="opIdgetSelfServiceRegistrationFlow"></a>
 
-### Get the request context of browser-based registration user flows
+### Get Registration Flow
 
 ```
-GET /self-service/browser/flows/requests/registration?request=string HTTP/1.1
+GET /self-service/registration/flows?id=string HTTP/1.1
 Accept: application/json
 
 ```
 
-This endpoint returns a registration request's context with, for example, error
-details and other information.
+This endpoint returns a registration flow's context with, for example, error details and other information.
 
-When accessing this endpoint through ORY Kratos' Public API, ensure that cookies
-are set as they are required for CSRF to work. To prevent token scanning
-attacks, the public endpoint does not return 404 status codes.
+More information can be found at [ORY Kratos User Login and User Registration Documentation](https://www.ory.sh/docs/next/kratos/self-service/flows/user-login-user-registration).
 
-More information can be found at
-[ORY Kratos User Login and User Registration Documentation](https://www.ory.sh/docs/next/kratos/self-service/flows/user-login-user-registration).
-
-<a id="get-the-request-context-of-browser-based-registration-user-flows-parameters"></a>
+<a id="get-registration-flow-parameters"></a>
 
 #### Parameters
 
-| Parameter | In    | Type   | Required | Description                            |
-| --------- | ----- | ------ | -------- | -------------------------------------- |
-| request   | query | string | true     | Request is the Registration Request ID |
+|Parameter|In|Type|Required|Description|
+|---|---|---|---|---|
+|id|query|string|true|The Registration Flow ID|
 
 ##### Detailed descriptions
 
-**request**: Request is the Registration Request ID
+**id**: The Registration Flow ID
 
-The value for this parameter comes from `request` URL Query parameter sent to
-your application (e.g. `/registration?request=abcde`).
+The value for this parameter comes from `flow` URL Query parameter sent to your
+application (e.g. `/registration?flow=abcde`).
 
 #### Responses
 
-<a id="get-the-request-context-of-browser-based-registration-user-flows-responses"></a>
+<a id="get-registration-flow-responses"></a>
 
 ##### Overview
 
-| Status | Meaning                                                                    | Description         | Schema                                            |
-| ------ | -------------------------------------------------------------------------- | ------------------- | ------------------------------------------------- |
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)                    | registrationRequest | [registrationRequest](#schemaregistrationrequest) |
-| 403    | [Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)             | genericError        | [genericError](#schemagenericerror)               |
-| 404    | [Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)             | genericError        | [genericError](#schemagenericerror)               |
-| 410    | [Gone](https://tools.ietf.org/html/rfc7231#section-6.5.9)                  | genericError        | [genericError](#schemagenericerror)               |
-| 500    | [Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1) | genericError        | [genericError](#schemagenericerror)               |
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|registrationFlow|[registrationFlow](#schemaregistrationflow)|
+|403|[Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)|genericError|[genericError](#schemagenericerror)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|genericError|[genericError](#schemagenericerror)|
+|410|[Gone](https://tools.ietf.org/html/rfc7231#section-6.5.9)|genericError|[genericError](#schemagenericerror)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
 
 ##### Examples
 
@@ -2358,11 +2812,14 @@ your application (e.g. `/registration?request=abcde`).
       "method": "string"
     }
   },
-  "request_url": "string"
+  "request_url": "string",
+  "type": "string"
 }
 ```
 
-<aside class="success">This operation does not require authentication</aside>
+<aside class="success">
+This operation does not require authentication
+</aside>
 
 #### Code samples
 
@@ -2372,7 +2829,7 @@ your application (e.g. `/registration?request=abcde`).
 <TabItem value="shell">
 
 ```shell
-curl -X GET /self-service/browser/flows/requests/registration?request=string \
+curl -X GET /self-service/registration/flows?id=string \
   -H 'Accept: application/json'
 ```
 
@@ -2388,14 +2845,14 @@ import (
 )
 
 func main() {
-    headers := map[string][]string{
+    headers := map[string][]string{ 
         "Accept": []string{"application/json"},
     }
 
     var body []byte
     // body = ...
 
-    req, err := http.NewRequest("GET", "/self-service/browser/flows/requests/registration", bytes.NewBuffer(body))
+    req, err := http.NewRequest("GET", "/self-service/registration/flows", bytes.NewBuffer(body))
     req.Header = headers
 
     client := &http.Client{}
@@ -2408,20 +2865,20 @@ func main() {
 <TabItem value="node">
 
 ```javascript
-const fetch = require('node-fetch')
+const fetch = require('node-fetch');
 
 const headers = {
-  Accept: 'application/json'
+  'Accept': 'application/json'
 }
 
-fetch('/self-service/browser/flows/requests/registration?request=string', {
+fetch('/self-service/registration/flows?id=string', {
   method: 'GET',
   headers
 })
-  .then((r) => r.json())
-  .then((body) => {
+.then(r => r.json())
+.then((body) => {
     console.log(body)
-  })
+})
 ```
 
 </TabItem>
@@ -2429,7 +2886,7 @@ fetch('/self-service/browser/flows/requests/registration?request=string', {
 
 ```java
 // This sample needs improvement.
-URL obj = new URL("/self-service/browser/flows/requests/registration?request=string");
+URL obj = new URL("/self-service/registration/flows?id=string");
 
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("GET");
@@ -2461,9 +2918,9 @@ headers = {
 }
 
 r = requests.get(
-  '/self-service/browser/flows/requests/registration',
+  '/self-service/registration/flows',
   params={
-    'request': 'string'},
+    'id': 'string'},
   headers = headers)
 
 print r.json()
@@ -2480,9 +2937,9 @@ headers = {
   'Accept' => 'application/json'
 }
 
-result = RestClient.get '/self-service/browser/flows/requests/registration',
+result = RestClient.get '/self-service/registration/flows',
   params: {
-    'request' => 'string'}, headers: headers
+    'id' => 'string'}, headers: headers
 
 p JSON.parse(result)
 ```
@@ -2490,52 +2947,52 @@ p JSON.parse(result)
 </TabItem>
 </Tabs>
 
-<a id="opIdgetSelfServiceBrowserSettingsRequest"></a>
+<a id="opIdgetSelfServiceSettingsFlow"></a>
 
-### Get the request context of browser-based settings flows
+### Get Settings Flow
 
 ```
-GET /self-service/browser/flows/requests/settings?request=string HTTP/1.1
+GET /self-service/settings/flows?id=string HTTP/1.1
 Accept: application/json
 
 ```
 
-When accessing this endpoint through ORY Kratos' Public API, ensure that cookies
-are set as they are required for checking the auth session. To prevent scanning
-attacks, the public endpoint does not return 404 status codes but instead 403
-or 500.
+When accessing this endpoint through ORY Kratos' Public API you must ensure that either the ORY Kratos Session Cookie
+or the ORY Kratos Session Token are set. The public endpoint does not return 404 status codes
+but instead 403 or 500 to improve data privacy.
 
-More information can be found at
-[ORY Kratos User Settings & Profile Management Documentation](../self-service/flows/user-settings).
+You can access this endpoint without credentials when using ORY Kratos' Admin API.
 
-<a id="get-the-request-context-of-browser-based-settings-flows-parameters"></a>
+More information can be found at [ORY Kratos User Settings & Profile Management Documentation](../self-service/flows/user-settings).
+
+<a id="get-settings-flow-parameters"></a>
 
 #### Parameters
 
-| Parameter | In    | Type   | Required | Description                     |
-| --------- | ----- | ------ | -------- | ------------------------------- |
-| request   | query | string | true     | Request is the Login Request ID |
+|Parameter|In|Type|Required|Description|
+|---|---|---|---|---|
+|id|query|string|true|ID is the Settings Flow ID|
 
 ##### Detailed descriptions
 
-**request**: Request is the Login Request ID
+**id**: ID is the Settings Flow ID
 
-The value for this parameter comes from `request` URL Query parameter sent to
-your application (e.g. `/settingss?request=abcde`).
+The value for this parameter comes from `flow` URL Query parameter sent to your
+application (e.g. `/settings?flow=abcde`).
 
 #### Responses
 
-<a id="get-the-request-context-of-browser-based-settings-flows-responses"></a>
+<a id="get-settings-flow-responses"></a>
 
 ##### Overview
 
-| Status | Meaning                                                                    | Description     | Schema                                    |
-| ------ | -------------------------------------------------------------------------- | --------------- | ----------------------------------------- |
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)                    | settingsRequest | [settingsRequest](#schemasettingsrequest) |
-| 403    | [Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)             | genericError    | [genericError](#schemagenericerror)       |
-| 404    | [Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)             | genericError    | [genericError](#schemagenericerror)       |
-| 410    | [Gone](https://tools.ietf.org/html/rfc7231#section-6.5.9)                  | genericError    | [genericError](#schemagenericerror)       |
-| 500    | [Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1) | genericError    | [genericError](#schemagenericerror)       |
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|settingsFlow|[settingsFlow](#schemasettingsflow)|
+|403|[Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)|genericError|[genericError](#schemagenericerror)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|genericError|[genericError](#schemagenericerror)|
+|410|[Gone](https://tools.ietf.org/html/rfc7231#section-6.5.9)|genericError|[genericError](#schemagenericerror)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
 
 ##### Examples
 
@@ -2560,8 +3017,8 @@ your application (e.g. `/settingss?request=abcde`).
     "traits": {},
     "verifiable_addresses": [
       {
-        "expires_at": "2019-08-24T14:15:22Z",
         "id": "string",
+        "status": "string",
         "value": "string",
         "verified": true,
         "verified_at": "2019-08-24T14:15:22Z",
@@ -2647,11 +3104,14 @@ your application (e.g. `/settingss?request=abcde`).
     }
   },
   "request_url": "string",
-  "state": "string"
+  "state": "string",
+  "type": "string"
 }
 ```
 
-<aside class="success">This operation does not require authentication</aside>
+<aside class="success">
+This operation does not require authentication
+</aside>
 
 #### Code samples
 
@@ -2661,7 +3121,7 @@ your application (e.g. `/settingss?request=abcde`).
 <TabItem value="shell">
 
 ```shell
-curl -X GET /self-service/browser/flows/requests/settings?request=string \
+curl -X GET /self-service/settings/flows?id=string \
   -H 'Accept: application/json'
 ```
 
@@ -2677,14 +3137,14 @@ import (
 )
 
 func main() {
-    headers := map[string][]string{
+    headers := map[string][]string{ 
         "Accept": []string{"application/json"},
     }
 
     var body []byte
     // body = ...
 
-    req, err := http.NewRequest("GET", "/self-service/browser/flows/requests/settings", bytes.NewBuffer(body))
+    req, err := http.NewRequest("GET", "/self-service/settings/flows", bytes.NewBuffer(body))
     req.Header = headers
 
     client := &http.Client{}
@@ -2697,20 +3157,20 @@ func main() {
 <TabItem value="node">
 
 ```javascript
-const fetch = require('node-fetch')
+const fetch = require('node-fetch');
 
 const headers = {
-  Accept: 'application/json'
+  'Accept': 'application/json'
 }
 
-fetch('/self-service/browser/flows/requests/settings?request=string', {
+fetch('/self-service/settings/flows?id=string', {
   method: 'GET',
   headers
 })
-  .then((r) => r.json())
-  .then((body) => {
+.then(r => r.json())
+.then((body) => {
     console.log(body)
-  })
+})
 ```
 
 </TabItem>
@@ -2718,7 +3178,7 @@ fetch('/self-service/browser/flows/requests/settings?request=string', {
 
 ```java
 // This sample needs improvement.
-URL obj = new URL("/self-service/browser/flows/requests/settings?request=string");
+URL obj = new URL("/self-service/settings/flows?id=string");
 
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("GET");
@@ -2750,9 +3210,9 @@ headers = {
 }
 
 r = requests.get(
-  '/self-service/browser/flows/requests/settings',
+  '/self-service/settings/flows',
   params={
-    'request': 'string'},
+    'id': 'string'},
   headers = headers)
 
 print r.json()
@@ -2769,9 +3229,9 @@ headers = {
   'Accept' => 'application/json'
 }
 
-result = RestClient.get '/self-service/browser/flows/requests/settings',
+result = RestClient.get '/self-service/settings/flows',
   params: {
-    'request' => 'string'}, headers: headers
+    'id' => 'string'}, headers: headers
 
 p JSON.parse(result)
 ```
@@ -2779,51 +3239,47 @@ p JSON.parse(result)
 </TabItem>
 </Tabs>
 
-<a id="opIdgetSelfServiceVerificationRequest"></a>
+<a id="opIdgetSelfServiceVerificationFlow"></a>
 
-### Get the request context of browser-based verification flows
+### Get Verification Flow
 
 ```
-GET /self-service/browser/flows/requests/verification?request=string HTTP/1.1
+GET /self-service/verification/flows?id=string HTTP/1.1
 Accept: application/json
 
 ```
 
-When accessing this endpoint through ORY Kratos' Public API, ensure that cookies
-are set as they are required for checking the auth session. To prevent scanning
-attacks, the public endpoint does not return 404 status codes but instead 403
-or 500.
+This endpoint returns a verification flow's context with, for example, error details and other information.
 
-More information can be found at
-[ORY Kratos Email and Phone Verification Documentation](https://www.ory.sh/docs/kratos/selfservice/flows/verify-email-account-activation).
+More information can be found at [ORY Kratos Email and Phone Verification Documentation](https://www.ory.sh/docs/kratos/selfservice/flows/verify-email-account-activation).
 
-<a id="get-the-request-context-of-browser-based-verification-flows-parameters"></a>
+<a id="get-verification-flow-parameters"></a>
 
 #### Parameters
 
-| Parameter | In    | Type   | Required | Description               |
-| --------- | ----- | ------ | -------- | ------------------------- |
-| request   | query | string | true     | Request is the Request ID |
+|Parameter|In|Type|Required|Description|
+|---|---|---|---|---|
+|id|query|string|true|The Flow ID|
 
 ##### Detailed descriptions
 
-**request**: Request is the Request ID
+**id**: The Flow ID
 
-The value for this parameter comes from `request` URL Query parameter sent to
-your application (e.g. `/verify?request=abcde`).
+The value for this parameter comes from `request` URL Query parameter sent to your
+application (e.g. `/verification?flow=abcde`).
 
 #### Responses
 
-<a id="get-the-request-context-of-browser-based-verification-flows-responses"></a>
+<a id="get-verification-flow-responses"></a>
 
 ##### Overview
 
-| Status | Meaning                                                                    | Description         | Schema                                            |
-| ------ | -------------------------------------------------------------------------- | ------------------- | ------------------------------------------------- |
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)                    | verificationRequest | [verificationRequest](#schemaverificationrequest) |
-| 403    | [Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)             | genericError        | [genericError](#schemagenericerror)               |
-| 404    | [Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)             | genericError        | [genericError](#schemagenericerror)               |
-| 500    | [Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1) | genericError        | [genericError](#schemagenericerror)               |
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|verificationFlow|[verificationFlow](#schemaverificationflow)|
+|403|[Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)|genericError|[genericError](#schemagenericerror)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|genericError|[genericError](#schemagenericerror)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
 
 ##### Examples
 
@@ -2831,37 +3287,8 @@ your application (e.g. `/verify?request=abcde`).
 
 ```json
 {
+  "active": "string",
   "expires_at": "2019-08-24T14:15:22Z",
-  "form": {
-    "action": "string",
-    "fields": [
-      {
-        "disabled": true,
-        "messages": [
-          {
-            "context": {},
-            "id": 0,
-            "text": "string",
-            "type": "string"
-          }
-        ],
-        "name": "string",
-        "pattern": "string",
-        "required": true,
-        "type": "string",
-        "value": {}
-      }
-    ],
-    "messages": [
-      {
-        "context": {},
-        "id": 0,
-        "text": "string",
-        "type": "string"
-      }
-    ],
-    "method": "string"
-  },
   "id": "string",
   "issued_at": "2019-08-24T14:15:22Z",
   "messages": [
@@ -2872,13 +3299,83 @@ your application (e.g. `/verify?request=abcde`).
       "type": "string"
     }
   ],
+  "methods": {
+    "property1": {
+      "config": {
+        "action": "string",
+        "fields": [
+          {
+            "disabled": true,
+            "messages": [
+              {
+                "context": {},
+                "id": 0,
+                "text": "string",
+                "type": "string"
+              }
+            ],
+            "name": "string",
+            "pattern": "string",
+            "required": true,
+            "type": "string",
+            "value": {}
+          }
+        ],
+        "messages": [
+          {
+            "context": {},
+            "id": 0,
+            "text": "string",
+            "type": "string"
+          }
+        ],
+        "method": "string"
+      },
+      "method": "string"
+    },
+    "property2": {
+      "config": {
+        "action": "string",
+        "fields": [
+          {
+            "disabled": true,
+            "messages": [
+              {
+                "context": {},
+                "id": 0,
+                "text": "string",
+                "type": "string"
+              }
+            ],
+            "name": "string",
+            "pattern": "string",
+            "required": true,
+            "type": "string",
+            "value": {}
+          }
+        ],
+        "messages": [
+          {
+            "context": {},
+            "id": 0,
+            "text": "string",
+            "type": "string"
+          }
+        ],
+        "method": "string"
+      },
+      "method": "string"
+    }
+  },
   "request_url": "string",
-  "success": true,
-  "via": "string"
+  "state": "string",
+  "type": "string"
 }
 ```
 
-<aside class="success">This operation does not require authentication</aside>
+<aside class="success">
+This operation does not require authentication
+</aside>
 
 #### Code samples
 
@@ -2888,7 +3385,7 @@ your application (e.g. `/verify?request=abcde`).
 <TabItem value="shell">
 
 ```shell
-curl -X GET /self-service/browser/flows/requests/verification?request=string \
+curl -X GET /self-service/verification/flows?id=string \
   -H 'Accept: application/json'
 ```
 
@@ -2904,14 +3401,14 @@ import (
 )
 
 func main() {
-    headers := map[string][]string{
+    headers := map[string][]string{ 
         "Accept": []string{"application/json"},
     }
 
     var body []byte
     // body = ...
 
-    req, err := http.NewRequest("GET", "/self-service/browser/flows/requests/verification", bytes.NewBuffer(body))
+    req, err := http.NewRequest("GET", "/self-service/verification/flows", bytes.NewBuffer(body))
     req.Header = headers
 
     client := &http.Client{}
@@ -2924,20 +3421,20 @@ func main() {
 <TabItem value="node">
 
 ```javascript
-const fetch = require('node-fetch')
+const fetch = require('node-fetch');
 
 const headers = {
-  Accept: 'application/json'
+  'Accept': 'application/json'
 }
 
-fetch('/self-service/browser/flows/requests/verification?request=string', {
+fetch('/self-service/verification/flows?id=string', {
   method: 'GET',
   headers
 })
-  .then((r) => r.json())
-  .then((body) => {
+.then(r => r.json())
+.then((body) => {
     console.log(body)
-  })
+})
 ```
 
 </TabItem>
@@ -2945,7 +3442,7 @@ fetch('/self-service/browser/flows/requests/verification?request=string', {
 
 ```java
 // This sample needs improvement.
-URL obj = new URL("/self-service/browser/flows/requests/verification?request=string");
+URL obj = new URL("/self-service/verification/flows?id=string");
 
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("GET");
@@ -2977,9 +3474,9 @@ headers = {
 }
 
 r = requests.get(
-  '/self-service/browser/flows/requests/verification',
+  '/self-service/verification/flows',
   params={
-    'request': 'string'},
+    'id': 'string'},
   headers = headers)
 
 print r.json()
@@ -2996,187 +3493,9 @@ headers = {
   'Accept' => 'application/json'
 }
 
-result = RestClient.get '/self-service/browser/flows/requests/verification',
+result = RestClient.get '/self-service/verification/flows',
   params: {
-    'request' => 'string'}, headers: headers
-
-p JSON.parse(result)
-```
-
-</TabItem>
-</Tabs>
-
-<a id="opIdgetSelfServiceError"></a>
-
-### Get user-facing self-service errors
-
-```
-GET /self-service/errors HTTP/1.1
-Accept: application/json
-
-```
-
-This endpoint returns the error associated with a user-facing self service
-errors.
-
-When accessing this endpoint through ORY Kratos' Public API, ensure that cookies
-are set as they are required for CSRF to work. To prevent token scanning
-attacks, the public endpoint does not return 404 status codes.
-
-More information can be found at
-[ORY Kratos User User Facing Error Documentation](https://www.ory.sh/docs/kratos/self-service/flows/user-facing-errors).
-
-<a id="get-user-facing-self-service-errors-parameters"></a>
-
-#### Parameters
-
-| Parameter | In    | Type   | Required | Description |
-| --------- | ----- | ------ | -------- | ----------- |
-| error     | query | string | false    | none        |
-
-#### Responses
-
-<a id="get-user-facing-self-service-errors-responses"></a>
-
-##### Overview
-
-| Status | Meaning                                                                    | Description                | Schema                                  |
-| ------ | -------------------------------------------------------------------------- | -------------------------- | --------------------------------------- |
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)                    | User-facing error response | [errorContainer](#schemaerrorcontainer) |
-| 403    | [Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)             | genericError               | [genericError](#schemagenericerror)     |
-| 404    | [Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)             | genericError               | [genericError](#schemagenericerror)     |
-| 500    | [Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1) | genericError               | [genericError](#schemagenericerror)     |
-
-##### Examples
-
-###### 200 response
-
-```json
-{
-  "errors": {},
-  "id": "string"
-}
-```
-
-<aside class="success">This operation does not require authentication</aside>
-
-#### Code samples
-
-<Tabs groupId="code-samples" defaultValue="shell"
-  values={[{label: 'Shell', value: 'shell'}, {label: 'Go', value: 'go'}, {label: 'Node', value: 'node'},
-    {label: 'Java', value: 'java'}, {label: 'Python', value: 'python'}, {label: 'Ruby', value: 'ruby'}]}>
-<TabItem value="shell">
-
-```shell
-curl -X GET /self-service/errors \
-  -H 'Accept: application/json'
-```
-
-</TabItem>
-<TabItem value="go">
-
-```go
-package main
-
-import (
-    "bytes"
-    "net/http"
-)
-
-func main() {
-    headers := map[string][]string{
-        "Accept": []string{"application/json"},
-    }
-
-    var body []byte
-    // body = ...
-
-    req, err := http.NewRequest("GET", "/self-service/errors", bytes.NewBuffer(body))
-    req.Header = headers
-
-    client := &http.Client{}
-    resp, err := client.Do(req)
-    // ...
-}
-```
-
-</TabItem>
-<TabItem value="node">
-
-```javascript
-const fetch = require('node-fetch')
-
-const headers = {
-  Accept: 'application/json'
-}
-
-fetch('/self-service/errors', {
-  method: 'GET',
-  headers
-})
-  .then((r) => r.json())
-  .then((body) => {
-    console.log(body)
-  })
-```
-
-</TabItem>
-<TabItem value="java">
-
-```java
-// This sample needs improvement.
-URL obj = new URL("/self-service/errors");
-
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-
-int responseCode = con.getResponseCode();
-
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream())
-);
-
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-
-System.out.println(response.toString());
-```
-
-</TabItem>
-<TabItem value="python">
-
-```python
-import requests
-
-headers = {
-  'Accept': 'application/json'
-}
-
-r = requests.get(
-  '/self-service/errors',
-  params={},
-  headers = headers)
-
-print r.json()
-```
-
-</TabItem>
-<TabItem value="ruby">
-
-```ruby
-require 'rest-client'
-require 'json'
-
-headers = {
-  'Accept' => 'application/json'
-}
-
-result = RestClient.get '/self-service/errors',
-  params: {}, headers: headers
+    'id' => 'string'}, headers: headers
 
 p JSON.parse(result)
 ```
@@ -3187,198 +3506,6 @@ p JSON.parse(result)
 <a id="ory-kratos-public-endpoints"></a>
 
 ## Public Endpoints
-
-<a id="opIdinitializeSelfServiceBrowserLoginFlow"></a>
-
-### Initialize browser-based login user flow
-
-```
-GET /self-service/browser/flows/login HTTP/1.1
-Accept: application/json
-
-```
-
-This endpoint initializes a browser-based user login flow. Once initialized, the
-browser will be redirected to `selfservice.flows.login.ui_url` with the request
-ID set as a query parameter. If a valid user session exists already, the browser
-will be redirected to `urls.default_redirect_url`.
-
-> This endpoint is NOT INTENDED for API clients and only works with browsers
-> (Chrome, Firefox, ...).
-
-More information can be found at
-[ORY Kratos User Login and User Registration Documentation](https://www.ory.sh/docs/next/kratos/self-service/flows/user-login-user-registration).
-
-<a id="initialize-browser-based-login-user-flow-parameters"></a>
-
-#### Parameters
-
-| Parameter | In    | Type    | Required | Description             |
-| --------- | ----- | ------- | -------- | ----------------------- |
-| refresh   | query | boolean | false    | Refresh a login session |
-
-##### Detailed descriptions
-
-**refresh**: Refresh a login session
-
-If set to true, this will refresh an existing login session by asking the user
-to sign in again. This will reset the authenticated_at time of the session.
-
-#### Responses
-
-<a id="initialize-browser-based-login-user-flow-responses"></a>
-
-##### Overview
-
-| Status         | Meaning                                                                    | Description                                                                                                    | Schema                              |
-| -------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| 302            | [Found](https://tools.ietf.org/html/rfc7231#section-6.4.3)                 | Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is |
-| typically 201. | None                                                                       |
-| 500            | [Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1) | genericError                                                                                                   | [genericError](#schemagenericerror) |
-
-##### Examples
-
-###### 500 response
-
-```json
-{
-  "error": {
-    "code": 404,
-    "debug": "The database adapter was unable to find the element",
-    "details": {},
-    "message": "string",
-    "reason": "string",
-    "request": "string",
-    "status": "string"
-  }
-}
-```
-
-<aside class="success">This operation does not require authentication</aside>
-
-#### Code samples
-
-<Tabs groupId="code-samples" defaultValue="shell"
-  values={[{label: 'Shell', value: 'shell'}, {label: 'Go', value: 'go'}, {label: 'Node', value: 'node'},
-    {label: 'Java', value: 'java'}, {label: 'Python', value: 'python'}, {label: 'Ruby', value: 'ruby'}]}>
-<TabItem value="shell">
-
-```shell
-curl -X GET /self-service/browser/flows/login \
-  -H 'Accept: application/json'
-```
-
-</TabItem>
-<TabItem value="go">
-
-```go
-package main
-
-import (
-    "bytes"
-    "net/http"
-)
-
-func main() {
-    headers := map[string][]string{
-        "Accept": []string{"application/json"},
-    }
-
-    var body []byte
-    // body = ...
-
-    req, err := http.NewRequest("GET", "/self-service/browser/flows/login", bytes.NewBuffer(body))
-    req.Header = headers
-
-    client := &http.Client{}
-    resp, err := client.Do(req)
-    // ...
-}
-```
-
-</TabItem>
-<TabItem value="node">
-
-```javascript
-const fetch = require('node-fetch')
-
-const headers = {
-  Accept: 'application/json'
-}
-
-fetch('/self-service/browser/flows/login', {
-  method: 'GET',
-  headers
-})
-  .then((r) => r.json())
-  .then((body) => {
-    console.log(body)
-  })
-```
-
-</TabItem>
-<TabItem value="java">
-
-```java
-// This sample needs improvement.
-URL obj = new URL("/self-service/browser/flows/login");
-
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-
-int responseCode = con.getResponseCode();
-
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream())
-);
-
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-
-System.out.println(response.toString());
-```
-
-</TabItem>
-<TabItem value="python">
-
-```python
-import requests
-
-headers = {
-  'Accept': 'application/json'
-}
-
-r = requests.get(
-  '/self-service/browser/flows/login',
-  params={},
-  headers = headers)
-
-print r.json()
-```
-
-</TabItem>
-<TabItem value="ruby">
-
-```ruby
-require 'rest-client'
-require 'json'
-
-headers = {
-  'Accept' => 'application/json'
-}
-
-result = RestClient.get '/self-service/browser/flows/login',
-  params: {}, headers: headers
-
-p JSON.parse(result)
-```
-
-</TabItem>
-</Tabs>
 
 <a id="opIdinitializeSelfServiceBrowserLogoutFlow"></a>
 
@@ -3392,14 +3519,12 @@ Accept: application/json
 
 This endpoint initializes a logout flow.
 
-> This endpoint is NOT INTENDED for API clients and only works with browsers
-> (Chrome, Firefox, ...).
+> This endpoint is NOT INTENDED for API clients and only works
+with browsers (Chrome, Firefox, ...).
 
-On successful logout, the browser will be redirected (HTTP 302 Found) to
-`urls.default_return_to`.
+On successful logout, the browser will be redirected (HTTP 302 Found) to `urls.default_return_to`.
 
-More information can be found at
-[ORY Kratos User Logout Documentation](https://www.ory.sh/docs/next/kratos/self-service/flows/user-logout).
+More information can be found at [ORY Kratos User Logout Documentation](https://www.ory.sh/docs/next/kratos/self-service/flows/user-logout).
 
 #### Responses
 
@@ -3407,11 +3532,11 @@ More information can be found at
 
 ##### Overview
 
-| Status         | Meaning                                                                    | Description                                                                                                    | Schema                              |
-| -------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| 302            | [Found](https://tools.ietf.org/html/rfc7231#section-6.4.3)                 | Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is |
-| typically 201. | None                                                                       |
-| 500            | [Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1) | genericError                                                                                                   | [genericError](#schemagenericerror) |
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|302|[Found](https://tools.ietf.org/html/rfc7231#section-6.4.3)|Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
+typically 201.|None|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
 
 ##### Examples
 
@@ -3431,7 +3556,9 @@ More information can be found at
 }
 ```
 
-<aside class="success">This operation does not require authentication</aside>
+<aside class="success">
+This operation does not require authentication
+</aside>
 
 #### Code samples
 
@@ -3457,7 +3584,7 @@ import (
 )
 
 func main() {
-    headers := map[string][]string{
+    headers := map[string][]string{ 
         "Accept": []string{"application/json"},
     }
 
@@ -3477,20 +3604,20 @@ func main() {
 <TabItem value="node">
 
 ```javascript
-const fetch = require('node-fetch')
+const fetch = require('node-fetch');
 
 const headers = {
-  Accept: 'application/json'
+  'Accept': 'application/json'
 }
 
 fetch('/self-service/browser/flows/logout', {
   method: 'GET',
   headers
 })
-  .then((r) => r.json())
-  .then((body) => {
+.then(r => r.json())
+.then((body) => {
     console.log(body)
-  })
+})
 ```
 
 </TabItem>
@@ -3557,536 +3684,9 @@ p JSON.parse(result)
 </TabItem>
 </Tabs>
 
-<a id="opIdinitializeSelfServiceRecoveryFlow"></a>
-
-### Initialize browser-based account recovery flow
-
-```
-GET /self-service/browser/flows/recovery HTTP/1.1
-Accept: application/json
-
-```
-
-This endpoint initializes a browser-based account recovery flow. Once
-initialized, the browser will be redirected to
-`selfservice.flows.recovery.ui_url` with the request ID set as a query
-parameter. If a valid user session exists, the request is aborted.
-
-> This endpoint is NOT INTENDED for API clients and only works with browsers
-> (Chrome, Firefox, ...).
-
-More information can be found at
-[ORY Kratos Account Recovery Documentation](../self-service/flows/account-recovery.mdx).
-
-#### Responses
-
-<a id="initialize-browser-based-account-recovery-flow-responses"></a>
-
-##### Overview
-
-| Status         | Meaning                                                                    | Description                                                                                                    | Schema                              |
-| -------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| 302            | [Found](https://tools.ietf.org/html/rfc7231#section-6.4.3)                 | Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is |
-| typically 201. | None                                                                       |
-| 500            | [Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1) | genericError                                                                                                   | [genericError](#schemagenericerror) |
-
-##### Examples
-
-###### 500 response
-
-```json
-{
-  "error": {
-    "code": 404,
-    "debug": "The database adapter was unable to find the element",
-    "details": {},
-    "message": "string",
-    "reason": "string",
-    "request": "string",
-    "status": "string"
-  }
-}
-```
-
-<aside class="success">This operation does not require authentication</aside>
-
-#### Code samples
-
-<Tabs groupId="code-samples" defaultValue="shell"
-  values={[{label: 'Shell', value: 'shell'}, {label: 'Go', value: 'go'}, {label: 'Node', value: 'node'},
-    {label: 'Java', value: 'java'}, {label: 'Python', value: 'python'}, {label: 'Ruby', value: 'ruby'}]}>
-<TabItem value="shell">
-
-```shell
-curl -X GET /self-service/browser/flows/recovery \
-  -H 'Accept: application/json'
-```
-
-</TabItem>
-<TabItem value="go">
-
-```go
-package main
-
-import (
-    "bytes"
-    "net/http"
-)
-
-func main() {
-    headers := map[string][]string{
-        "Accept": []string{"application/json"},
-    }
-
-    var body []byte
-    // body = ...
-
-    req, err := http.NewRequest("GET", "/self-service/browser/flows/recovery", bytes.NewBuffer(body))
-    req.Header = headers
-
-    client := &http.Client{}
-    resp, err := client.Do(req)
-    // ...
-}
-```
-
-</TabItem>
-<TabItem value="node">
-
-```javascript
-const fetch = require('node-fetch')
-
-const headers = {
-  Accept: 'application/json'
-}
-
-fetch('/self-service/browser/flows/recovery', {
-  method: 'GET',
-  headers
-})
-  .then((r) => r.json())
-  .then((body) => {
-    console.log(body)
-  })
-```
-
-</TabItem>
-<TabItem value="java">
-
-```java
-// This sample needs improvement.
-URL obj = new URL("/self-service/browser/flows/recovery");
-
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-
-int responseCode = con.getResponseCode();
-
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream())
-);
-
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-
-System.out.println(response.toString());
-```
-
-</TabItem>
-<TabItem value="python">
-
-```python
-import requests
-
-headers = {
-  'Accept': 'application/json'
-}
-
-r = requests.get(
-  '/self-service/browser/flows/recovery',
-  params={},
-  headers = headers)
-
-print r.json()
-```
-
-</TabItem>
-<TabItem value="ruby">
-
-```ruby
-require 'rest-client'
-require 'json'
-
-headers = {
-  'Accept' => 'application/json'
-}
-
-result = RestClient.get '/self-service/browser/flows/recovery',
-  params: {}, headers: headers
-
-p JSON.parse(result)
-```
-
-</TabItem>
-</Tabs>
-
-<a id="opIdcompleteSelfServiceBrowserRecoveryLinkStrategyFlow"></a>
-
-### Complete the browser-based recovery flow using a recovery link
-
-```
-POST /self-service/browser/flows/recovery/link HTTP/1.1
-Accept: application/json
-
-```
-
-> This endpoint is NOT INTENDED for API clients and only works with browsers
-> (Chrome, Firefox, ...) and HTML Forms.
-
-More information can be found at
-[ORY Kratos Account Recovery Documentation](../self-service/flows/account-recovery.mdx).
-
-#### Responses
-
-<a id="complete-the-browser-based-recovery-flow-using-a-recovery-link-responses"></a>
-
-##### Overview
-
-| Status         | Meaning                                                                    | Description                                                                                                    | Schema                              |
-| -------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| 302            | [Found](https://tools.ietf.org/html/rfc7231#section-6.4.3)                 | Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is |
-| typically 201. | None                                                                       |
-| 500            | [Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1) | genericError                                                                                                   | [genericError](#schemagenericerror) |
-
-##### Examples
-
-###### 500 response
-
-```json
-{
-  "error": {
-    "code": 404,
-    "debug": "The database adapter was unable to find the element",
-    "details": {},
-    "message": "string",
-    "reason": "string",
-    "request": "string",
-    "status": "string"
-  }
-}
-```
-
-<aside class="success">This operation does not require authentication</aside>
-
-#### Code samples
-
-<Tabs groupId="code-samples" defaultValue="shell"
-  values={[{label: 'Shell', value: 'shell'}, {label: 'Go', value: 'go'}, {label: 'Node', value: 'node'},
-    {label: 'Java', value: 'java'}, {label: 'Python', value: 'python'}, {label: 'Ruby', value: 'ruby'}]}>
-<TabItem value="shell">
-
-```shell
-curl -X POST /self-service/browser/flows/recovery/link \
-  -H 'Accept: application/json'
-```
-
-</TabItem>
-<TabItem value="go">
-
-```go
-package main
-
-import (
-    "bytes"
-    "net/http"
-)
-
-func main() {
-    headers := map[string][]string{
-        "Accept": []string{"application/json"},
-    }
-
-    var body []byte
-    // body = ...
-
-    req, err := http.NewRequest("POST", "/self-service/browser/flows/recovery/link", bytes.NewBuffer(body))
-    req.Header = headers
-
-    client := &http.Client{}
-    resp, err := client.Do(req)
-    // ...
-}
-```
-
-</TabItem>
-<TabItem value="node">
-
-```javascript
-const fetch = require('node-fetch')
-
-const headers = {
-  Accept: 'application/json'
-}
-
-fetch('/self-service/browser/flows/recovery/link', {
-  method: 'POST',
-  headers
-})
-  .then((r) => r.json())
-  .then((body) => {
-    console.log(body)
-  })
-```
-
-</TabItem>
-<TabItem value="java">
-
-```java
-// This sample needs improvement.
-URL obj = new URL("/self-service/browser/flows/recovery/link");
-
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
-
-int responseCode = con.getResponseCode();
-
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream())
-);
-
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-
-System.out.println(response.toString());
-```
-
-</TabItem>
-<TabItem value="python">
-
-```python
-import requests
-
-headers = {
-  'Accept': 'application/json'
-}
-
-r = requests.post(
-  '/self-service/browser/flows/recovery/link',
-  params={},
-  headers = headers)
-
-print r.json()
-```
-
-</TabItem>
-<TabItem value="ruby">
-
-```ruby
-require 'rest-client'
-require 'json'
-
-headers = {
-  'Accept' => 'application/json'
-}
-
-result = RestClient.post '/self-service/browser/flows/recovery/link',
-  params: {}, headers: headers
-
-p JSON.parse(result)
-```
-
-</TabItem>
-</Tabs>
-
-<a id="opIdinitializeSelfServiceBrowserRegistrationFlow"></a>
-
-### Initialize browser-based registration user flow
-
-```
-GET /self-service/browser/flows/registration HTTP/1.1
-Accept: application/json
-
-```
-
-This endpoint initializes a browser-based user registration flow. Once
-initialized, the browser will be redirected to
-`selfservice.flows.registration.ui_url` with the request ID set as a query
-parameter. If a valid user session exists already, the browser will be
-redirected to `urls.default_redirect_url`.
-
-> This endpoint is NOT INTENDED for API clients and only works with browsers
-> (Chrome, Firefox, ...).
-
-More information can be found at
-[ORY Kratos User Login and User Registration Documentation](https://www.ory.sh/docs/next/kratos/self-service/flows/user-login-user-registration).
-
-#### Responses
-
-<a id="initialize-browser-based-registration-user-flow-responses"></a>
-
-##### Overview
-
-| Status         | Meaning                                                                    | Description                                                                                                    | Schema                              |
-| -------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| 302            | [Found](https://tools.ietf.org/html/rfc7231#section-6.4.3)                 | Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is |
-| typically 201. | None                                                                       |
-| 500            | [Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1) | genericError                                                                                                   | [genericError](#schemagenericerror) |
-
-##### Examples
-
-###### 500 response
-
-```json
-{
-  "error": {
-    "code": 404,
-    "debug": "The database adapter was unable to find the element",
-    "details": {},
-    "message": "string",
-    "reason": "string",
-    "request": "string",
-    "status": "string"
-  }
-}
-```
-
-<aside class="success">This operation does not require authentication</aside>
-
-#### Code samples
-
-<Tabs groupId="code-samples" defaultValue="shell"
-  values={[{label: 'Shell', value: 'shell'}, {label: 'Go', value: 'go'}, {label: 'Node', value: 'node'},
-    {label: 'Java', value: 'java'}, {label: 'Python', value: 'python'}, {label: 'Ruby', value: 'ruby'}]}>
-<TabItem value="shell">
-
-```shell
-curl -X GET /self-service/browser/flows/registration \
-  -H 'Accept: application/json'
-```
-
-</TabItem>
-<TabItem value="go">
-
-```go
-package main
-
-import (
-    "bytes"
-    "net/http"
-)
-
-func main() {
-    headers := map[string][]string{
-        "Accept": []string{"application/json"},
-    }
-
-    var body []byte
-    // body = ...
-
-    req, err := http.NewRequest("GET", "/self-service/browser/flows/registration", bytes.NewBuffer(body))
-    req.Header = headers
-
-    client := &http.Client{}
-    resp, err := client.Do(req)
-    // ...
-}
-```
-
-</TabItem>
-<TabItem value="node">
-
-```javascript
-const fetch = require('node-fetch')
-
-const headers = {
-  Accept: 'application/json'
-}
-
-fetch('/self-service/browser/flows/registration', {
-  method: 'GET',
-  headers
-})
-  .then((r) => r.json())
-  .then((body) => {
-    console.log(body)
-  })
-```
-
-</TabItem>
-<TabItem value="java">
-
-```java
-// This sample needs improvement.
-URL obj = new URL("/self-service/browser/flows/registration");
-
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-
-int responseCode = con.getResponseCode();
-
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream())
-);
-
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-
-System.out.println(response.toString());
-```
-
-</TabItem>
-<TabItem value="python">
-
-```python
-import requests
-
-headers = {
-  'Accept': 'application/json'
-}
-
-r = requests.get(
-  '/self-service/browser/flows/registration',
-  params={},
-  headers = headers)
-
-print r.json()
-```
-
-</TabItem>
-<TabItem value="ruby">
-
-```ruby
-require 'rest-client'
-require 'json'
-
-headers = {
-  'Accept' => 'application/json'
-}
-
-result = RestClient.get '/self-service/browser/flows/registration',
-  params: {}, headers: headers
-
-p JSON.parse(result)
-```
-
-</TabItem>
-</Tabs>
-
 <a id="opIdcompleteSelfServiceBrowserSettingsOIDCSettingsFlow"></a>
 
-### Complete the browser-based settings flow for the OpenID Connect strategy
+### Complete the Browser-Based Settings Flow for the OpenID Connect Strategy
 
 ```
 POST /self-service/browser/flows/registration/strategies/oidc/settings/connections HTTP/1.1
@@ -4094,14 +3694,12 @@ Accept: application/json
 
 ```
 
-This endpoint completes a browser-based settings flow. This is usually achieved
-by POSTing data to this endpoint.
+This endpoint completes a browser-based settings flow. This is usually achieved by POSTing data to this
+endpoint.
 
-> This endpoint is NOT INTENDED for API clients and only works with browsers
-> (Chrome, Firefox, ...) and HTML Forms.
+> This endpoint is NOT INTENDED for API clients and only works with browsers (Chrome, Firefox, ...) and HTML Forms.
 
-More information can be found at
-[ORY Kratos User Settings & Profile Management Documentation](../self-service/flows/user-settings).
+More information can be found at [ORY Kratos User Settings & Profile Management Documentation](../self-service/flows/user-settings).
 
 #### Responses
 
@@ -4109,11 +3707,11 @@ More information can be found at
 
 ##### Overview
 
-| Status         | Meaning                                                                    | Description                                                                                                    | Schema                              |
-| -------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| 302            | [Found](https://tools.ietf.org/html/rfc7231#section-6.4.3)                 | Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is |
-| typically 201. | None                                                                       |
-| 500            | [Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1) | genericError                                                                                                   | [genericError](#schemagenericerror) |
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|302|[Found](https://tools.ietf.org/html/rfc7231#section-6.4.3)|Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
+typically 201.|None|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
 
 ##### Examples
 
@@ -4133,7 +3731,9 @@ More information can be found at
 }
 ```
 
-<aside class="success">This operation does not require authentication</aside>
+<aside class="success">
+This operation does not require authentication
+</aside>
 
 #### Code samples
 
@@ -4159,7 +3759,7 @@ import (
 )
 
 func main() {
-    headers := map[string][]string{
+    headers := map[string][]string{ 
         "Accept": []string{"application/json"},
     }
 
@@ -4179,23 +3779,20 @@ func main() {
 <TabItem value="node">
 
 ```javascript
-const fetch = require('node-fetch')
+const fetch = require('node-fetch');
 
 const headers = {
-  Accept: 'application/json'
+  'Accept': 'application/json'
 }
 
-fetch(
-  '/self-service/browser/flows/registration/strategies/oidc/settings/connections',
-  {
-    method: 'POST',
-    headers
-  }
-)
-  .then((r) => r.json())
-  .then((body) => {
+fetch('/self-service/browser/flows/registration/strategies/oidc/settings/connections', {
+  method: 'POST',
+  headers
+})
+.then(r => r.json())
+.then((body) => {
     console.log(body)
-  })
+})
 ```
 
 </TabItem>
@@ -4262,58 +3859,194 @@ p JSON.parse(result)
 </TabItem>
 </Tabs>
 
-<a id="opIdinitializeSelfServiceSettingsFlow"></a>
+<a id="opIdinitializeSelfServiceLoginViaAPIFlow"></a>
 
-### Initialize browser-based settings flow
+### Initialize Login Flow for API clients
 
 ```
-GET /self-service/browser/flows/settings HTTP/1.1
+GET /self-service/login/api HTTP/1.1
 Accept: application/json
 
 ```
 
-This endpoint initializes a browser-based settings flow. Once initialized, the
-browser will be redirected to `selfservice.flows.settings.ui_url` with the
-request ID set as a query parameter. If no valid user session exists, a login
-flow will be initialized.
+This endpoint initiates a login flow for API clients such as mobile devices, smart TVs, and so on.
 
-> This endpoint is NOT INTENDED for API clients and only works with browsers
-> (Chrome, Firefox, ...).
+If a valid provided session cookie or session token is provided, a 400 Bad Request error
+will be returned unless the URL query parameter `?refresh=true` is set.
 
-More information can be found at
-[ORY Kratos User Settings & Profile Management Documentation](../self-service/flows/user-settings).
+To fetch an existing login flow call `/self-service/login/flows?flow=<flow_id>`.
+
+:::warning
+
+You MUST NOT use this endpoint in client-side (Single Page Apps, ReactJS, AngularJS) nor server-side (Java Server
+Pages, NodeJS, PHP, Golang, ...) browser applications. Using this endpoint in these applications will make
+you vulnerable to a variety of CSRF attacks, including CSRF login attacks.
+
+This endpoint MUST ONLY be used in scenarios such as native mobile apps (React Native, Objective C, Swift, Java, ...).
+
+:::
+
+More information can be found at [ORY Kratos User Login and User Registration Documentation](https://www.ory.sh/docs/next/kratos/self-service/flows/user-login-user-registration).
+
+<a id="initialize-login-flow-for-api-clients-parameters"></a>
+
+#### Parameters
+
+|Parameter|In|Type|Required|Description|
+|---|---|---|---|---|
+|refresh|query|boolean|false|Refresh a login session|
+
+##### Detailed descriptions
+
+**refresh**: Refresh a login session
+
+If set to true, this will refresh an existing login session by
+asking the user to sign in again. This will reset the
+authenticated_at time of the session.
 
 #### Responses
 
-<a id="initialize-browser-based-settings-flow-responses"></a>
+<a id="initialize-login-flow-for-api-clients-responses"></a>
 
 ##### Overview
 
-| Status         | Meaning                                                                    | Description                                                                                                    | Schema                              |
-| -------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| 302            | [Found](https://tools.ietf.org/html/rfc7231#section-6.4.3)                 | Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is |
-| typically 201. | None                                                                       |
-| 500            | [Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1) | genericError                                                                                                   | [genericError](#schemagenericerror) |
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|loginFlow|[loginFlow](#schemaloginflow)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|genericError|[genericError](#schemagenericerror)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
 
 ##### Examples
 
-###### 500 response
+###### 200 response
 
 ```json
 {
-  "error": {
-    "code": 404,
-    "debug": "The database adapter was unable to find the element",
-    "details": {},
-    "message": "string",
-    "reason": "string",
-    "request": "string",
-    "status": "string"
-  }
+  "active": "string",
+  "expires_at": "2019-08-24T14:15:22Z",
+  "forced": true,
+  "id": "string",
+  "issued_at": "2019-08-24T14:15:22Z",
+  "messages": [
+    {
+      "context": {},
+      "id": 0,
+      "text": "string",
+      "type": "string"
+    }
+  ],
+  "methods": {
+    "property1": {
+      "config": {
+        "action": "string",
+        "fields": [
+          {
+            "disabled": true,
+            "messages": [
+              {
+                "context": {},
+                "id": 0,
+                "text": "string",
+                "type": "string"
+              }
+            ],
+            "name": "string",
+            "pattern": "string",
+            "required": true,
+            "type": "string",
+            "value": {}
+          }
+        ],
+        "messages": [
+          {
+            "context": {},
+            "id": 0,
+            "text": "string",
+            "type": "string"
+          }
+        ],
+        "method": "string",
+        "providers": [
+          {
+            "disabled": true,
+            "messages": [
+              {
+                "context": {},
+                "id": 0,
+                "text": "string",
+                "type": "string"
+              }
+            ],
+            "name": "string",
+            "pattern": "string",
+            "required": true,
+            "type": "string",
+            "value": {}
+          }
+        ]
+      },
+      "method": "string"
+    },
+    "property2": {
+      "config": {
+        "action": "string",
+        "fields": [
+          {
+            "disabled": true,
+            "messages": [
+              {
+                "context": {},
+                "id": 0,
+                "text": "string",
+                "type": "string"
+              }
+            ],
+            "name": "string",
+            "pattern": "string",
+            "required": true,
+            "type": "string",
+            "value": {}
+          }
+        ],
+        "messages": [
+          {
+            "context": {},
+            "id": 0,
+            "text": "string",
+            "type": "string"
+          }
+        ],
+        "method": "string",
+        "providers": [
+          {
+            "disabled": true,
+            "messages": [
+              {
+                "context": {},
+                "id": 0,
+                "text": "string",
+                "type": "string"
+              }
+            ],
+            "name": "string",
+            "pattern": "string",
+            "required": true,
+            "type": "string",
+            "value": {}
+          }
+        ]
+      },
+      "method": "string"
+    }
+  },
+  "request_url": "string",
+  "type": "string"
 }
 ```
 
-<aside class="success">This operation does not require authentication</aside>
+<aside class="success">
+This operation does not require authentication
+</aside>
 
 #### Code samples
 
@@ -4323,7 +4056,7 @@ More information can be found at
 <TabItem value="shell">
 
 ```shell
-curl -X GET /self-service/browser/flows/settings \
+curl -X GET /self-service/login/api \
   -H 'Accept: application/json'
 ```
 
@@ -4339,14 +4072,14 @@ import (
 )
 
 func main() {
-    headers := map[string][]string{
+    headers := map[string][]string{ 
         "Accept": []string{"application/json"},
     }
 
     var body []byte
     // body = ...
 
-    req, err := http.NewRequest("GET", "/self-service/browser/flows/settings", bytes.NewBuffer(body))
+    req, err := http.NewRequest("GET", "/self-service/login/api", bytes.NewBuffer(body))
     req.Header = headers
 
     client := &http.Client{}
@@ -4359,20 +4092,20 @@ func main() {
 <TabItem value="node">
 
 ```javascript
-const fetch = require('node-fetch')
+const fetch = require('node-fetch');
 
 const headers = {
-  Accept: 'application/json'
+  'Accept': 'application/json'
 }
 
-fetch('/self-service/browser/flows/settings', {
+fetch('/self-service/login/api', {
   method: 'GET',
   headers
 })
-  .then((r) => r.json())
-  .then((body) => {
+.then(r => r.json())
+.then((body) => {
     console.log(body)
-  })
+})
 ```
 
 </TabItem>
@@ -4380,7 +4113,7 @@ fetch('/self-service/browser/flows/settings', {
 
 ```java
 // This sample needs improvement.
-URL obj = new URL("/self-service/browser/flows/settings");
+URL obj = new URL("/self-service/login/api");
 
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("GET");
@@ -4412,7 +4145,7 @@ headers = {
 }
 
 r = requests.get(
-  '/self-service/browser/flows/settings',
+  '/self-service/login/api',
   params={},
   headers = headers)
 
@@ -4430,7 +4163,7 @@ headers = {
   'Accept' => 'application/json'
 }
 
-result = RestClient.get '/self-service/browser/flows/settings',
+result = RestClient.get '/self-service/login/api',
   params: {}, headers: headers
 
 p JSON.parse(result)
@@ -4439,36 +4172,36 @@ p JSON.parse(result)
 </TabItem>
 </Tabs>
 
-<a id="opIdcompleteSelfServiceBrowserSettingsPasswordStrategyFlow"></a>
+<a id="opIdinitializeSelfServiceLoginViaBrowserFlow"></a>
 
-### Complete the browser-based settings flow for the password strategy
+### Initialize Login Flow for browsers
 
 ```
-POST /self-service/browser/flows/settings/strategies/password HTTP/1.1
+GET /self-service/login/browser HTTP/1.1
 Accept: application/json
 
 ```
 
-This endpoint completes a browser-based settings flow. This is usually achieved
-by POSTing data to this endpoint.
+This endpoint initializes a browser-based user login flow. Once initialized, the browser will be redirected to
+`selfservice.flows.login.ui_url` with the flow ID set as the query parameter `?flow=`. If a valid user session
+exists already, the browser will be redirected to `urls.default_redirect_url` unless the query parameter
+`?refresh=true` was set.
 
-> This endpoint is NOT INTENDED for API clients and only works with browsers
-> (Chrome, Firefox, ...) and HTML Forms.
+This endpoint is NOT INTENDED for API clients and only works with browsers (Chrome, Firefox, ...).
 
-More information can be found at
-[ORY Kratos User Settings & Profile Management Documentation](../self-service/flows/user-settings).
+More information can be found at [ORY Kratos User Login and User Registration Documentation](https://www.ory.sh/docs/next/kratos/self-service/flows/user-login-user-registration).
 
 #### Responses
 
-<a id="complete-the-browser-based-settings-flow-for-the-password-strategy-responses"></a>
+<a id="initialize-login-flow-for-browsers-responses"></a>
 
 ##### Overview
 
-| Status         | Meaning                                                                    | Description                                                                                                    | Schema                              |
-| -------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| 302            | [Found](https://tools.ietf.org/html/rfc7231#section-6.4.3)                 | Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is |
-| typically 201. | None                                                                       |
-| 500            | [Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1) | genericError                                                                                                   | [genericError](#schemagenericerror) |
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|302|[Found](https://tools.ietf.org/html/rfc7231#section-6.4.3)|Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
+typically 201.|None|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
 
 ##### Examples
 
@@ -4488,7 +4221,9 @@ More information can be found at
 }
 ```
 
-<aside class="success">This operation does not require authentication</aside>
+<aside class="success">
+This operation does not require authentication
+</aside>
 
 #### Code samples
 
@@ -4498,7 +4233,7 @@ More information can be found at
 <TabItem value="shell">
 
 ```shell
-curl -X POST /self-service/browser/flows/settings/strategies/password \
+curl -X GET /self-service/login/browser \
   -H 'Accept: application/json'
 ```
 
@@ -4514,14 +4249,14 @@ import (
 )
 
 func main() {
-    headers := map[string][]string{
+    headers := map[string][]string{ 
         "Accept": []string{"application/json"},
     }
 
     var body []byte
     // body = ...
 
-    req, err := http.NewRequest("POST", "/self-service/browser/flows/settings/strategies/password", bytes.NewBuffer(body))
+    req, err := http.NewRequest("GET", "/self-service/login/browser", bytes.NewBuffer(body))
     req.Header = headers
 
     client := &http.Client{}
@@ -4534,20 +4269,20 @@ func main() {
 <TabItem value="node">
 
 ```javascript
-const fetch = require('node-fetch')
+const fetch = require('node-fetch');
 
 const headers = {
-  Accept: 'application/json'
+  'Accept': 'application/json'
 }
 
-fetch('/self-service/browser/flows/settings/strategies/password', {
-  method: 'POST',
+fetch('/self-service/login/browser', {
+  method: 'GET',
   headers
 })
-  .then((r) => r.json())
-  .then((body) => {
+.then(r => r.json())
+.then((body) => {
     console.log(body)
-  })
+})
 ```
 
 </TabItem>
@@ -4555,10 +4290,10 @@ fetch('/self-service/browser/flows/settings/strategies/password', {
 
 ```java
 // This sample needs improvement.
-URL obj = new URL("/self-service/browser/flows/settings/strategies/password");
+URL obj = new URL("/self-service/login/browser");
 
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
+con.setRequestMethod("GET");
 
 int responseCode = con.getResponseCode();
 
@@ -4586,8 +4321,8 @@ headers = {
   'Accept': 'application/json'
 }
 
-r = requests.post(
-  '/self-service/browser/flows/settings/strategies/password',
+r = requests.get(
+  '/self-service/login/browser',
   params={},
   headers = headers)
 
@@ -4605,7 +4340,7 @@ headers = {
   'Accept' => 'application/json'
 }
 
-result = RestClient.post '/self-service/browser/flows/settings/strategies/password',
+result = RestClient.get '/self-service/login/browser',
   params: {}, headers: headers
 
 p JSON.parse(result)
@@ -4614,64 +4349,514 @@ p JSON.parse(result)
 </TabItem>
 </Tabs>
 
-<a id="opIdcompleteSelfServiceBrowserSettingsProfileStrategyFlow"></a>
+<a id="opIdcompleteSelfServiceLoginFlowWithPasswordMethod"></a>
 
-### Complete the browser-based settings flow for profile data
+### Complete Login Flow with Username/Email Password Method
 
 ```
-POST /self-service/browser/flows/settings/strategies/profile?request=string HTTP/1.1
-Content-Type: application/json
+GET /self-service/login/methods/password?flow=string HTTP/1.1
 Accept: application/json
 
 ```
 
-This endpoint completes a browser-based settings flow. This is usually achieved
-by POSTing data to this endpoint.
+Use this endpoint to complete a login flow by sending an identity's identifier and password. This endpoint
+behaves differently for API and browser flows.
 
-If the provided profile data is valid against the Identity's Traits JSON Schema,
-the data will be updated and the browser redirected to `url.settings_ui` for
-further steps.
+API flows expect `application/json` to be sent in the body and responds with
+HTTP 200 and a application/json body with the session token on success;
+HTTP 302 redirect to a fresh login flow if the original flow expired with the appropriate error messages set;
+HTTP 400 on form validation errors.
 
-> This endpoint is NOT INTENDED for API clients and only works with browsers
-> (Chrome, Firefox, ...) and HTML Forms.
+Browser flows expect `application/x-www-form-urlencoded` to be sent in the body and responds with
+a HTTP 302 redirect to the post/after login URL or the `return_to` value if it was set and if the login succeeded;
+a HTTP 302 redirect to the login UI URL with the flow ID containing the validation errors otherwise.
 
-More information can be found at
-[ORY Kratos User Settings & Profile Management Documentation](../self-service/flows/user-settings).
+More information can be found at [ORY Kratos User Login and User Registration Documentation](https://www.ory.sh/docs/next/kratos/self-service/flows/user-login-user-registration).
 
-#### Request body
-
-```json
-{
-  "request_id": "string",
-  "traits": {}
-}
-```
-
-```yaml
-request_id: string
-traits: {}
-```
-
-<a id="complete-the-browser-based-settings-flow-for-profile-data-parameters"></a>
+<a id="complete-login-flow-with-username/email-password-method-parameters"></a>
 
 #### Parameters
 
-| Parameter | In    | Type                                                                                                                                | Required | Description                |
-| --------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------- | -------- | -------------------------- |
-| request   | query | string                                                                                                                              | true     | Request is the request ID. |
-| body      | body  | [completeSelfServiceBrowserSettingsStrategyProfileFlowPayload](#schemacompleteselfservicebrowsersettingsstrategyprofileflowpayload) | true     | none                       |
+|Parameter|In|Type|Required|Description|
+|---|---|---|---|---|
+|password|query|string|false|The user's password.|
+|identifier|query|string|false|Identifier is the email or username of the user trying to log in.|
+|csrf_token|query|string|false|Sending the anti-csrf token is only required for browser login flows.|
+|flow|query|string|true|The Flow ID|
 
 #### Responses
 
-<a id="complete-the-browser-based-settings-flow-for-profile-data-responses"></a>
+<a id="complete-login-flow-with-username/email-password-method-responses"></a>
 
 ##### Overview
 
-| Status         | Meaning                                                                    | Description                                                                                                    | Schema                              |
-| -------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| 302            | [Found](https://tools.ietf.org/html/rfc7231#section-6.4.3)                 | Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is |
-| typically 201. | None                                                                       |
-| 500            | [Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1) | genericError                                                                                                   | [genericError](#schemagenericerror) |
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|loginViaApiResponse|[loginViaApiResponse](#schemaloginviaapiresponse)|
+|302|[Found](https://tools.ietf.org/html/rfc7231#section-6.4.3)|Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
+typically 201.|None|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|loginFlow|[loginFlow](#schemaloginflow)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
+
+##### Examples
+
+###### 200 response
+
+```json
+{
+  "session": {
+    "active": true,
+    "authenticated_at": "2019-08-24T14:15:22Z",
+    "expires_at": "2019-08-24T14:15:22Z",
+    "id": "string",
+    "identity": {
+      "id": "string",
+      "recovery_addresses": [
+        {
+          "id": "string",
+          "value": "string",
+          "via": "string"
+        }
+      ],
+      "schema_id": "string",
+      "schema_url": "string",
+      "traits": {},
+      "verifiable_addresses": [
+        {
+          "id": "string",
+          "status": "string",
+          "value": "string",
+          "verified": true,
+          "verified_at": "2019-08-24T14:15:22Z",
+          "via": "string"
+        }
+      ]
+    },
+    "issued_at": "2019-08-24T14:15:22Z"
+  },
+  "session_token": "string"
+}
+```
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+#### Code samples
+
+<Tabs groupId="code-samples" defaultValue="shell"
+  values={[{label: 'Shell', value: 'shell'}, {label: 'Go', value: 'go'}, {label: 'Node', value: 'node'},
+    {label: 'Java', value: 'java'}, {label: 'Python', value: 'python'}, {label: 'Ruby', value: 'ruby'}]}>
+<TabItem value="shell">
+
+```shell
+curl -X GET /self-service/login/methods/password?flow=string \
+  -H 'Accept: application/json'
+```
+
+</TabItem>
+<TabItem value="go">
+
+```go
+package main
+
+import (
+    "bytes"
+    "net/http"
+)
+
+func main() {
+    headers := map[string][]string{ 
+        "Accept": []string{"application/json"},
+    }
+
+    var body []byte
+    // body = ...
+
+    req, err := http.NewRequest("GET", "/self-service/login/methods/password", bytes.NewBuffer(body))
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+```
+
+</TabItem>
+<TabItem value="node">
+
+```javascript
+const fetch = require('node-fetch');
+
+const headers = {
+  'Accept': 'application/json'
+}
+
+fetch('/self-service/login/methods/password?flow=string', {
+  method: 'GET',
+  headers
+})
+.then(r => r.json())
+.then((body) => {
+    console.log(body)
+})
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+// This sample needs improvement.
+URL obj = new URL("/self-service/login/methods/password?flow=string");
+
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+
+int responseCode = con.getResponseCode();
+
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream())
+);
+
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+
+System.out.println(response.toString());
+```
+
+</TabItem>
+<TabItem value="python">
+
+```python
+import requests
+
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get(
+  '/self-service/login/methods/password',
+  params={
+    'flow': 'string'},
+  headers = headers)
+
+print r.json()
+```
+
+</TabItem>
+<TabItem value="ruby">
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.get '/self-service/login/methods/password',
+  params: {
+    'flow' => 'string'}, headers: headers
+
+p JSON.parse(result)
+```
+
+</TabItem>
+</Tabs>
+
+<a id="opIdinitializeSelfServiceRecoveryViaAPIFlow"></a>
+
+### Initialize Recovery Flow for API Clients
+
+```
+GET /self-service/recovery/api HTTP/1.1
+Accept: application/json
+
+```
+
+This endpoint initiates a recovery flow for API clients such as mobile devices, smart TVs, and so on.
+
+If a valid provided session cookie or session token is provided, a 400 Bad Request error.
+
+To fetch an existing recovery flow call `/self-service/recovery/flows?flow=<flow_id>`.
+
+:::warning
+
+You MUST NOT use this endpoint in client-side (Single Page Apps, ReactJS, AngularJS) nor server-side (Java Server
+Pages, NodeJS, PHP, Golang, ...) browser applications. Using this endpoint in these applications will make
+you vulnerable to a variety of CSRF attacks.
+
+This endpoint MUST ONLY be used in scenarios such as native mobile apps (React Native, Objective C, Swift, Java, ...).
+
+:::
+
+More information can be found at [ORY Kratos Account Recovery Documentation](../self-service/flows/account-recovery.mdx).
+
+#### Responses
+
+<a id="initialize-recovery-flow-for-api-clients-responses"></a>
+
+##### Overview
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|recoveryFlow|[recoveryFlow](#schemarecoveryflow)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|genericError|[genericError](#schemagenericerror)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
+
+##### Examples
+
+###### 200 response
+
+```json
+{
+  "active": "string",
+  "expires_at": "2019-08-24T14:15:22Z",
+  "id": "string",
+  "issued_at": "2019-08-24T14:15:22Z",
+  "messages": [
+    {
+      "context": {},
+      "id": 0,
+      "text": "string",
+      "type": "string"
+    }
+  ],
+  "methods": {
+    "property1": {
+      "config": {
+        "action": "string",
+        "fields": [
+          {
+            "disabled": true,
+            "messages": [
+              {
+                "context": {},
+                "id": 0,
+                "text": "string",
+                "type": "string"
+              }
+            ],
+            "name": "string",
+            "pattern": "string",
+            "required": true,
+            "type": "string",
+            "value": {}
+          }
+        ],
+        "messages": [
+          {
+            "context": {},
+            "id": 0,
+            "text": "string",
+            "type": "string"
+          }
+        ],
+        "method": "string"
+      },
+      "method": "string"
+    },
+    "property2": {
+      "config": {
+        "action": "string",
+        "fields": [
+          {
+            "disabled": true,
+            "messages": [
+              {
+                "context": {},
+                "id": 0,
+                "text": "string",
+                "type": "string"
+              }
+            ],
+            "name": "string",
+            "pattern": "string",
+            "required": true,
+            "type": "string",
+            "value": {}
+          }
+        ],
+        "messages": [
+          {
+            "context": {},
+            "id": 0,
+            "text": "string",
+            "type": "string"
+          }
+        ],
+        "method": "string"
+      },
+      "method": "string"
+    }
+  },
+  "request_url": "string",
+  "state": "string",
+  "type": "string"
+}
+```
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+#### Code samples
+
+<Tabs groupId="code-samples" defaultValue="shell"
+  values={[{label: 'Shell', value: 'shell'}, {label: 'Go', value: 'go'}, {label: 'Node', value: 'node'},
+    {label: 'Java', value: 'java'}, {label: 'Python', value: 'python'}, {label: 'Ruby', value: 'ruby'}]}>
+<TabItem value="shell">
+
+```shell
+curl -X GET /self-service/recovery/api \
+  -H 'Accept: application/json'
+```
+
+</TabItem>
+<TabItem value="go">
+
+```go
+package main
+
+import (
+    "bytes"
+    "net/http"
+)
+
+func main() {
+    headers := map[string][]string{ 
+        "Accept": []string{"application/json"},
+    }
+
+    var body []byte
+    // body = ...
+
+    req, err := http.NewRequest("GET", "/self-service/recovery/api", bytes.NewBuffer(body))
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+```
+
+</TabItem>
+<TabItem value="node">
+
+```javascript
+const fetch = require('node-fetch');
+
+const headers = {
+  'Accept': 'application/json'
+}
+
+fetch('/self-service/recovery/api', {
+  method: 'GET',
+  headers
+})
+.then(r => r.json())
+.then((body) => {
+    console.log(body)
+})
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+// This sample needs improvement.
+URL obj = new URL("/self-service/recovery/api");
+
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+
+int responseCode = con.getResponseCode();
+
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream())
+);
+
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+
+System.out.println(response.toString());
+```
+
+</TabItem>
+<TabItem value="python">
+
+```python
+import requests
+
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get(
+  '/self-service/recovery/api',
+  params={},
+  headers = headers)
+
+print r.json()
+```
+
+</TabItem>
+<TabItem value="ruby">
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.get '/self-service/recovery/api',
+  params: {}, headers: headers
+
+p JSON.parse(result)
+```
+
+</TabItem>
+</Tabs>
+
+<a id="opIdinitializeSelfServiceRecoveryViaBrowserFlow"></a>
+
+### Initialize Recovery Flow for Browser Clients
+
+```
+GET /self-service/recovery/browser HTTP/1.1
+Accept: application/json
+
+```
+
+This endpoint initializes a browser-based account recovery flow. Once initialized, the browser will be redirected to
+`selfservice.flows.recovery.ui_url` with the flow ID set as the query parameter `?flow=`. If a valid user session
+exists, the browser is returned to the configured return URL.
+
+This endpoint is NOT INTENDED for API clients and only works with browsers (Chrome, Firefox, ...).
+
+More information can be found at [ORY Kratos Account Recovery Documentation](../self-service/flows/account-recovery.mdx).
+
+#### Responses
+
+<a id="initialize-recovery-flow-for-browser-clients-responses"></a>
+
+##### Overview
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|302|[Found](https://tools.ietf.org/html/rfc7231#section-6.4.3)|Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
+typically 201.|None|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
 
 ##### Examples
 
@@ -4691,7 +4876,9 @@ traits: {}
 }
 ```
 
-<aside class="success">This operation does not require authentication</aside>
+<aside class="success">
+This operation does not require authentication
+</aside>
 
 #### Code samples
 
@@ -4701,7 +4888,304 @@ traits: {}
 <TabItem value="shell">
 
 ```shell
-curl -X POST /self-service/browser/flows/settings/strategies/profile?request=string \
+curl -X GET /self-service/recovery/browser \
+  -H 'Accept: application/json'
+```
+
+</TabItem>
+<TabItem value="go">
+
+```go
+package main
+
+import (
+    "bytes"
+    "net/http"
+)
+
+func main() {
+    headers := map[string][]string{ 
+        "Accept": []string{"application/json"},
+    }
+
+    var body []byte
+    // body = ...
+
+    req, err := http.NewRequest("GET", "/self-service/recovery/browser", bytes.NewBuffer(body))
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+```
+
+</TabItem>
+<TabItem value="node">
+
+```javascript
+const fetch = require('node-fetch');
+
+const headers = {
+  'Accept': 'application/json'
+}
+
+fetch('/self-service/recovery/browser', {
+  method: 'GET',
+  headers
+})
+.then(r => r.json())
+.then((body) => {
+    console.log(body)
+})
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+// This sample needs improvement.
+URL obj = new URL("/self-service/recovery/browser");
+
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+
+int responseCode = con.getResponseCode();
+
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream())
+);
+
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+
+System.out.println(response.toString());
+```
+
+</TabItem>
+<TabItem value="python">
+
+```python
+import requests
+
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get(
+  '/self-service/recovery/browser',
+  params={},
+  headers = headers)
+
+print r.json()
+```
+
+</TabItem>
+<TabItem value="ruby">
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.get '/self-service/recovery/browser',
+  params: {}, headers: headers
+
+p JSON.parse(result)
+```
+
+</TabItem>
+</Tabs>
+
+<a id="opIdcompleteSelfServiceRecoveryFlowWithLinkMethod"></a>
+
+### Complete Recovery Flow with Link Method
+
+```
+POST /self-service/recovery/methods/link HTTP/1.1
+Content-Type: application/json
+Accept: application/json
+
+```
+
+Use this endpoint to complete a recovery flow using the link method. This endpoint
+behaves differently for API and browser flows and has several states:
+
+`choose_method` expects `flow` (in the URL query) and `email` (in the body) to be sent
+and works with API- and Browser-initiated flows.
+For API clients it either returns a HTTP 200 OK when the form is valid and HTTP 400 OK when the form is invalid
+and a HTTP 302 Found redirect with a fresh recovery flow if the flow was otherwise invalid (e.g. expired).
+For Browser clients it returns a HTTP 302 Found redirect to the Recovery UI URL with the Recovery Flow ID appended.
+`sent_email` is the success state after `choose_method` and allows the user to request another recovery email. It
+works for both API and Browser-initiated flows and returns the same responses as the flow in `choose_method` state.
+`passed_challenge` expects a `token` to be sent in the URL query and given the nature of the flow ("sending a recovery link")
+does not have any API capabilities. The server responds with a HTTP 302 Found redirect either to the Settings UI URL
+(if the link was valid) and instructs the user to update their password, or a redirect to the Recover UI URL with
+a new Recovery Flow ID which contains an error message that the recovery link was invalid.
+
+More information can be found at [ORY Kratos Account Recovery Documentation](../self-service/flows/account-recovery.mdx).
+
+#### Request body
+
+```json
+{
+  "csrf_token": "string",
+  "email": "string"
+}
+```
+
+```yaml
+csrf_token: string
+email: string
+
+```
+
+<a id="complete-recovery-flow-with-link-method-parameters"></a>
+
+#### Parameters
+
+|Parameter|In|Type|Required|Description|
+|---|---|---|---|---|
+|token|query|string|false|Recovery Token|
+|flow|query|string|false|The Flow ID|
+|body|body|[completeSelfServiceRecoveryFlowWithLinkMethod](#schemacompleteselfservicerecoveryflowwithlinkmethod)|false|none|
+
+##### Detailed descriptions
+
+**token**: Recovery Token
+
+The recovery token which completes the recovery request. If the token
+is invalid (e.g. expired) an error will be shown to the end-user.
+
+**flow**: The Flow ID
+
+format: uuid
+
+#### Responses
+
+<a id="complete-recovery-flow-with-link-method-responses"></a>
+
+##### Overview
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|302|[Found](https://tools.ietf.org/html/rfc7231#section-6.4.3)|Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
+typically 201.|None|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|recoveryFlow|[recoveryFlow](#schemarecoveryflow)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
+
+##### Examples
+
+###### 400 response
+
+```json
+{
+  "active": "string",
+  "expires_at": "2019-08-24T14:15:22Z",
+  "id": "string",
+  "issued_at": "2019-08-24T14:15:22Z",
+  "messages": [
+    {
+      "context": {},
+      "id": 0,
+      "text": "string",
+      "type": "string"
+    }
+  ],
+  "methods": {
+    "property1": {
+      "config": {
+        "action": "string",
+        "fields": [
+          {
+            "disabled": true,
+            "messages": [
+              {
+                "context": {},
+                "id": 0,
+                "text": "string",
+                "type": "string"
+              }
+            ],
+            "name": "string",
+            "pattern": "string",
+            "required": true,
+            "type": "string",
+            "value": {}
+          }
+        ],
+        "messages": [
+          {
+            "context": {},
+            "id": 0,
+            "text": "string",
+            "type": "string"
+          }
+        ],
+        "method": "string"
+      },
+      "method": "string"
+    },
+    "property2": {
+      "config": {
+        "action": "string",
+        "fields": [
+          {
+            "disabled": true,
+            "messages": [
+              {
+                "context": {},
+                "id": 0,
+                "text": "string",
+                "type": "string"
+              }
+            ],
+            "name": "string",
+            "pattern": "string",
+            "required": true,
+            "type": "string",
+            "value": {}
+          }
+        ],
+        "messages": [
+          {
+            "context": {},
+            "id": 0,
+            "text": "string",
+            "type": "string"
+          }
+        ],
+        "method": "string"
+      },
+      "method": "string"
+    }
+  },
+  "request_url": "string",
+  "state": "string",
+  "type": "string"
+}
+```
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+#### Code samples
+
+<Tabs groupId="code-samples" defaultValue="shell"
+  values={[{label: 'Shell', value: 'shell'}, {label: 'Go', value: 'go'}, {label: 'Node', value: 'node'},
+    {label: 'Java', value: 'java'}, {label: 'Python', value: 'python'}, {label: 'Ruby', value: 'ruby'}]}>
+<TabItem value="shell">
+
+```shell
+curl -X POST /self-service/recovery/methods/link \
   -H 'Content-Type: application/json' \  -H 'Accept: application/json'
 ```
 
@@ -4717,7 +5201,7 @@ import (
 )
 
 func main() {
-    headers := map[string][]string{
+    headers := map[string][]string{ 
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
     }
@@ -4725,7 +5209,7 @@ func main() {
     var body []byte
     // body = ...
 
-    req, err := http.NewRequest("POST", "/self-service/browser/flows/settings/strategies/profile", bytes.NewBuffer(body))
+    req, err := http.NewRequest("POST", "/self-service/recovery/methods/link", bytes.NewBuffer(body))
     req.Header = headers
 
     client := &http.Client{}
@@ -4740,14 +5224,14 @@ func main() {
 ```javascript
 const fetch = require('node-fetch');
 const input = '{
-  "request_id": "string",
-  "traits": {}
+  "csrf_token": "string",
+  "email": "string"
 }';
 const headers = {
   'Content-Type': 'application/json',  'Accept': 'application/json'
 }
 
-fetch('/self-service/browser/flows/settings/strategies/profile?request=string', {
+fetch('/self-service/recovery/methods/link', {
   method: 'POST',
   body: input,
   headers
@@ -4763,7 +5247,7 @@ fetch('/self-service/browser/flows/settings/strategies/profile?request=string', 
 
 ```java
 // This sample needs improvement.
-URL obj = new URL("/self-service/browser/flows/settings/strategies/profile?request=string");
+URL obj = new URL("/self-service/recovery/methods/link");
 
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("POST");
@@ -4796,9 +5280,8 @@ headers = {
 }
 
 r = requests.post(
-  '/self-service/browser/flows/settings/strategies/profile',
-  params={
-    'request': 'string'},
+  '/self-service/recovery/methods/link',
+  params={},
   headers = headers)
 
 print r.json()
@@ -4816,199 +5299,7 @@ headers = {
   'Accept' => 'application/json'
 }
 
-result = RestClient.post '/self-service/browser/flows/settings/strategies/profile',
-  params: {
-    'request' => 'string'}, headers: headers
-
-p JSON.parse(result)
-```
-
-</TabItem>
-</Tabs>
-
-<a id="opIdinitializeSelfServiceBrowserVerificationFlow"></a>
-
-### Initialize browser-based verification flow
-
-```
-GET /self-service/browser/flows/verification/init/{via} HTTP/1.1
-Accept: application/json
-
-```
-
-This endpoint initializes a browser-based verification flow. Once initialized,
-the browser will be redirected to `selfservice.flows.settings.ui_url` with the
-request ID set as a query parameter. If no valid user session exists, a login
-flow will be initialized.
-
-> This endpoint is NOT INTENDED for API clients and only works with browsers
-> (Chrome, Firefox, ...).
-
-More information can be found at
-[ORY Kratos Email and Phone Verification Documentation](https://www.ory.sh/docs/kratos/selfservice/flows/verify-email-account-activation).
-
-<a id="initialize-browser-based-verification-flow-parameters"></a>
-
-#### Parameters
-
-| Parameter | In   | Type   | Required | Description    |
-| --------- | ---- | ------ | -------- | -------------- |
-| via       | path | string | true     | What to verify |
-
-##### Detailed descriptions
-
-**via**: What to verify
-
-Currently only "email" is supported.
-
-#### Responses
-
-<a id="initialize-browser-based-verification-flow-responses"></a>
-
-##### Overview
-
-| Status         | Meaning                                                                    | Description                                                                                                    | Schema                              |
-| -------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| 302            | [Found](https://tools.ietf.org/html/rfc7231#section-6.4.3)                 | Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is |
-| typically 201. | None                                                                       |
-| 500            | [Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1) | genericError                                                                                                   | [genericError](#schemagenericerror) |
-
-##### Examples
-
-###### 500 response
-
-```json
-{
-  "error": {
-    "code": 404,
-    "debug": "The database adapter was unable to find the element",
-    "details": {},
-    "message": "string",
-    "reason": "string",
-    "request": "string",
-    "status": "string"
-  }
-}
-```
-
-<aside class="success">This operation does not require authentication</aside>
-
-#### Code samples
-
-<Tabs groupId="code-samples" defaultValue="shell"
-  values={[{label: 'Shell', value: 'shell'}, {label: 'Go', value: 'go'}, {label: 'Node', value: 'node'},
-    {label: 'Java', value: 'java'}, {label: 'Python', value: 'python'}, {label: 'Ruby', value: 'ruby'}]}>
-<TabItem value="shell">
-
-```shell
-curl -X GET /self-service/browser/flows/verification/init/{via} \
-  -H 'Accept: application/json'
-```
-
-</TabItem>
-<TabItem value="go">
-
-```go
-package main
-
-import (
-    "bytes"
-    "net/http"
-)
-
-func main() {
-    headers := map[string][]string{
-        "Accept": []string{"application/json"},
-    }
-
-    var body []byte
-    // body = ...
-
-    req, err := http.NewRequest("GET", "/self-service/browser/flows/verification/init/{via}", bytes.NewBuffer(body))
-    req.Header = headers
-
-    client := &http.Client{}
-    resp, err := client.Do(req)
-    // ...
-}
-```
-
-</TabItem>
-<TabItem value="node">
-
-```javascript
-const fetch = require('node-fetch')
-
-const headers = {
-  Accept: 'application/json'
-}
-
-fetch('/self-service/browser/flows/verification/init/{via}', {
-  method: 'GET',
-  headers
-})
-  .then((r) => r.json())
-  .then((body) => {
-    console.log(body)
-  })
-```
-
-</TabItem>
-<TabItem value="java">
-
-```java
-// This sample needs improvement.
-URL obj = new URL("/self-service/browser/flows/verification/init/{via}");
-
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-
-int responseCode = con.getResponseCode();
-
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream())
-);
-
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-
-System.out.println(response.toString());
-```
-
-</TabItem>
-<TabItem value="python">
-
-```python
-import requests
-
-headers = {
-  'Accept': 'application/json'
-}
-
-r = requests.get(
-  '/self-service/browser/flows/verification/init/{via}',
-  params={},
-  headers = headers)
-
-print r.json()
-```
-
-</TabItem>
-<TabItem value="ruby">
-
-```ruby
-require 'rest-client'
-require 'json'
-
-headers = {
-  'Accept' => 'application/json'
-}
-
-result = RestClient.get '/self-service/browser/flows/verification/init/{via}',
+result = RestClient.post '/self-service/recovery/methods/link',
   params: {}, headers: headers
 
 p JSON.parse(result)
@@ -5017,224 +5308,46 @@ p JSON.parse(result)
 </TabItem>
 </Tabs>
 
-<a id="opIdselfServiceBrowserVerify"></a>
+<a id="opIdinitializeSelfServiceRegistrationViaAPIFlow"></a>
 
-### Complete the browser-based verification flows
+### Initialize Registration Flow for API clients
 
 ```
-GET /self-service/browser/flows/verification/{via}/confirm/{code} HTTP/1.1
+GET /self-service/registration/api HTTP/1.1
 Accept: application/json
 
 ```
 
-This endpoint completes a browser-based verification flow.
+This endpoint initiates a registration flow for API clients such as mobile devices, smart TVs, and so on.
 
-> This endpoint is NOT INTENDED for API clients and only works with browsers
-> (Chrome, Firefox, ...) and HTML Forms.
+If a valid provided session cookie or session token is provided, a 400 Bad Request error
+will be returned unless the URL query parameter `?refresh=true` is set.
 
-More information can be found at
-[ORY Kratos Email and Phone Verification Documentation](https://www.ory.sh/docs/kratos/selfservice/flows/verify-email-account-activation).
+To fetch an existing registration flow call `/self-service/registration/flows?flow=<flow_id>`.
 
-<a id="complete-the-browser-based-verification-flows-parameters"></a>
+:::warning
 
-#### Parameters
+You MUST NOT use this endpoint in client-side (Single Page Apps, ReactJS, AngularJS) nor server-side (Java Server
+Pages, NodeJS, PHP, Golang, ...) browser applications. Using this endpoint in these applications will make
+you vulnerable to a variety of CSRF attacks.
 
-| Parameter | In   | Type   | Required | Description    |
-| --------- | ---- | ------ | -------- | -------------- |
-| code      | path | string | true     | none           |
-| via       | path | string | true     | What to verify |
+This endpoint MUST ONLY be used in scenarios such as native mobile apps (React Native, Objective C, Swift, Java, ...).
 
-##### Detailed descriptions
+:::
 
-**via**: What to verify
-
-Currently only "email" is supported.
+More information can be found at [ORY Kratos User Login and User Registration Documentation](https://www.ory.sh/docs/next/kratos/self-service/flows/user-login-user-registration).
 
 #### Responses
 
-<a id="complete-the-browser-based-verification-flows-responses"></a>
+<a id="initialize-registration-flow-for-api-clients-responses"></a>
 
 ##### Overview
 
-| Status         | Meaning                                                                    | Description                                                                                                    | Schema                              |
-| -------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| 302            | [Found](https://tools.ietf.org/html/rfc7231#section-6.4.3)                 | Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is |
-| typically 201. | None                                                                       |
-| 500            | [Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1) | genericError                                                                                                   | [genericError](#schemagenericerror) |
-
-##### Examples
-
-###### 500 response
-
-```json
-{
-  "error": {
-    "code": 404,
-    "debug": "The database adapter was unable to find the element",
-    "details": {},
-    "message": "string",
-    "reason": "string",
-    "request": "string",
-    "status": "string"
-  }
-}
-```
-
-<aside class="success">This operation does not require authentication</aside>
-
-#### Code samples
-
-<Tabs groupId="code-samples" defaultValue="shell"
-  values={[{label: 'Shell', value: 'shell'}, {label: 'Go', value: 'go'}, {label: 'Node', value: 'node'},
-    {label: 'Java', value: 'java'}, {label: 'Python', value: 'python'}, {label: 'Ruby', value: 'ruby'}]}>
-<TabItem value="shell">
-
-```shell
-curl -X GET /self-service/browser/flows/verification/{via}/confirm/{code} \
-  -H 'Accept: application/json'
-```
-
-</TabItem>
-<TabItem value="go">
-
-```go
-package main
-
-import (
-    "bytes"
-    "net/http"
-)
-
-func main() {
-    headers := map[string][]string{
-        "Accept": []string{"application/json"},
-    }
-
-    var body []byte
-    // body = ...
-
-    req, err := http.NewRequest("GET", "/self-service/browser/flows/verification/{via}/confirm/{code}", bytes.NewBuffer(body))
-    req.Header = headers
-
-    client := &http.Client{}
-    resp, err := client.Do(req)
-    // ...
-}
-```
-
-</TabItem>
-<TabItem value="node">
-
-```javascript
-const fetch = require('node-fetch')
-
-const headers = {
-  Accept: 'application/json'
-}
-
-fetch('/self-service/browser/flows/verification/{via}/confirm/{code}', {
-  method: 'GET',
-  headers
-})
-  .then((r) => r.json())
-  .then((body) => {
-    console.log(body)
-  })
-```
-
-</TabItem>
-<TabItem value="java">
-
-```java
-// This sample needs improvement.
-URL obj = new URL("/self-service/browser/flows/verification/{via}/confirm/{code}");
-
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-
-int responseCode = con.getResponseCode();
-
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream())
-);
-
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-
-System.out.println(response.toString());
-```
-
-</TabItem>
-<TabItem value="python">
-
-```python
-import requests
-
-headers = {
-  'Accept': 'application/json'
-}
-
-r = requests.get(
-  '/self-service/browser/flows/verification/{via}/confirm/{code}',
-  params={},
-  headers = headers)
-
-print r.json()
-```
-
-</TabItem>
-<TabItem value="ruby">
-
-```ruby
-require 'rest-client'
-require 'json'
-
-headers = {
-  'Accept' => 'application/json'
-}
-
-result = RestClient.get '/self-service/browser/flows/verification/{via}/confirm/{code}',
-  params: {}, headers: headers
-
-p JSON.parse(result)
-```
-
-</TabItem>
-</Tabs>
-
-<a id="opIdwhoami"></a>
-
-### Check who the current HTTP session belongs to
-
-```
-GET /sessions/whoami HTTP/1.1
-Accept: application/json
-
-```
-
-Uses the HTTP Headers in the GET request to determine (e.g. by using checking
-the cookies) who is authenticated. Returns a session object in the body or 401
-if the credentials are invalid or no credentials were sent. Additionally when
-the request it successful it adds the user ID to the
-'X-Kratos-Authenticated-Identity-Id' header in the response.
-
-This endpoint is useful for reverse proxies and API Gateways.
-
-#### Responses
-
-<a id="check-who-the-current-http-session-belongs-to-responses"></a>
-
-##### Overview
-
-| Status | Meaning                                                                    | Description  | Schema                              |
-| ------ | -------------------------------------------------------------------------- | ------------ | ----------------------------------- |
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)                    | session      | [session](#schemasession)           |
-| 403    | [Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)             | genericError | [genericError](#schemagenericerror) |
-| 500    | [Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1) | genericError | [genericError](#schemagenericerror) |
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|registrationFlow|[registrationFlow](#schemaregistrationflow)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|genericError|[genericError](#schemagenericerror)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
 
 ##### Examples
 
@@ -5242,8 +5355,502 @@ This endpoint is useful for reverse proxies and API Gateways.
 
 ```json
 {
-  "authenticated_at": "2019-08-24T14:15:22Z",
+  "active": "string",
   "expires_at": "2019-08-24T14:15:22Z",
+  "id": "string",
+  "issued_at": "2019-08-24T14:15:22Z",
+  "messages": [
+    {
+      "context": {},
+      "id": 0,
+      "text": "string",
+      "type": "string"
+    }
+  ],
+  "methods": {
+    "property1": {
+      "config": {
+        "action": "string",
+        "fields": [
+          {
+            "disabled": true,
+            "messages": [
+              {
+                "context": {},
+                "id": 0,
+                "text": "string",
+                "type": "string"
+              }
+            ],
+            "name": "string",
+            "pattern": "string",
+            "required": true,
+            "type": "string",
+            "value": {}
+          }
+        ],
+        "messages": [
+          {
+            "context": {},
+            "id": 0,
+            "text": "string",
+            "type": "string"
+          }
+        ],
+        "method": "string",
+        "providers": [
+          {
+            "disabled": true,
+            "messages": [
+              {
+                "context": {},
+                "id": 0,
+                "text": "string",
+                "type": "string"
+              }
+            ],
+            "name": "string",
+            "pattern": "string",
+            "required": true,
+            "type": "string",
+            "value": {}
+          }
+        ]
+      },
+      "method": "string"
+    },
+    "property2": {
+      "config": {
+        "action": "string",
+        "fields": [
+          {
+            "disabled": true,
+            "messages": [
+              {
+                "context": {},
+                "id": 0,
+                "text": "string",
+                "type": "string"
+              }
+            ],
+            "name": "string",
+            "pattern": "string",
+            "required": true,
+            "type": "string",
+            "value": {}
+          }
+        ],
+        "messages": [
+          {
+            "context": {},
+            "id": 0,
+            "text": "string",
+            "type": "string"
+          }
+        ],
+        "method": "string",
+        "providers": [
+          {
+            "disabled": true,
+            "messages": [
+              {
+                "context": {},
+                "id": 0,
+                "text": "string",
+                "type": "string"
+              }
+            ],
+            "name": "string",
+            "pattern": "string",
+            "required": true,
+            "type": "string",
+            "value": {}
+          }
+        ]
+      },
+      "method": "string"
+    }
+  },
+  "request_url": "string",
+  "type": "string"
+}
+```
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+#### Code samples
+
+<Tabs groupId="code-samples" defaultValue="shell"
+  values={[{label: 'Shell', value: 'shell'}, {label: 'Go', value: 'go'}, {label: 'Node', value: 'node'},
+    {label: 'Java', value: 'java'}, {label: 'Python', value: 'python'}, {label: 'Ruby', value: 'ruby'}]}>
+<TabItem value="shell">
+
+```shell
+curl -X GET /self-service/registration/api \
+  -H 'Accept: application/json'
+```
+
+</TabItem>
+<TabItem value="go">
+
+```go
+package main
+
+import (
+    "bytes"
+    "net/http"
+)
+
+func main() {
+    headers := map[string][]string{ 
+        "Accept": []string{"application/json"},
+    }
+
+    var body []byte
+    // body = ...
+
+    req, err := http.NewRequest("GET", "/self-service/registration/api", bytes.NewBuffer(body))
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+```
+
+</TabItem>
+<TabItem value="node">
+
+```javascript
+const fetch = require('node-fetch');
+
+const headers = {
+  'Accept': 'application/json'
+}
+
+fetch('/self-service/registration/api', {
+  method: 'GET',
+  headers
+})
+.then(r => r.json())
+.then((body) => {
+    console.log(body)
+})
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+// This sample needs improvement.
+URL obj = new URL("/self-service/registration/api");
+
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+
+int responseCode = con.getResponseCode();
+
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream())
+);
+
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+
+System.out.println(response.toString());
+```
+
+</TabItem>
+<TabItem value="python">
+
+```python
+import requests
+
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get(
+  '/self-service/registration/api',
+  params={},
+  headers = headers)
+
+print r.json()
+```
+
+</TabItem>
+<TabItem value="ruby">
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.get '/self-service/registration/api',
+  params: {}, headers: headers
+
+p JSON.parse(result)
+```
+
+</TabItem>
+</Tabs>
+
+<a id="opIdinitializeSelfServiceRegistrationViaBrowserFlow"></a>
+
+### Initialize Registration Flow for browsers
+
+```
+GET /self-service/registration/browser HTTP/1.1
+Accept: application/json
+
+```
+
+This endpoint initializes a browser-based user registration flow. Once initialized, the browser will be redirected to
+`selfservice.flows.registration.ui_url` with the flow ID set as the query parameter `?flow=`. If a valid user session
+exists already, the browser will be redirected to `urls.default_redirect_url` unless the query parameter
+`?refresh=true` was set.
+
+:::note
+
+This endpoint is NOT INTENDED for API clients and only works with browsers (Chrome, Firefox, ...).
+
+:::
+
+More information can be found at [ORY Kratos User Login and User Registration Documentation](https://www.ory.sh/docs/next/kratos/self-service/flows/user-login-user-registration).
+
+#### Responses
+
+<a id="initialize-registration-flow-for-browsers-responses"></a>
+
+##### Overview
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|302|[Found](https://tools.ietf.org/html/rfc7231#section-6.4.3)|Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
+typically 201.|None|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
+
+##### Examples
+
+###### 500 response
+
+```json
+{
+  "error": {
+    "code": 404,
+    "debug": "The database adapter was unable to find the element",
+    "details": {},
+    "message": "string",
+    "reason": "string",
+    "request": "string",
+    "status": "string"
+  }
+}
+```
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+#### Code samples
+
+<Tabs groupId="code-samples" defaultValue="shell"
+  values={[{label: 'Shell', value: 'shell'}, {label: 'Go', value: 'go'}, {label: 'Node', value: 'node'},
+    {label: 'Java', value: 'java'}, {label: 'Python', value: 'python'}, {label: 'Ruby', value: 'ruby'}]}>
+<TabItem value="shell">
+
+```shell
+curl -X GET /self-service/registration/browser \
+  -H 'Accept: application/json'
+```
+
+</TabItem>
+<TabItem value="go">
+
+```go
+package main
+
+import (
+    "bytes"
+    "net/http"
+)
+
+func main() {
+    headers := map[string][]string{ 
+        "Accept": []string{"application/json"},
+    }
+
+    var body []byte
+    // body = ...
+
+    req, err := http.NewRequest("GET", "/self-service/registration/browser", bytes.NewBuffer(body))
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+```
+
+</TabItem>
+<TabItem value="node">
+
+```javascript
+const fetch = require('node-fetch');
+
+const headers = {
+  'Accept': 'application/json'
+}
+
+fetch('/self-service/registration/browser', {
+  method: 'GET',
+  headers
+})
+.then(r => r.json())
+.then((body) => {
+    console.log(body)
+})
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+// This sample needs improvement.
+URL obj = new URL("/self-service/registration/browser");
+
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+
+int responseCode = con.getResponseCode();
+
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream())
+);
+
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+
+System.out.println(response.toString());
+```
+
+</TabItem>
+<TabItem value="python">
+
+```python
+import requests
+
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get(
+  '/self-service/registration/browser',
+  params={},
+  headers = headers)
+
+print r.json()
+```
+
+</TabItem>
+<TabItem value="ruby">
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.get '/self-service/registration/browser',
+  params: {}, headers: headers
+
+p JSON.parse(result)
+```
+
+</TabItem>
+</Tabs>
+
+<a id="opIdcompleteSelfServiceRegistrationFlowWithPasswordMethod"></a>
+
+### Complete Registration Flow with Username/Email Password Method
+
+```
+POST /self-service/registration/methods/password HTTP/1.1
+Content-Type: application/json
+Accept: application/json
+
+```
+
+Use this endpoint to complete a registration flow by sending an identity's traits and password. This endpoint
+behaves differently for API and browser flows.
+
+API flows expect `application/json` to be sent in the body and respond with
+HTTP 200 and a application/json body with the created identity success - if the session hook is configured the
+`session` and `session_token` will also be included;
+HTTP 302 redirect to a fresh registration flow if the original flow expired with the appropriate error messages set;
+HTTP 400 on form validation errors.
+
+Browser flows expect `application/x-www-form-urlencoded` to be sent in the body and responds with
+a HTTP 302 redirect to the post/after registration URL or the `return_to` value if it was set and if the registration succeeded;
+a HTTP 302 redirect to the registration UI URL with the flow ID containing the validation errors otherwise.
+
+More information can be found at [ORY Kratos User Login and User Registration Documentation](https://www.ory.sh/docs/next/kratos/self-service/flows/user-login-user-registration).
+
+#### Request body
+
+```json
+{}
+```
+
+```yaml
+{}
+
+```
+
+<a id="complete-registration-flow-with-username/email-password-method-parameters"></a>
+
+#### Parameters
+
+|Parameter|In|Type|Required|Description|
+|---|---|---|---|---|
+|flow|query|string|false|Flow is flow ID.|
+|body|body|object|false|none|
+
+#### Responses
+
+<a id="complete-registration-flow-with-username/email-password-method-responses"></a>
+
+##### Overview
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|registrationViaApiResponse|[registrationViaApiResponse](#schemaregistrationviaapiresponse)|
+|302|[Found](https://tools.ietf.org/html/rfc7231#section-6.4.3)|Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
+typically 201.|None|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|registrationFlow|[registrationFlow](#schemaregistrationflow)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
+
+##### Examples
+
+###### 200 response
+
+```json
+{
   "identity": {
     "id": "string",
     "recovery_addresses": [
@@ -5258,8 +5865,245 @@ This endpoint is useful for reverse proxies and API Gateways.
     "traits": {},
     "verifiable_addresses": [
       {
-        "expires_at": "2019-08-24T14:15:22Z",
         "id": "string",
+        "status": "string",
+        "value": "string",
+        "verified": true,
+        "verified_at": "2019-08-24T14:15:22Z",
+        "via": "string"
+      }
+    ]
+  },
+  "session": {
+    "active": true,
+    "authenticated_at": "2019-08-24T14:15:22Z",
+    "expires_at": "2019-08-24T14:15:22Z",
+    "id": "string",
+    "identity": {
+      "id": "string",
+      "recovery_addresses": [
+        {
+          "id": "string",
+          "value": "string",
+          "via": "string"
+        }
+      ],
+      "schema_id": "string",
+      "schema_url": "string",
+      "traits": {},
+      "verifiable_addresses": [
+        {
+          "id": "string",
+          "status": "string",
+          "value": "string",
+          "verified": true,
+          "verified_at": "2019-08-24T14:15:22Z",
+          "via": "string"
+        }
+      ]
+    },
+    "issued_at": "2019-08-24T14:15:22Z"
+  },
+  "session_token": "string"
+}
+```
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+#### Code samples
+
+<Tabs groupId="code-samples" defaultValue="shell"
+  values={[{label: 'Shell', value: 'shell'}, {label: 'Go', value: 'go'}, {label: 'Node', value: 'node'},
+    {label: 'Java', value: 'java'}, {label: 'Python', value: 'python'}, {label: 'Ruby', value: 'ruby'}]}>
+<TabItem value="shell">
+
+```shell
+curl -X POST /self-service/registration/methods/password \
+  -H 'Content-Type: application/json' \  -H 'Accept: application/json'
+```
+
+</TabItem>
+<TabItem value="go">
+
+```go
+package main
+
+import (
+    "bytes"
+    "net/http"
+)
+
+func main() {
+    headers := map[string][]string{ 
+        "Content-Type": []string{"application/json"},
+        "Accept": []string{"application/json"},
+    }
+
+    var body []byte
+    // body = ...
+
+    req, err := http.NewRequest("POST", "/self-service/registration/methods/password", bytes.NewBuffer(body))
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+```
+
+</TabItem>
+<TabItem value="node">
+
+```javascript
+const fetch = require('node-fetch');
+const input = '{}';
+const headers = {
+  'Content-Type': 'application/json',  'Accept': 'application/json'
+}
+
+fetch('/self-service/registration/methods/password', {
+  method: 'POST',
+  body: input,
+  headers
+})
+.then(r => r.json())
+.then((body) => {
+    console.log(body)
+})
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+// This sample needs improvement.
+URL obj = new URL("/self-service/registration/methods/password");
+
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("POST");
+
+int responseCode = con.getResponseCode();
+
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream())
+);
+
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+
+System.out.println(response.toString());
+```
+
+</TabItem>
+<TabItem value="python">
+
+```python
+import requests
+
+headers = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json'
+}
+
+r = requests.post(
+  '/self-service/registration/methods/password',
+  params={},
+  headers = headers)
+
+print r.json()
+```
+
+</TabItem>
+<TabItem value="ruby">
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Content-Type' => 'application/json',
+  'Accept' => 'application/json'
+}
+
+result = RestClient.post '/self-service/registration/methods/password',
+  params: {}, headers: headers
+
+p JSON.parse(result)
+```
+
+</TabItem>
+</Tabs>
+
+<a id="opIdinitializeSelfServiceSettingsViaAPIFlow"></a>
+
+### Initialize Settings Flow for API Clients
+
+```
+GET /self-service/settings/api HTTP/1.1
+Accept: application/json
+
+```
+
+This endpoint initiates a settings flow for API clients such as mobile devices, smart TVs, and so on.
+You must provide a valid ORY Kratos Session Token for this endpoint to respond with HTTP 200 OK.
+
+To fetch an existing settings flow call `/self-service/settings/flows?flow=<flow_id>`.
+
+:::warning
+
+You MUST NOT use this endpoint in client-side (Single Page Apps, ReactJS, AngularJS) nor server-side (Java Server
+Pages, NodeJS, PHP, Golang, ...) browser applications. Using this endpoint in these applications will make
+you vulnerable to a variety of CSRF attacks.
+
+This endpoint MUST ONLY be used in scenarios such as native mobile apps (React Native, Objective C, Swift, Java, ...).
+
+:::
+
+More information can be found at [ORY Kratos User Settings & Profile Management Documentation](../self-service/flows/user-settings).
+
+#### Responses
+
+<a id="initialize-settings-flow-for-api-clients-responses"></a>
+
+##### Overview
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|settingsFlow|[settingsFlow](#schemasettingsflow)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|genericError|[genericError](#schemagenericerror)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
+
+##### Examples
+
+###### 200 response
+
+```json
+{
+  "active": "string",
+  "expires_at": "2019-08-24T14:15:22Z",
+  "id": "string",
+  "identity": {
+    "id": "string",
+    "recovery_addresses": [
+      {
+        "id": "string",
+        "value": "string",
+        "via": "string"
+      }
+    ],
+    "schema_id": "string",
+    "schema_url": "string",
+    "traits": {},
+    "verifiable_addresses": [
+      {
+        "id": "string",
+        "status": "string",
         "value": "string",
         "verified": true,
         "verified_at": "2019-08-24T14:15:22Z",
@@ -5268,11 +6112,2029 @@ This endpoint is useful for reverse proxies and API Gateways.
     ]
   },
   "issued_at": "2019-08-24T14:15:22Z",
-  "sid": "string"
+  "messages": [
+    {
+      "context": {},
+      "id": 0,
+      "text": "string",
+      "type": "string"
+    }
+  ],
+  "methods": {
+    "property1": {
+      "config": {
+        "action": "string",
+        "fields": [
+          {
+            "disabled": true,
+            "messages": [
+              {
+                "context": {},
+                "id": 0,
+                "text": "string",
+                "type": "string"
+              }
+            ],
+            "name": "string",
+            "pattern": "string",
+            "required": true,
+            "type": "string",
+            "value": {}
+          }
+        ],
+        "messages": [
+          {
+            "context": {},
+            "id": 0,
+            "text": "string",
+            "type": "string"
+          }
+        ],
+        "method": "string"
+      },
+      "method": "string"
+    },
+    "property2": {
+      "config": {
+        "action": "string",
+        "fields": [
+          {
+            "disabled": true,
+            "messages": [
+              {
+                "context": {},
+                "id": 0,
+                "text": "string",
+                "type": "string"
+              }
+            ],
+            "name": "string",
+            "pattern": "string",
+            "required": true,
+            "type": "string",
+            "value": {}
+          }
+        ],
+        "messages": [
+          {
+            "context": {},
+            "id": 0,
+            "text": "string",
+            "type": "string"
+          }
+        ],
+        "method": "string"
+      },
+      "method": "string"
+    }
+  },
+  "request_url": "string",
+  "state": "string",
+  "type": "string"
 }
 ```
 
-<aside class="success">This operation does not require authentication</aside>
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+#### Code samples
+
+<Tabs groupId="code-samples" defaultValue="shell"
+  values={[{label: 'Shell', value: 'shell'}, {label: 'Go', value: 'go'}, {label: 'Node', value: 'node'},
+    {label: 'Java', value: 'java'}, {label: 'Python', value: 'python'}, {label: 'Ruby', value: 'ruby'}]}>
+<TabItem value="shell">
+
+```shell
+curl -X GET /self-service/settings/api \
+  -H 'Accept: application/json'
+```
+
+</TabItem>
+<TabItem value="go">
+
+```go
+package main
+
+import (
+    "bytes"
+    "net/http"
+)
+
+func main() {
+    headers := map[string][]string{ 
+        "Accept": []string{"application/json"},
+    }
+
+    var body []byte
+    // body = ...
+
+    req, err := http.NewRequest("GET", "/self-service/settings/api", bytes.NewBuffer(body))
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+```
+
+</TabItem>
+<TabItem value="node">
+
+```javascript
+const fetch = require('node-fetch');
+
+const headers = {
+  'Accept': 'application/json'
+}
+
+fetch('/self-service/settings/api', {
+  method: 'GET',
+  headers
+})
+.then(r => r.json())
+.then((body) => {
+    console.log(body)
+})
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+// This sample needs improvement.
+URL obj = new URL("/self-service/settings/api");
+
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+
+int responseCode = con.getResponseCode();
+
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream())
+);
+
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+
+System.out.println(response.toString());
+```
+
+</TabItem>
+<TabItem value="python">
+
+```python
+import requests
+
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get(
+  '/self-service/settings/api',
+  params={},
+  headers = headers)
+
+print r.json()
+```
+
+</TabItem>
+<TabItem value="ruby">
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.get '/self-service/settings/api',
+  params: {}, headers: headers
+
+p JSON.parse(result)
+```
+
+</TabItem>
+</Tabs>
+
+<a id="opIdinitializeSelfServiceSettingsViaBrowserFlow"></a>
+
+### Initialize Settings Flow for Browsers
+
+```
+GET /self-service/settings/browser/flows HTTP/1.1
+Accept: application/json
+
+```
+
+This endpoint initializes a browser-based user settings flow. Once initialized, the browser will be redirected to
+`selfservice.flows.settings.ui_url` with the flow ID set as the query parameter `?flow=`. If no valid
+ORY Kratos Session Cookie is included in the request, a login flow will be initialized.
+
+:::note
+
+This endpoint is NOT INTENDED for API clients and only works with browsers (Chrome, Firefox, ...).
+
+:::
+
+More information can be found at [ORY Kratos User Settings & Profile Management Documentation](../self-service/flows/user-settings).
+
+#### Responses
+
+<a id="initialize-settings-flow-for-browsers-responses"></a>
+
+##### Overview
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|302|[Found](https://tools.ietf.org/html/rfc7231#section-6.4.3)|Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
+typically 201.|None|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
+
+##### Examples
+
+###### 500 response
+
+```json
+{
+  "error": {
+    "code": 404,
+    "debug": "The database adapter was unable to find the element",
+    "details": {},
+    "message": "string",
+    "reason": "string",
+    "request": "string",
+    "status": "string"
+  }
+}
+```
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+#### Code samples
+
+<Tabs groupId="code-samples" defaultValue="shell"
+  values={[{label: 'Shell', value: 'shell'}, {label: 'Go', value: 'go'}, {label: 'Node', value: 'node'},
+    {label: 'Java', value: 'java'}, {label: 'Python', value: 'python'}, {label: 'Ruby', value: 'ruby'}]}>
+<TabItem value="shell">
+
+```shell
+curl -X GET /self-service/settings/browser/flows \
+  -H 'Accept: application/json'
+```
+
+</TabItem>
+<TabItem value="go">
+
+```go
+package main
+
+import (
+    "bytes"
+    "net/http"
+)
+
+func main() {
+    headers := map[string][]string{ 
+        "Accept": []string{"application/json"},
+    }
+
+    var body []byte
+    // body = ...
+
+    req, err := http.NewRequest("GET", "/self-service/settings/browser/flows", bytes.NewBuffer(body))
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+```
+
+</TabItem>
+<TabItem value="node">
+
+```javascript
+const fetch = require('node-fetch');
+
+const headers = {
+  'Accept': 'application/json'
+}
+
+fetch('/self-service/settings/browser/flows', {
+  method: 'GET',
+  headers
+})
+.then(r => r.json())
+.then((body) => {
+    console.log(body)
+})
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+// This sample needs improvement.
+URL obj = new URL("/self-service/settings/browser/flows");
+
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+
+int responseCode = con.getResponseCode();
+
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream())
+);
+
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+
+System.out.println(response.toString());
+```
+
+</TabItem>
+<TabItem value="python">
+
+```python
+import requests
+
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get(
+  '/self-service/settings/browser/flows',
+  params={},
+  headers = headers)
+
+print r.json()
+```
+
+</TabItem>
+<TabItem value="ruby">
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.get '/self-service/settings/browser/flows',
+  params: {}, headers: headers
+
+p JSON.parse(result)
+```
+
+</TabItem>
+</Tabs>
+
+<a id="opIdcompleteSelfServiceSettingsFlowWithPasswordMethod"></a>
+
+### Complete Settings Flow with Username/Email Password Method
+
+```
+POST /self-service/settings/methods/password HTTP/1.1
+Content-Type: application/json
+Accept: application/json
+
+```
+
+Use this endpoint to complete a settings flow by sending an identity's updated password. This endpoint
+behaves differently for API and browser flows.
+
+API-initiated flows expect `application/json` to be sent in the body and respond with
+HTTP 200 and an application/json body with the session token on success;
+HTTP 302 redirect to a fresh settings flow if the original flow expired with the appropriate error messages set;
+HTTP 400 on form validation errors.
+HTTP 401 when the endpoint is called without a valid session token.
+HTTP 403 when `selfservice.flows.settings.privileged_session_max_age` was reached.
+Implies that the user needs to re-authenticate.
+
+Browser flows expect `application/x-www-form-urlencoded` to be sent in the body and responds with
+a HTTP 302 redirect to the post/after settings URL or the `return_to` value if it was set and if the flow succeeded;
+a HTTP 302 redirect to the Settings UI URL with the flow ID containing the validation errors otherwise.
+a HTTP 302 redirect to the login endpoint when `selfservice.flows.settings.privileged_session_max_age` was reached.
+
+More information can be found at [ORY Kratos User Settings & Profile Management Documentation](../self-service/flows/user-settings).
+
+#### Request body
+
+```json
+{
+  "csrf_token": "string",
+  "password": "string"
+}
+```
+
+```yaml
+csrf_token: string
+password: string
+
+```
+
+<a id="complete-settings-flow-with-username/email-password-method-parameters"></a>
+
+#### Parameters
+
+|Parameter|In|Type|Required|Description|
+|---|---|---|---|---|
+|flow|query|string|false|Flow is flow ID.|
+|body|body|[CompleteSelfServiceSettingsFlowWithPasswordMethod](#schemacompleteselfservicesettingsflowwithpasswordmethod)|false|none|
+
+#### Responses
+
+<a id="complete-settings-flow-with-username/email-password-method-responses"></a>
+
+##### Overview
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|settingsViaApiResponse|[settingsViaApiResponse](#schemasettingsviaapiresponse)|
+|302|[Found](https://tools.ietf.org/html/rfc7231#section-6.4.3)|Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
+typically 201.|None|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|settingsFlow|[settingsFlow](#schemasettingsflow)|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|genericError|[genericError](#schemagenericerror)|
+|403|[Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)|genericError|[genericError](#schemagenericerror)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
+
+##### Examples
+
+###### 200 response
+
+```json
+{
+  "flow": {
+    "active": "string",
+    "expires_at": "2019-08-24T14:15:22Z",
+    "id": "string",
+    "identity": {
+      "id": "string",
+      "recovery_addresses": [
+        {
+          "id": "string",
+          "value": "string",
+          "via": "string"
+        }
+      ],
+      "schema_id": "string",
+      "schema_url": "string",
+      "traits": {},
+      "verifiable_addresses": [
+        {
+          "id": "string",
+          "status": "string",
+          "value": "string",
+          "verified": true,
+          "verified_at": "2019-08-24T14:15:22Z",
+          "via": "string"
+        }
+      ]
+    },
+    "issued_at": "2019-08-24T14:15:22Z",
+    "messages": [
+      {
+        "context": {},
+        "id": 0,
+        "text": "string",
+        "type": "string"
+      }
+    ],
+    "methods": {
+      "property1": {
+        "config": {
+          "action": "string",
+          "fields": [
+            {
+              "disabled": true,
+              "messages": [
+                {
+                  "context": {},
+                  "id": 0,
+                  "text": "string",
+                  "type": "string"
+                }
+              ],
+              "name": "string",
+              "pattern": "string",
+              "required": true,
+              "type": "string",
+              "value": {}
+            }
+          ],
+          "messages": [
+            {
+              "context": {},
+              "id": 0,
+              "text": "string",
+              "type": "string"
+            }
+          ],
+          "method": "string"
+        },
+        "method": "string"
+      },
+      "property2": {
+        "config": {
+          "action": "string",
+          "fields": [
+            {
+              "disabled": true,
+              "messages": [
+                {
+                  "context": {},
+                  "id": 0,
+                  "text": "string",
+                  "type": "string"
+                }
+              ],
+              "name": "string",
+              "pattern": "string",
+              "required": true,
+              "type": "string",
+              "value": {}
+            }
+          ],
+          "messages": [
+            {
+              "context": {},
+              "id": 0,
+              "text": "string",
+              "type": "string"
+            }
+          ],
+          "method": "string"
+        },
+        "method": "string"
+      }
+    },
+    "request_url": "string",
+    "state": "string",
+    "type": "string"
+  },
+  "identity": {
+    "id": "string",
+    "recovery_addresses": [
+      {
+        "id": "string",
+        "value": "string",
+        "via": "string"
+      }
+    ],
+    "schema_id": "string",
+    "schema_url": "string",
+    "traits": {},
+    "verifiable_addresses": [
+      {
+        "id": "string",
+        "status": "string",
+        "value": "string",
+        "verified": true,
+        "verified_at": "2019-08-24T14:15:22Z",
+        "via": "string"
+      }
+    ]
+  }
+}
+```
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+#### Code samples
+
+<Tabs groupId="code-samples" defaultValue="shell"
+  values={[{label: 'Shell', value: 'shell'}, {label: 'Go', value: 'go'}, {label: 'Node', value: 'node'},
+    {label: 'Java', value: 'java'}, {label: 'Python', value: 'python'}, {label: 'Ruby', value: 'ruby'}]}>
+<TabItem value="shell">
+
+```shell
+curl -X POST /self-service/settings/methods/password \
+  -H 'Content-Type: application/json' \  -H 'Accept: application/json'
+```
+
+</TabItem>
+<TabItem value="go">
+
+```go
+package main
+
+import (
+    "bytes"
+    "net/http"
+)
+
+func main() {
+    headers := map[string][]string{ 
+        "Content-Type": []string{"application/json"},
+        "Accept": []string{"application/json"},
+    }
+
+    var body []byte
+    // body = ...
+
+    req, err := http.NewRequest("POST", "/self-service/settings/methods/password", bytes.NewBuffer(body))
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+```
+
+</TabItem>
+<TabItem value="node">
+
+```javascript
+const fetch = require('node-fetch');
+const input = '{
+  "csrf_token": "string",
+  "password": "string"
+}';
+const headers = {
+  'Content-Type': 'application/json',  'Accept': 'application/json'
+}
+
+fetch('/self-service/settings/methods/password', {
+  method: 'POST',
+  body: input,
+  headers
+})
+.then(r => r.json())
+.then((body) => {
+    console.log(body)
+})
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+// This sample needs improvement.
+URL obj = new URL("/self-service/settings/methods/password");
+
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("POST");
+
+int responseCode = con.getResponseCode();
+
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream())
+);
+
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+
+System.out.println(response.toString());
+```
+
+</TabItem>
+<TabItem value="python">
+
+```python
+import requests
+
+headers = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json'
+}
+
+r = requests.post(
+  '/self-service/settings/methods/password',
+  params={},
+  headers = headers)
+
+print r.json()
+```
+
+</TabItem>
+<TabItem value="ruby">
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Content-Type' => 'application/json',
+  'Accept' => 'application/json'
+}
+
+result = RestClient.post '/self-service/settings/methods/password',
+  params: {}, headers: headers
+
+p JSON.parse(result)
+```
+
+</TabItem>
+</Tabs>
+
+<a id="opIdcompleteSelfServiceSettingsFlowWithProfileMethod"></a>
+
+### Complete Settings Flow with Profile Method
+
+```
+POST /self-service/settings/methods/profile HTTP/1.1
+Accept: application/json
+
+```
+
+Use this endpoint to complete a settings flow by sending an identity's updated traits. This endpoint
+behaves differently for API and browser flows.
+
+API-initiated flows expect `application/json` to be sent in the body and respond with
+HTTP 200 and an application/json body with the session token on success;
+HTTP 302 redirect to a fresh settings flow if the original flow expired with the appropriate error messages set;
+HTTP 400 on form validation errors.
+HTTP 401 when the endpoint is called without a valid session token.
+HTTP 403 when `selfservice.flows.settings.privileged_session_max_age` was reached and a sensitive field was
+updated (e.g. recovery email). Implies that the user needs to re-authenticate.
+
+Browser flows expect `application/x-www-form-urlencoded` to be sent in the body and responds with
+a HTTP 302 redirect to the post/after settings URL or the `return_to` value if it was set and if the flow succeeded;
+a HTTP 302 redirect to the settings UI URL with the flow ID containing the validation errors otherwise.
+a HTTP 302 redirect to the login endpoint when `selfservice.flows.settings.privileged_session_max_age` was reached.
+
+More information can be found at [ORY Kratos User Settings & Profile Management Documentation](../self-service/flows/user-settings).
+
+#### Responses
+
+<a id="complete-settings-flow-with-profile-method-responses"></a>
+
+##### Overview
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|settingsFlow|[settingsFlow](#schemasettingsflow)|
+|302|[Found](https://tools.ietf.org/html/rfc7231#section-6.4.3)|Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
+typically 201.|None|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|settingsFlow|[settingsFlow](#schemasettingsflow)|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|genericError|[genericError](#schemagenericerror)|
+|403|[Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)|genericError|[genericError](#schemagenericerror)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
+
+##### Examples
+
+###### 200 response
+
+```json
+{
+  "active": "string",
+  "expires_at": "2019-08-24T14:15:22Z",
+  "id": "string",
+  "identity": {
+    "id": "string",
+    "recovery_addresses": [
+      {
+        "id": "string",
+        "value": "string",
+        "via": "string"
+      }
+    ],
+    "schema_id": "string",
+    "schema_url": "string",
+    "traits": {},
+    "verifiable_addresses": [
+      {
+        "id": "string",
+        "status": "string",
+        "value": "string",
+        "verified": true,
+        "verified_at": "2019-08-24T14:15:22Z",
+        "via": "string"
+      }
+    ]
+  },
+  "issued_at": "2019-08-24T14:15:22Z",
+  "messages": [
+    {
+      "context": {},
+      "id": 0,
+      "text": "string",
+      "type": "string"
+    }
+  ],
+  "methods": {
+    "property1": {
+      "config": {
+        "action": "string",
+        "fields": [
+          {
+            "disabled": true,
+            "messages": [
+              {
+                "context": {},
+                "id": 0,
+                "text": "string",
+                "type": "string"
+              }
+            ],
+            "name": "string",
+            "pattern": "string",
+            "required": true,
+            "type": "string",
+            "value": {}
+          }
+        ],
+        "messages": [
+          {
+            "context": {},
+            "id": 0,
+            "text": "string",
+            "type": "string"
+          }
+        ],
+        "method": "string"
+      },
+      "method": "string"
+    },
+    "property2": {
+      "config": {
+        "action": "string",
+        "fields": [
+          {
+            "disabled": true,
+            "messages": [
+              {
+                "context": {},
+                "id": 0,
+                "text": "string",
+                "type": "string"
+              }
+            ],
+            "name": "string",
+            "pattern": "string",
+            "required": true,
+            "type": "string",
+            "value": {}
+          }
+        ],
+        "messages": [
+          {
+            "context": {},
+            "id": 0,
+            "text": "string",
+            "type": "string"
+          }
+        ],
+        "method": "string"
+      },
+      "method": "string"
+    }
+  },
+  "request_url": "string",
+  "state": "string",
+  "type": "string"
+}
+```
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+#### Code samples
+
+<Tabs groupId="code-samples" defaultValue="shell"
+  values={[{label: 'Shell', value: 'shell'}, {label: 'Go', value: 'go'}, {label: 'Node', value: 'node'},
+    {label: 'Java', value: 'java'}, {label: 'Python', value: 'python'}, {label: 'Ruby', value: 'ruby'}]}>
+<TabItem value="shell">
+
+```shell
+curl -X POST /self-service/settings/methods/profile \
+  -H 'Accept: application/json'
+```
+
+</TabItem>
+<TabItem value="go">
+
+```go
+package main
+
+import (
+    "bytes"
+    "net/http"
+)
+
+func main() {
+    headers := map[string][]string{ 
+        "Accept": []string{"application/json"},
+    }
+
+    var body []byte
+    // body = ...
+
+    req, err := http.NewRequest("POST", "/self-service/settings/methods/profile", bytes.NewBuffer(body))
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+```
+
+</TabItem>
+<TabItem value="node">
+
+```javascript
+const fetch = require('node-fetch');
+
+const headers = {
+  'Accept': 'application/json'
+}
+
+fetch('/self-service/settings/methods/profile', {
+  method: 'POST',
+  headers
+})
+.then(r => r.json())
+.then((body) => {
+    console.log(body)
+})
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+// This sample needs improvement.
+URL obj = new URL("/self-service/settings/methods/profile");
+
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("POST");
+
+int responseCode = con.getResponseCode();
+
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream())
+);
+
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+
+System.out.println(response.toString());
+```
+
+</TabItem>
+<TabItem value="python">
+
+```python
+import requests
+
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.post(
+  '/self-service/settings/methods/profile',
+  params={},
+  headers = headers)
+
+print r.json()
+```
+
+</TabItem>
+<TabItem value="ruby">
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.post '/self-service/settings/methods/profile',
+  params: {}, headers: headers
+
+p JSON.parse(result)
+```
+
+</TabItem>
+</Tabs>
+
+<a id="opIdinitializeSelfServiceVerificationViaAPIFlow"></a>
+
+### Initialize Verification Flow for API Clients
+
+```
+GET /self-service/verification/api HTTP/1.1
+Accept: application/json
+
+```
+
+This endpoint initiates a verification flow for API clients such as mobile devices, smart TVs, and so on.
+
+To fetch an existing verification flow call `/self-service/verification/flows?flow=<flow_id>`.
+
+:::warning
+
+You MUST NOT use this endpoint in client-side (Single Page Apps, ReactJS, AngularJS) nor server-side (Java Server
+Pages, NodeJS, PHP, Golang, ...) browser applications. Using this endpoint in these applications will make
+you vulnerable to a variety of CSRF attacks.
+
+This endpoint MUST ONLY be used in scenarios such as native mobile apps (React Native, Objective C, Swift, Java, ...).
+
+:::
+
+More information can be found at [ORY Kratos Email and Phone Verification Documentation](https://www.ory.sh/docs/kratos/selfservice/flows/verify-email-account-activation).
+
+#### Responses
+
+<a id="initialize-verification-flow-for-api-clients-responses"></a>
+
+##### Overview
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|verificationFlow|[verificationFlow](#schemaverificationflow)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|genericError|[genericError](#schemagenericerror)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
+
+##### Examples
+
+###### 200 response
+
+```json
+{
+  "active": "string",
+  "expires_at": "2019-08-24T14:15:22Z",
+  "id": "string",
+  "issued_at": "2019-08-24T14:15:22Z",
+  "messages": [
+    {
+      "context": {},
+      "id": 0,
+      "text": "string",
+      "type": "string"
+    }
+  ],
+  "methods": {
+    "property1": {
+      "config": {
+        "action": "string",
+        "fields": [
+          {
+            "disabled": true,
+            "messages": [
+              {
+                "context": {},
+                "id": 0,
+                "text": "string",
+                "type": "string"
+              }
+            ],
+            "name": "string",
+            "pattern": "string",
+            "required": true,
+            "type": "string",
+            "value": {}
+          }
+        ],
+        "messages": [
+          {
+            "context": {},
+            "id": 0,
+            "text": "string",
+            "type": "string"
+          }
+        ],
+        "method": "string"
+      },
+      "method": "string"
+    },
+    "property2": {
+      "config": {
+        "action": "string",
+        "fields": [
+          {
+            "disabled": true,
+            "messages": [
+              {
+                "context": {},
+                "id": 0,
+                "text": "string",
+                "type": "string"
+              }
+            ],
+            "name": "string",
+            "pattern": "string",
+            "required": true,
+            "type": "string",
+            "value": {}
+          }
+        ],
+        "messages": [
+          {
+            "context": {},
+            "id": 0,
+            "text": "string",
+            "type": "string"
+          }
+        ],
+        "method": "string"
+      },
+      "method": "string"
+    }
+  },
+  "request_url": "string",
+  "state": "string",
+  "type": "string"
+}
+```
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+#### Code samples
+
+<Tabs groupId="code-samples" defaultValue="shell"
+  values={[{label: 'Shell', value: 'shell'}, {label: 'Go', value: 'go'}, {label: 'Node', value: 'node'},
+    {label: 'Java', value: 'java'}, {label: 'Python', value: 'python'}, {label: 'Ruby', value: 'ruby'}]}>
+<TabItem value="shell">
+
+```shell
+curl -X GET /self-service/verification/api \
+  -H 'Accept: application/json'
+```
+
+</TabItem>
+<TabItem value="go">
+
+```go
+package main
+
+import (
+    "bytes"
+    "net/http"
+)
+
+func main() {
+    headers := map[string][]string{ 
+        "Accept": []string{"application/json"},
+    }
+
+    var body []byte
+    // body = ...
+
+    req, err := http.NewRequest("GET", "/self-service/verification/api", bytes.NewBuffer(body))
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+```
+
+</TabItem>
+<TabItem value="node">
+
+```javascript
+const fetch = require('node-fetch');
+
+const headers = {
+  'Accept': 'application/json'
+}
+
+fetch('/self-service/verification/api', {
+  method: 'GET',
+  headers
+})
+.then(r => r.json())
+.then((body) => {
+    console.log(body)
+})
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+// This sample needs improvement.
+URL obj = new URL("/self-service/verification/api");
+
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+
+int responseCode = con.getResponseCode();
+
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream())
+);
+
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+
+System.out.println(response.toString());
+```
+
+</TabItem>
+<TabItem value="python">
+
+```python
+import requests
+
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get(
+  '/self-service/verification/api',
+  params={},
+  headers = headers)
+
+print r.json()
+```
+
+</TabItem>
+<TabItem value="ruby">
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.get '/self-service/verification/api',
+  params: {}, headers: headers
+
+p JSON.parse(result)
+```
+
+</TabItem>
+</Tabs>
+
+<a id="opIdinitializeSelfServiceVerificationViaBrowserFlow"></a>
+
+### Initialize Verification Flow for Browser Clients
+
+```
+GET /self-service/verification/browser HTTP/1.1
+Accept: application/json
+
+```
+
+This endpoint initializes a browser-based account verification flow. Once initialized, the browser will be redirected to
+`selfservice.flows.verification.ui_url` with the flow ID set as the query parameter `?flow=`.
+
+This endpoint is NOT INTENDED for API clients and only works with browsers (Chrome, Firefox, ...).
+
+More information can be found at [ORY Kratos Email and Phone Verification Documentation](https://www.ory.sh/docs/kratos/selfservice/flows/verify-email-account-activation).
+
+#### Responses
+
+<a id="initialize-verification-flow-for-browser-clients-responses"></a>
+
+##### Overview
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|302|[Found](https://tools.ietf.org/html/rfc7231#section-6.4.3)|Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
+typically 201.|None|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
+
+##### Examples
+
+###### 500 response
+
+```json
+{
+  "error": {
+    "code": 404,
+    "debug": "The database adapter was unable to find the element",
+    "details": {},
+    "message": "string",
+    "reason": "string",
+    "request": "string",
+    "status": "string"
+  }
+}
+```
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+#### Code samples
+
+<Tabs groupId="code-samples" defaultValue="shell"
+  values={[{label: 'Shell', value: 'shell'}, {label: 'Go', value: 'go'}, {label: 'Node', value: 'node'},
+    {label: 'Java', value: 'java'}, {label: 'Python', value: 'python'}, {label: 'Ruby', value: 'ruby'}]}>
+<TabItem value="shell">
+
+```shell
+curl -X GET /self-service/verification/browser \
+  -H 'Accept: application/json'
+```
+
+</TabItem>
+<TabItem value="go">
+
+```go
+package main
+
+import (
+    "bytes"
+    "net/http"
+)
+
+func main() {
+    headers := map[string][]string{ 
+        "Accept": []string{"application/json"},
+    }
+
+    var body []byte
+    // body = ...
+
+    req, err := http.NewRequest("GET", "/self-service/verification/browser", bytes.NewBuffer(body))
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+```
+
+</TabItem>
+<TabItem value="node">
+
+```javascript
+const fetch = require('node-fetch');
+
+const headers = {
+  'Accept': 'application/json'
+}
+
+fetch('/self-service/verification/browser', {
+  method: 'GET',
+  headers
+})
+.then(r => r.json())
+.then((body) => {
+    console.log(body)
+})
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+// This sample needs improvement.
+URL obj = new URL("/self-service/verification/browser");
+
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+
+int responseCode = con.getResponseCode();
+
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream())
+);
+
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+
+System.out.println(response.toString());
+```
+
+</TabItem>
+<TabItem value="python">
+
+```python
+import requests
+
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get(
+  '/self-service/verification/browser',
+  params={},
+  headers = headers)
+
+print r.json()
+```
+
+</TabItem>
+<TabItem value="ruby">
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.get '/self-service/verification/browser',
+  params: {}, headers: headers
+
+p JSON.parse(result)
+```
+
+</TabItem>
+</Tabs>
+
+<a id="opIdcompleteSelfServiceVerificationFlowWithLinkMethod"></a>
+
+### Complete Verification Flow with Link Method
+
+```
+POST /self-service/verification/methods/link HTTP/1.1
+Content-Type: application/json
+Accept: application/json
+
+```
+
+Use this endpoint to complete a verification flow using the link method. This endpoint
+behaves differently for API and browser flows and has several states:
+
+`choose_method` expects `flow` (in the URL query) and `email` (in the body) to be sent
+and works with API- and Browser-initiated flows.
+For API clients it either returns a HTTP 200 OK when the form is valid and HTTP 400 OK when the form is invalid
+and a HTTP 302 Found redirect with a fresh verification flow if the flow was otherwise invalid (e.g. expired).
+For Browser clients it returns a HTTP 302 Found redirect to the Verification UI URL with the Verification Flow ID appended.
+`sent_email` is the success state after `choose_method` and allows the user to request another verification email. It
+works for both API and Browser-initiated flows and returns the same responses as the flow in `choose_method` state.
+`passed_challenge` expects a `token` to be sent in the URL query and given the nature of the flow ("sending a verification link")
+does not have any API capabilities. The server responds with a HTTP 302 Found redirect either to the Settings UI URL
+(if the link was valid) and instructs the user to update their password, or a redirect to the Verification UI URL with
+a new Verification Flow ID which contains an error message that the verification link was invalid.
+
+More information can be found at [ORY Kratos Email and Phone Verification Documentation](https://www.ory.sh/docs/kratos/selfservice/flows/verify-email-account-activation).
+
+#### Request body
+
+```json
+{
+  "csrf_token": "string",
+  "email": "string"
+}
+```
+
+```yaml
+csrf_token: string
+email: string
+
+```
+
+<a id="complete-verification-flow-with-link-method-parameters"></a>
+
+#### Parameters
+
+|Parameter|In|Type|Required|Description|
+|---|---|---|---|---|
+|token|query|string|false|Verification Token|
+|flow|query|string|false|The Flow ID|
+|body|body|[completeSelfServiceVerificationFlowWithLinkMethod](#schemacompleteselfserviceverificationflowwithlinkmethod)|false|none|
+
+##### Detailed descriptions
+
+**token**: Verification Token
+
+The verification token which completes the verification request. If the token
+is invalid (e.g. expired) an error will be shown to the end-user.
+
+**flow**: The Flow ID
+
+format: uuid
+
+#### Responses
+
+<a id="complete-verification-flow-with-link-method-responses"></a>
+
+##### Overview
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|302|[Found](https://tools.ietf.org/html/rfc7231#section-6.4.3)|Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
+typically 201.|None|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|verificationFlow|[verificationFlow](#schemaverificationflow)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
+
+##### Examples
+
+###### 400 response
+
+```json
+{
+  "active": "string",
+  "expires_at": "2019-08-24T14:15:22Z",
+  "id": "string",
+  "issued_at": "2019-08-24T14:15:22Z",
+  "messages": [
+    {
+      "context": {},
+      "id": 0,
+      "text": "string",
+      "type": "string"
+    }
+  ],
+  "methods": {
+    "property1": {
+      "config": {
+        "action": "string",
+        "fields": [
+          {
+            "disabled": true,
+            "messages": [
+              {
+                "context": {},
+                "id": 0,
+                "text": "string",
+                "type": "string"
+              }
+            ],
+            "name": "string",
+            "pattern": "string",
+            "required": true,
+            "type": "string",
+            "value": {}
+          }
+        ],
+        "messages": [
+          {
+            "context": {},
+            "id": 0,
+            "text": "string",
+            "type": "string"
+          }
+        ],
+        "method": "string"
+      },
+      "method": "string"
+    },
+    "property2": {
+      "config": {
+        "action": "string",
+        "fields": [
+          {
+            "disabled": true,
+            "messages": [
+              {
+                "context": {},
+                "id": 0,
+                "text": "string",
+                "type": "string"
+              }
+            ],
+            "name": "string",
+            "pattern": "string",
+            "required": true,
+            "type": "string",
+            "value": {}
+          }
+        ],
+        "messages": [
+          {
+            "context": {},
+            "id": 0,
+            "text": "string",
+            "type": "string"
+          }
+        ],
+        "method": "string"
+      },
+      "method": "string"
+    }
+  },
+  "request_url": "string",
+  "state": "string",
+  "type": "string"
+}
+```
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+#### Code samples
+
+<Tabs groupId="code-samples" defaultValue="shell"
+  values={[{label: 'Shell', value: 'shell'}, {label: 'Go', value: 'go'}, {label: 'Node', value: 'node'},
+    {label: 'Java', value: 'java'}, {label: 'Python', value: 'python'}, {label: 'Ruby', value: 'ruby'}]}>
+<TabItem value="shell">
+
+```shell
+curl -X POST /self-service/verification/methods/link \
+  -H 'Content-Type: application/json' \  -H 'Accept: application/json'
+```
+
+</TabItem>
+<TabItem value="go">
+
+```go
+package main
+
+import (
+    "bytes"
+    "net/http"
+)
+
+func main() {
+    headers := map[string][]string{ 
+        "Content-Type": []string{"application/json"},
+        "Accept": []string{"application/json"},
+    }
+
+    var body []byte
+    // body = ...
+
+    req, err := http.NewRequest("POST", "/self-service/verification/methods/link", bytes.NewBuffer(body))
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+```
+
+</TabItem>
+<TabItem value="node">
+
+```javascript
+const fetch = require('node-fetch');
+const input = '{
+  "csrf_token": "string",
+  "email": "string"
+}';
+const headers = {
+  'Content-Type': 'application/json',  'Accept': 'application/json'
+}
+
+fetch('/self-service/verification/methods/link', {
+  method: 'POST',
+  body: input,
+  headers
+})
+.then(r => r.json())
+.then((body) => {
+    console.log(body)
+})
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+// This sample needs improvement.
+URL obj = new URL("/self-service/verification/methods/link");
+
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("POST");
+
+int responseCode = con.getResponseCode();
+
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream())
+);
+
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+
+System.out.println(response.toString());
+```
+
+</TabItem>
+<TabItem value="python">
+
+```python
+import requests
+
+headers = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json'
+}
+
+r = requests.post(
+  '/self-service/verification/methods/link',
+  params={},
+  headers = headers)
+
+print r.json()
+```
+
+</TabItem>
+<TabItem value="ruby">
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Content-Type' => 'application/json',
+  'Accept' => 'application/json'
+}
+
+result = RestClient.post '/self-service/verification/methods/link',
+  params: {}, headers: headers
+
+p JSON.parse(result)
+```
+
+</TabItem>
+</Tabs>
+
+<a id="opIdrevokeSession"></a>
+
+### Revoke and Invalidate a Session
+
+```
+DELETE /sessions HTTP/1.1
+Content-Type: application/json
+Accept: application/json
+
+```
+
+Use this endpoint to revoke a session using its token. This endpoint is particularly useful for API clients
+such as mobile apps to log the user out of the system and invalidate the session.
+
+This endpoint does not remove any HTTP Cookies - use the Self-Service Logout Flow instead.
+
+#### Request body
+
+```json
+{
+  "session_token": "string"
+}
+```
+
+<a id="revoke-and-invalidate-a-session-parameters"></a>
+
+#### Parameters
+
+|Parameter|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[revokeSession](#schemarevokesession)|true|none|
+
+#### Responses
+
+<a id="revoke-and-invalidate-a-session-responses"></a>
+
+##### Overview
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is
+typically 201.|None|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|genericError|[genericError](#schemagenericerror)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
+
+##### Examples
+
+###### 400 response
+
+```json
+{
+  "error": {
+    "code": 404,
+    "debug": "The database adapter was unable to find the element",
+    "details": {},
+    "message": "string",
+    "reason": "string",
+    "request": "string",
+    "status": "string"
+  }
+}
+```
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+#### Code samples
+
+<Tabs groupId="code-samples" defaultValue="shell"
+  values={[{label: 'Shell', value: 'shell'}, {label: 'Go', value: 'go'}, {label: 'Node', value: 'node'},
+    {label: 'Java', value: 'java'}, {label: 'Python', value: 'python'}, {label: 'Ruby', value: 'ruby'}]}>
+<TabItem value="shell">
+
+```shell
+curl -X DELETE /sessions \
+  -H 'Content-Type: application/json' \  -H 'Accept: application/json'
+```
+
+</TabItem>
+<TabItem value="go">
+
+```go
+package main
+
+import (
+    "bytes"
+    "net/http"
+)
+
+func main() {
+    headers := map[string][]string{ 
+        "Content-Type": []string{"application/json"},
+        "Accept": []string{"application/json"},
+    }
+
+    var body []byte
+    // body = ...
+
+    req, err := http.NewRequest("DELETE", "/sessions", bytes.NewBuffer(body))
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+```
+
+</TabItem>
+<TabItem value="node">
+
+```javascript
+const fetch = require('node-fetch');
+const input = '{
+  "session_token": "string"
+}';
+const headers = {
+  'Content-Type': 'application/json',  'Accept': 'application/json'
+}
+
+fetch('/sessions', {
+  method: 'DELETE',
+  body: input,
+  headers
+})
+.then(r => r.json())
+.then((body) => {
+    console.log(body)
+})
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+// This sample needs improvement.
+URL obj = new URL("/sessions");
+
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("DELETE");
+
+int responseCode = con.getResponseCode();
+
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream())
+);
+
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+
+System.out.println(response.toString());
+```
+
+</TabItem>
+<TabItem value="python">
+
+```python
+import requests
+
+headers = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json'
+}
+
+r = requests.delete(
+  '/sessions',
+  params={},
+  headers = headers)
+
+print r.json()
+```
+
+</TabItem>
+<TabItem value="ruby">
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Content-Type' => 'application/json',
+  'Accept' => 'application/json'
+}
+
+result = RestClient.delete '/sessions',
+  params: {}, headers: headers
+
+p JSON.parse(result)
+```
+
+</TabItem>
+</Tabs>
+
+<a id="opIdwhoami"></a>
+
+### Check Who the Current HTTP Session Belongs To
+
+```
+GET /sessions/whoami HTTP/1.1
+Accept: application/json
+
+```
+
+Uses the HTTP Headers in the GET request to determine (e.g. by using checking the cookies) who is authenticated.
+Returns a session object in the body or 401 if the credentials are invalid or no credentials were sent.
+Additionally when the request it successful it adds the user ID to the 'X-Kratos-Authenticated-Identity-Id' header in the response.
+
+This endpoint is useful for reverse proxies and API Gateways.
+
+#### Responses
+
+<a id="check-who-the-current-http-session-belongs-to-responses"></a>
+
+##### Overview
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|session|[session](#schemasession)|
+|403|[Forbidden](https://tools.ietf.org/html/rfc7231#section-6.5.3)|genericError|[genericError](#schemagenericerror)|
+|500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|genericError|[genericError](#schemagenericerror)|
+
+##### Examples
+
+###### 200 response
+
+```json
+{
+  "active": true,
+  "authenticated_at": "2019-08-24T14:15:22Z",
+  "expires_at": "2019-08-24T14:15:22Z",
+  "id": "string",
+  "identity": {
+    "id": "string",
+    "recovery_addresses": [
+      {
+        "id": "string",
+        "value": "string",
+        "via": "string"
+      }
+    ],
+    "schema_id": "string",
+    "schema_url": "string",
+    "traits": {},
+    "verifiable_addresses": [
+      {
+        "id": "string",
+        "status": "string",
+        "value": "string",
+        "verified": true,
+        "verified_at": "2019-08-24T14:15:22Z",
+        "via": "string"
+      }
+    ]
+  },
+  "issued_at": "2019-08-24T14:15:22Z"
+}
+```
+
+<aside class="success">
+This operation does not require authentication
+</aside>
 
 #### Code samples
 
@@ -5298,7 +8160,7 @@ import (
 )
 
 func main() {
-    headers := map[string][]string{
+    headers := map[string][]string{ 
         "Accept": []string{"application/json"},
     }
 
@@ -5318,20 +8180,20 @@ func main() {
 <TabItem value="node">
 
 ```javascript
-const fetch = require('node-fetch')
+const fetch = require('node-fetch');
 
 const headers = {
-  Accept: 'application/json'
+  'Accept': 'application/json'
 }
 
 fetch('/sessions/whoami', {
   method: 'GET',
   headers
 })
-  .then((r) => r.json())
-  .then((body) => {
+.then(r => r.json())
+.then((body) => {
     console.log(body)
-  })
+})
 ```
 
 </TabItem>
@@ -5412,14 +8274,13 @@ Accept: application/json
 
 ```
 
-This endpoint returns the service version typically notated using semantic
-versioning.
+This endpoint returns the service version typically notated using semantic versioning.
 
 If the service supports TLS Edge Termination, this endpoint does not require the
 `X-Forwarded-Proto` header to be set.
 
-Be aware that if you are running multiple nodes of this service, the health
-status will never refer to the cluster state, only to a single instance.
+Be aware that if you are running multiple nodes of this service, the health status will never
+refer to the cluster state, only to a single instance.
 
 #### Responses
 
@@ -5427,9 +8288,9 @@ status will never refer to the cluster state, only to a single instance.
 
 ##### Overview
 
-| Status | Meaning                                                 | Description | Schema                    |
-| ------ | ------------------------------------------------------- | ----------- | ------------------------- |
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | version     | [version](#schemaversion) |
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|version|[version](#schemaversion)|
 
 ##### Examples
 
@@ -5441,7 +8302,9 @@ status will never refer to the cluster state, only to a single instance.
 }
 ```
 
-<aside class="success">This operation does not require authentication</aside>
+<aside class="success">
+This operation does not require authentication
+</aside>
 
 #### Code samples
 
@@ -5467,7 +8330,7 @@ import (
 )
 
 func main() {
-    headers := map[string][]string{
+    headers := map[string][]string{ 
         "Accept": []string{"application/json"},
     }
 
@@ -5487,20 +8350,20 @@ func main() {
 <TabItem value="node">
 
 ```javascript
-const fetch = require('node-fetch')
+const fetch = require('node-fetch');
 
 const headers = {
-  Accept: 'application/json'
+  'Accept': 'application/json'
 }
 
 fetch('/version', {
   method: 'GET',
   headers
 })
-  .then((r) => r.json())
-  .then((body) => {
+.then(r => r.json())
+.then((body) => {
     console.log(body)
-  })
+})
 ```
 
 </TabItem>
@@ -5569,40 +8432,156 @@ p JSON.parse(result)
 
 ## Schemas
 
-<a id="tocScredentialstype">CredentialsType</a>
+<a id="tocScompleteselfservicesettingsflowwithpasswordmethod"></a>
+
+#### CompleteSelfServiceSettingsFlowWithPasswordMethod
+
+<a id="schemacompleteselfservicesettingsflowwithpasswordmethod"></a>
+
+```json
+{
+  "csrf_token": "string",
+  "password": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|csrf_token|string|false|none|CSRFToken is the anti-CSRF token<br><br>type: string|
+|password|string|true|none|Password is the updated password<br><br>type: string|
+
+<a id="tocScreateidentity"></a>
+
+#### CreateIdentity
+
+<a id="schemacreateidentity"></a>
+
+```json
+{
+  "schema_id": "string",
+  "traits": {}
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|schema_id|string|true|none|SchemaID is the ID of the JSON Schema to be used for validating the identity's traits.|
+|traits|object|true|none|Traits represent an identity's traits. The identity is able to create, modify, and delete traits<br>in a self-service manner. The input will always be validated against the JSON Schema defined<br>in `schema_url`.|
+
+<a id="tocScreaterecoverylink"></a>
+
+#### CreateRecoveryLink
+
+<a id="schemacreaterecoverylink"></a>
+
+```json
+{
+  "expires_in": "string",
+  "identity_id": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|expires_in|string|false|none|Link Expires In<br><br>The recovery link will expire at that point in time. Defaults to the configuration value of<br>`selfservice.flows.recovery.request_lifespan`.|
+|identity_id|[UUID](#schemauuid)|true|none|none|
+
+<a id="tocScredentialstype"></a>
+
 #### CredentialsType
 
 <a id="schemacredentialstype"></a>
 
 ```json
 "string"
+
 ```
 
-_CredentialsType represents several different credential types, like password
-credentials, passwordless credentials,_
+*CredentialsType  represents several different credential types, like password credentials, passwordless credentials,*
 
 #### Properties
 
-| Name                                                                                                                | Type   | Required | Restrictions | Description |
-| ------------------------------------------------------------------------------------------------------------------- | ------ | -------- | ------------ | ----------- |
-| CredentialsType represents several different credential types, like password credentials, passwordless credentials, | string | false    | none         | and so on.  |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|CredentialsType  represents several different credential types, like password credentials, passwordless credentials,|string|false|none|and so on.|
 
-<a id="tocSid">ID</a>
+<a id="tocSflowmethodconfig"></a>
+
+#### FlowMethodConfig
+
+<a id="schemaflowmethodconfig"></a>
+
+```json
+{
+  "action": "string",
+  "fields": [
+    {
+      "disabled": true,
+      "messages": [
+        {
+          "context": {},
+          "id": 0,
+          "text": "string",
+          "type": "string"
+        }
+      ],
+      "name": "string",
+      "pattern": "string",
+      "required": true,
+      "type": "string",
+      "value": {}
+    }
+  ],
+  "messages": [
+    {
+      "context": {},
+      "id": 0,
+      "text": "string",
+      "type": "string"
+    }
+  ],
+  "method": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|action|string|true|none|Action should be used as the form action URL `<form action="{{ .Action }}" method="post">`.|
+|fields|[formFields](#schemaformfields)|true|none|Fields contains multiple fields|
+|messages|[Messages](#schemamessages)|false|none|none|
+|method|string|true|none|Method is the form method (e.g. POST)|
+
+<a id="tocSid"></a>
+
 #### ID
 
 <a id="schemaid"></a>
 
 ```json
 0
+
 ```
 
 #### Properties
 
-| Name        | Type           | Required | Restrictions | Description |
-| ----------- | -------------- | -------- | ------------ | ----------- |
-| _anonymous_ | integer(int64) | false    | none         | none        |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|integer(int64)|false|none|none|
 
-<a id="tocSidentity">Identity</a>
+<a id="tocSidentity"></a>
+
 #### Identity
 
 <a id="schemaidentity"></a>
@@ -5622,8 +8601,8 @@ credentials, passwordless credentials,_
   "traits": {},
   "verifiable_addresses": [
     {
-      "expires_at": "2019-08-24T14:15:22Z",
       "id": "string",
+      "status": "string",
       "value": "string",
       "verified": true,
       "verified_at": "2019-08-24T14:15:22Z",
@@ -5631,20 +8610,22 @@ credentials, passwordless credentials,_
     }
   ]
 }
+
 ```
 
 #### Properties
 
-| Name                 | Type                                            | Required | Restrictions | Description                                                                                              |
-| -------------------- | ----------------------------------------------- | -------- | ------------ | -------------------------------------------------------------------------------------------------------- |
-| id                   | [UUID](#schemauuid)                             | true     | none         | none                                                                                                     |
-| recovery_addresses   | [[RecoveryAddress](#schemarecoveryaddress)]     | false    | none         | RecoveryAddresses contains all the addresses that can be used to recover an identity.                    |
-| schema_id            | string                                          | true     | none         | SchemaID is the ID of the JSON Schema to be used for validating the identity's traits.                   |
-| schema_url           | string                                          | false    | none         | SchemaURL is the URL of the endpoint where the identity's traits schema can be fetched from. format: url |
-| traits               | [Traits](#schematraits)                         | true     | none         | none                                                                                                     |
-| verifiable_addresses | [[VerifiableAddress](#schemaverifiableaddress)] | false    | none         | VerifiableAddresses contains all the addresses that can be verified by the user.                         |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|id|[UUID](#schemauuid)|true|none|none|
+|recovery_addresses|[[RecoveryAddress](#schemarecoveryaddress)]|false|none|RecoveryAddresses contains all the addresses that can be used to recover an identity.|
+|schema_id|string|true|none|SchemaID is the ID of the JSON Schema to be used for validating the identity's traits.|
+|schema_url|string|false|none|SchemaURL is the URL of the endpoint where the identity's traits schema can be fetched from.<br><br>format: url|
+|traits|[Traits](#schematraits)|true|none|none|
+|verifiable_addresses|[[VerifiableAddress](#schemaverifiableaddress)]|false|none|VerifiableAddresses contains all the addresses that can be verified by the user.|
 
-<a id="tocSmessage">Message</a>
+<a id="tocSmessage"></a>
+
 #### Message
 
 <a id="schemamessage"></a>
@@ -5656,18 +8637,20 @@ credentials, passwordless credentials,_
   "text": "string",
   "type": "string"
 }
+
 ```
 
 #### Properties
 
-| Name    | Type                | Required | Restrictions | Description |
-| ------- | ------------------- | -------- | ------------ | ----------- |
-| context | object              | false    | none         | none        |
-| id      | [ID](#schemaid)     | false    | none         | none        |
-| text    | string              | false    | none         | none        |
-| type    | [Type](#schematype) | false    | none         | none        |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|context|object|false|none|none|
+|id|[ID](#schemaid)|false|none|none|
+|text|string|false|none|none|
+|type|[Type](#schematype)|false|none|The flow type can either be `api` or `browser`.|
 
-<a id="tocSmessages">Messages</a>
+<a id="tocSmessages"></a>
+
 #### Messages
 
 <a id="schemamessages"></a>
@@ -5681,34 +8664,36 @@ credentials, passwordless credentials,_
     "type": "string"
   }
 ]
+
 ```
 
 #### Properties
 
-| Name        | Type                        | Required | Restrictions | Description |
-| ----------- | --------------------------- | -------- | ------------ | ----------- |
-| _anonymous_ | [[Message](#schemamessage)] | false    | none         | none        |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|[[Message](#schemamessage)]|false|none|none|
 
-<a id="tocSprovidercredentialsconfig">ProviderCredentialsConfig</a>
-#### ProviderCredentialsConfig
+<a id="tocSnulltime"></a>
 
-<a id="schemaprovidercredentialsconfig"></a>
+#### NullTime
+
+<a id="schemanulltime"></a>
 
 ```json
-{
-  "provider": "string",
-  "subject": "string"
-}
+"2019-08-24T14:15:22Z"
+
 ```
+
+*NullTime implements sql.NullTime functionality.*
 
 #### Properties
 
-| Name     | Type   | Required | Restrictions | Description |
-| -------- | ------ | -------- | ------------ | ----------- |
-| provider | string | false    | none         | none        |
-| subject  | string | false    | none         | none        |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|NullTime implements sql.NullTime functionality.|string(date-time)|false|none|none|
 
-<a id="tocSrecoveryaddress">RecoveryAddress</a>
+<a id="tocSrecoveryaddress"></a>
+
 #### RecoveryAddress
 
 <a id="schemarecoveryaddress"></a>
@@ -5719,200 +8704,230 @@ credentials, passwordless credentials,_
   "value": "string",
   "via": "string"
 }
+
 ```
 
 #### Properties
 
-| Name  | Type                                              | Required | Restrictions | Description |
-| ----- | ------------------------------------------------- | -------- | ------------ | ----------- |
-| id    | [UUID](#schemauuid)                               | true     | none         | none        |
-| value | string                                            | true     | none         | none        |
-| via   | [RecoveryAddressType](#schemarecoveryaddresstype) | true     | none         | none        |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|id|[UUID](#schemauuid)|true|none|none|
+|value|string|true|none|none|
+|via|[RecoveryAddressType](#schemarecoveryaddresstype)|true|none|none|
 
-<a id="tocSrecoveryaddresstype">RecoveryAddressType</a>
+<a id="tocSrecoveryaddresstype"></a>
+
 #### RecoveryAddressType
 
 <a id="schemarecoveryaddresstype"></a>
 
 ```json
 "string"
+
 ```
 
 #### Properties
 
-| Name        | Type   | Required | Restrictions | Description |
-| ----------- | ------ | -------- | ------------ | ----------- |
-| _anonymous_ | string | false    | none         | none        |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|string|false|none|none|
 
-<a id="tocSrequestmethodconfig">RequestMethodConfig</a>
-#### RequestMethodConfig
+<a id="tocSstate"></a>
 
-<a id="schemarequestmethodconfig"></a>
-
-```json
-{
-  "action": "string",
-  "fields": [
-    {
-      "disabled": true,
-      "messages": [
-        {
-          "context": {},
-          "id": 0,
-          "text": "string",
-          "type": "string"
-        }
-      ],
-      "name": "string",
-      "pattern": "string",
-      "required": true,
-      "type": "string",
-      "value": {}
-    }
-  ],
-  "messages": [
-    {
-      "context": {},
-      "id": 0,
-      "text": "string",
-      "type": "string"
-    }
-  ],
-  "method": "string"
-}
-```
-
-#### Properties
-
-| Name     | Type                            | Required | Restrictions | Description                                                                                 |
-| -------- | ------------------------------- | -------- | ------------ | ------------------------------------------------------------------------------------------- |
-| action   | string                          | true     | none         | Action should be used as the form action URL `<form action="{{ .Action }}" method="post">`. |
-| fields   | [formFields](#schemaformfields) | true     | none         | Fields contains multiple fields                                                             |
-| messages | [Messages](#schemamessages)     | false    | none         | none                                                                                        |
-| method   | string                          | true     | none         | Method is the form method (e.g. POST)                                                       |
-
-<a id="tocSstate">State</a>
 #### State
 
 <a id="schemastate"></a>
 
 ```json
 "string"
+
 ```
 
 #### Properties
 
-| Name        | Type   | Required | Restrictions | Description |
-| ----------- | ------ | -------- | ------------ | ----------- |
-| _anonymous_ | string | false    | none         | none        |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|string|false|none|none|
 
-<a id="tocStraits">Traits</a>
+<a id="tocStraits"></a>
+
 #### Traits
 
 <a id="schematraits"></a>
 
 ```json
 {}
+
 ```
 
 #### Properties
 
-_None_
+*None*
 
-<a id="tocStype">Type</a>
+<a id="tocStype"></a>
+
 #### Type
 
 <a id="schematype"></a>
 
 ```json
 "string"
+
 ```
+
+*Type is the flow type.*
 
 #### Properties
 
-| Name        | Type   | Required | Restrictions | Description |
-| ----------- | ------ | -------- | ------------ | ----------- |
-| _anonymous_ | string | false    | none         | none        |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|Type is the flow type.|string|false|none|The flow type can either be `api` or `browser`.|
 
-<a id="tocSuuid">UUID</a>
+<a id="tocSuuid"></a>
+
 #### UUID
 
 <a id="schemauuid"></a>
 
 ```json
 "string"
+
 ```
 
 #### Properties
 
-| Name        | Type          | Required | Restrictions | Description |
-| ----------- | ------------- | -------- | ------------ | ----------- |
-| _anonymous_ | string(uuid4) | false    | none         | none        |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|string(uuid4)|false|none|none|
 
-<a id="tocSverifiableaddress">VerifiableAddress</a>
+<a id="tocSupdateidentity"></a>
+
+#### UpdateIdentity
+
+<a id="schemaupdateidentity"></a>
+
+```json
+{
+  "schema_id": "string",
+  "traits": {}
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|schema_id|string|false|none|SchemaID is the ID of the JSON Schema to be used for validating the identity's traits. If set<br>will update the Identity's SchemaID.|
+|traits|object|true|none|Traits represent an identity's traits. The identity is able to create, modify, and delete traits<br>in a self-service manner. The input will always be validated against the JSON Schema defined<br>in `schema_id`.|
+
+<a id="tocSverifiableaddress"></a>
+
 #### VerifiableAddress
 
 <a id="schemaverifiableaddress"></a>
 
 ```json
 {
-  "expires_at": "2019-08-24T14:15:22Z",
   "id": "string",
+  "status": "string",
   "value": "string",
   "verified": true,
   "verified_at": "2019-08-24T14:15:22Z",
   "via": "string"
 }
+
 ```
 
 #### Properties
 
-| Name        | Type                                                  | Required | Restrictions | Description |
-| ----------- | ----------------------------------------------------- | -------- | ------------ | ----------- |
-| expires_at  | string(date-time)                                     | true     | none         | none        |
-| id          | [UUID](#schemauuid)                                   | true     | none         | none        |
-| value       | string                                                | true     | none         | none        |
-| verified    | boolean                                               | true     | none         | none        |
-| verified_at | string(date-time)                                     | false    | none         | none        |
-| via         | [VerifiableAddressType](#schemaverifiableaddresstype) | true     | none         | none        |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|id|[UUID](#schemauuid)|true|none|none|
+|status|[VerifiableAddressStatus](#schemaverifiableaddressstatus)|true|none|none|
+|value|string|true|none|none|
+|verified|boolean|true|none|none|
+|verified_at|[NullTime](#schemanulltime)|false|none|none|
+|via|[VerifiableAddressType](#schemaverifiableaddresstype)|true|none|none|
 
-<a id="tocSverifiableaddresstype">VerifiableAddressType</a>
+<a id="tocSverifiableaddressstatus"></a>
+
+#### VerifiableAddressStatus
+
+<a id="schemaverifiableaddressstatus"></a>
+
+```json
+"string"
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|string|false|none|none|
+
+<a id="tocSverifiableaddresstype"></a>
+
 #### VerifiableAddressType
 
 <a id="schemaverifiableaddresstype"></a>
 
 ```json
 "string"
+
 ```
 
 #### Properties
 
-| Name        | Type   | Required | Restrictions | Description |
-| ----------- | ------ | -------- | ------------ | ----------- |
-| _anonymous_ | string | false    | none         | none        |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|string|false|none|none|
 
-<a id="tocScompleteselfservicebrowsersettingsstrategyprofileflowpayload">
-  completeSelfServiceBrowserSettingsStrategyProfileFlowPayload
-</a>
-#### completeSelfServiceBrowserSettingsStrategyProfileFlowPayload
+<a id="tocScompleteselfservicerecoveryflowwithlinkmethod"></a>
 
-<a id="schemacompleteselfservicebrowsersettingsstrategyprofileflowpayload"></a>
+#### completeSelfServiceRecoveryFlowWithLinkMethod
+
+<a id="schemacompleteselfservicerecoveryflowwithlinkmethod"></a>
 
 ```json
 {
-  "request_id": "string",
-  "traits": {}
+  "csrf_token": "string",
+  "email": "string"
 }
+
 ```
 
 #### Properties
 
-| Name       | Type   | Required | Restrictions | Description                                                               |
-| ---------- | ------ | -------- | ------------ | ------------------------------------------------------------------------- |
-| request_id | string | false    | none         | RequestID is request ID. in: query                                        |
-| traits     | object | true     | none         | Traits contains all of the identity's traits. type: string format: binary |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|csrf_token|string|false|none|Sending the anti-csrf token is only required for browser login flows.|
+|email|string|false|none|Email to Recover<br><br>Needs to be set when initiating the flow. If the email is a registered<br>recovery email, a recovery link will be sent. If the email is not known,<br>a email with details on what happened will be sent instead.<br><br>format: email<br>in: body|
 
-<a id="tocSerrorcontainer">errorContainer</a>
+<a id="tocScompleteselfserviceverificationflowwithlinkmethod"></a>
+
+#### completeSelfServiceVerificationFlowWithLinkMethod
+
+<a id="schemacompleteselfserviceverificationflowwithlinkmethod"></a>
+
+```json
+{
+  "csrf_token": "string",
+  "email": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|csrf_token|string|false|none|Sending the anti-csrf token is only required for browser login flows.|
+|email|string|false|none|Email to Verify<br><br>Needs to be set when initiating the flow. If the email is a registered<br>verification email, a verification link will be sent. If the email is not known,<br>a email with details on what happened will be sent instead.<br><br>format: email<br>in: body|
+
+<a id="tocSerrorcontainer"></a>
+
 #### errorContainer
 
 <a id="schemaerrorcontainer"></a>
@@ -5922,66 +8937,18 @@ _None_
   "errors": {},
   "id": "string"
 }
+
 ```
 
 #### Properties
 
-| Name   | Type                | Required | Restrictions | Description |
-| ------ | ------------------- | -------- | ------------ | ----------- |
-| errors | object              | false    | none         | none        |
-| id     | [UUID](#schemauuid) | false    | none         | none        |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|errors|object|true|none|Errors in the container|
+|id|[UUID](#schemauuid)|true|none|none|
 
-<a id="tocSform">form</a>
-#### form
+<a id="tocSformfield"></a>
 
-<a id="schemaform"></a>
-
-```json
-{
-  "action": "string",
-  "fields": [
-    {
-      "disabled": true,
-      "messages": [
-        {
-          "context": {},
-          "id": 0,
-          "text": "string",
-          "type": "string"
-        }
-      ],
-      "name": "string",
-      "pattern": "string",
-      "required": true,
-      "type": "string",
-      "value": {}
-    }
-  ],
-  "messages": [
-    {
-      "context": {},
-      "id": 0,
-      "text": "string",
-      "type": "string"
-    }
-  ],
-  "method": "string"
-}
-```
-
-_HTMLForm represents a HTML Form. The container can work with both HTTP Form and
-JSON requests_
-
-#### Properties
-
-| Name     | Type                            | Required | Restrictions | Description                                                                                 |
-| -------- | ------------------------------- | -------- | ------------ | ------------------------------------------------------------------------------------------- |
-| action   | string                          | true     | none         | Action should be used as the form action URL `<form action="{{ .Action }}" method="post">`. |
-| fields   | [formFields](#schemaformfields) | true     | none         | Fields contains multiple fields                                                             |
-| messages | [Messages](#schemamessages)     | false    | none         | none                                                                                        |
-| method   | string                          | true     | none         | Method is the form method (e.g. POST)                                                       |
-
-<a id="tocSformfield">formField</a>
 #### formField
 
 <a id="schemaformfield"></a>
@@ -6003,23 +8970,25 @@ JSON requests_
   "type": "string",
   "value": {}
 }
+
 ```
 
-_Field represents a HTML Form Field_
+*Field represents a HTML Form Field*
 
 #### Properties
 
-| Name     | Type                        | Required | Restrictions | Description                                                              |
-| -------- | --------------------------- | -------- | ------------ | ------------------------------------------------------------------------ |
-| disabled | boolean                     | false    | none         | Disabled is the equivalent of `<input {{if .Disabled}}disabled{{end}}">` |
-| messages | [Messages](#schemamessages) | false    | none         | none                                                                     |
-| name     | string                      | true     | none         | Name is the equivalent of `<input name="{{.Name}}">`                     |
-| pattern  | string                      | false    | none         | Pattern is the equivalent of `<input pattern="{{.Pattern}}">`            |
-| required | boolean                     | false    | none         | Required is the equivalent of `<input required="{{.Required}}">`         |
-| type     | string                      | true     | none         | Type is the equivalent of `<input type="{{.Type}}">`                     |
-| value    | object                      | false    | none         | Value is the equivalent of `<input value="{{.Value}}">`                  |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|disabled|boolean|false|none|Disabled is the equivalent of `<input {{if .Disabled}}disabled{{end}}">`|
+|messages|[Messages](#schemamessages)|false|none|none|
+|name|string|true|none|Name is the equivalent of `<input name="{{.Name}}">`|
+|pattern|string|false|none|Pattern is the equivalent of `<input pattern="{{.Pattern}}">`|
+|required|boolean|false|none|Required is the equivalent of `<input required="{{.Required}}">`|
+|type|string|true|none|Type is the equivalent of `<input type="{{.Type}}">`|
+|value|object|false|none|Value is the equivalent of `<input value="{{.Value}}">`|
 
-<a id="tocSformfields">formFields</a>
+<a id="tocSformfields"></a>
+
 #### formFields
 
 <a id="schemaformfields"></a>
@@ -6043,17 +9012,19 @@ _Field represents a HTML Form Field_
     "value": {}
   }
 ]
+
 ```
 
-_Fields contains multiple fields_
+*Fields contains multiple fields*
 
 #### Properties
 
-| Name        | Type                            | Required | Restrictions | Description                     |
-| ----------- | ------------------------------- | -------- | ------------ | ------------------------------- |
-| _anonymous_ | [[formField](#schemaformfield)] | false    | none         | Fields contains multiple fields |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|[[formField](#schemaformfield)]|false|none|Fields contains multiple fields|
 
-<a id="tocSgenericerror">genericError</a>
+<a id="tocSgenericerror"></a>
+
 #### genericError
 
 <a id="schemagenericerror"></a>
@@ -6070,17 +9041,19 @@ _Fields contains multiple fields_
     "status": "string"
   }
 }
+
 ```
 
-_Error response_
+*Error response*
 
 #### Properties
 
-| Name  | Type                                              | Required | Restrictions | Description |
-| ----- | ------------------------------------------------- | -------- | ------------ | ----------- |
-| error | [genericErrorPayload](#schemagenericerrorpayload) | false    | none         | none        |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|error|[genericErrorPayload](#schemagenericerrorpayload)|false|none|none|
 
-<a id="tocSgenericerrorpayload">genericErrorPayload</a>
+<a id="tocSgenericerrorpayload"></a>
+
 #### genericErrorPayload
 
 <a id="schemagenericerrorpayload"></a>
@@ -6095,21 +9068,23 @@ _Error response_
   "request": "string",
   "status": "string"
 }
+
 ```
 
 #### Properties
 
-| Name    | Type           | Required | Restrictions | Description                                                                            |
-| ------- | -------------- | -------- | ------------ | -------------------------------------------------------------------------------------- |
-| code    | integer(int64) | false    | none         | Code represents the error status code (404, 403, 401, ...).                            |
-| debug   | string         | false    | none         | Debug contains debug information. This is usually not available and has to be enabled. |
-| details | object         | false    | none         | none                                                                                   |
-| message | string         | false    | none         | none                                                                                   |
-| reason  | string         | false    | none         | none                                                                                   |
-| request | string         | false    | none         | none                                                                                   |
-| status  | string         | false    | none         | none                                                                                   |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|code|integer(int64)|false|none|Code represents the error status code (404, 403, 401, ...).|
+|debug|string|false|none|Debug contains debug information. This is usually not available and has to be enabled.|
+|details|object|false|none|none|
+|message|string|false|none|none|
+|reason|string|false|none|none|
+|request|string|false|none|none|
+|status|string|false|none|none|
 
-<a id="tocShealthnotreadystatus">healthNotReadyStatus</a>
+<a id="tocShealthnotreadystatus"></a>
+
 #### healthNotReadyStatus
 
 <a id="schemahealthnotreadystatus"></a>
@@ -6121,16 +9096,18 @@ _Error response_
     "property2": "string"
   }
 }
+
 ```
 
 #### Properties
 
-| Name                       | Type   | Required | Restrictions | Description                                                        |
-| -------------------------- | ------ | -------- | ------------ | ------------------------------------------------------------------ |
-| errors                     | object | false    | none         | Errors contains a list of errors that caused the not ready status. |
-| » **additionalProperties** | string | false    | none         | none                                                               |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|errors|object|false|none|Errors contains a list of errors that caused the not ready status.|
+|» **additionalProperties**|string|false|none|none|
 
-<a id="tocShealthstatus">healthStatus</a>
+<a id="tocShealthstatus"></a>
+
 #### healthStatus
 
 <a id="schemahealthstatus"></a>
@@ -6139,18 +9116,20 @@ _Error response_
 {
   "status": "string"
 }
+
 ```
 
 #### Properties
 
-| Name   | Type   | Required | Restrictions | Description                  |
-| ------ | ------ | -------- | ------------ | ---------------------------- |
-| status | string | false    | none         | Status always contains "ok". |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|status|string|false|none|Status always contains "ok".|
 
-<a id="tocSloginrequest">loginRequest</a>
-#### loginRequest
+<a id="tocSloginflow"></a>
 
-<a id="schemaloginrequest"></a>
+#### loginFlow
+
+<a id="schemaloginflow"></a>
 
 ```json
 {
@@ -6271,28 +9250,34 @@ _Error response_
       "method": "string"
     }
   },
-  "request_url": "string"
+  "request_url": "string",
+  "type": "string"
 }
+
 ```
+
+*Login Flow*
 
 #### Properties
 
-| Name                       | Type                                            | Required | Restrictions | Description                                                                                                                                                                 |
-| -------------------------- | ----------------------------------------------- | -------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| active                     | [CredentialsType](#schemacredentialstype)       | false    | none         | and so on.                                                                                                                                                                  |
-| expires_at                 | string(date-time)                               | true     | none         | ExpiresAt is the time (UTC) when the request expires. If the user still wishes to log in, a new request has to be initiated.                                                |
-| forced                     | boolean                                         | false    | none         | Forced stores whether this login request should enforce reauthentication.                                                                                                   |
-| id                         | [UUID](#schemauuid)                             | true     | none         | none                                                                                                                                                                        |
-| issued_at                  | string(date-time)                               | true     | none         | IssuedAt is the time (UTC) when the request occurred.                                                                                                                       |
-| messages                   | [Messages](#schemamessages)                     | false    | none         | none                                                                                                                                                                        |
-| methods                    | object                                          | true     | none         | Methods contains context for all enabled login methods. If a login request has been processed, but for example the password is incorrect, this will contain error messages. |
-| » **additionalProperties** | [loginRequestMethod](#schemaloginrequestmethod) | false    | none         | none                                                                                                                                                                        |
-| request_url                | string                                          | true     | none         | RequestURL is the initial URL that was requested from ORY Kratos. It can be used to forward information contained in the URL's path or query for example.                   |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|active|[CredentialsType](#schemacredentialstype)|false|none|and so on.|
+|expires_at|string(date-time)|true|none|ExpiresAt is the time (UTC) when the flow expires. If the user still wishes to log in,<br>a new flow has to be initiated.|
+|forced|boolean|false|none|Forced stores whether this login flow should enforce re-authentication.|
+|id|[UUID](#schemauuid)|true|none|none|
+|issued_at|string(date-time)|true|none|IssuedAt is the time (UTC) when the flow started.|
+|messages|[Messages](#schemamessages)|false|none|none|
+|methods|object|true|none|List of login methods<br><br>This is the list of available login methods with their required form fields, such as `identifier` and `password`<br>for the password login method. This will also contain error messages such as "password can not be empty".|
+|» **additionalProperties**|[loginFlowMethod](#schemaloginflowmethod)|false|none|none|
+|request_url|string|true|none|RequestURL is the initial URL that was requested from ORY Kratos. It can be used<br>to forward information contained in the URL's path or query for example.|
+|type|[Type](#schematype)|false|none|The flow type can either be `api` or `browser`.|
 
-<a id="tocSloginrequestmethod">loginRequestMethod</a>
-#### loginRequestMethod
+<a id="tocSloginflowmethod"></a>
 
-<a id="schemaloginrequestmethod"></a>
+#### loginFlowMethod
+
+<a id="schemaloginflowmethod"></a>
 
 ```json
 {
@@ -6346,19 +9331,21 @@ _Error response_
   },
   "method": "string"
 }
+
 ```
 
 #### Properties
 
-| Name   | Type                                                        | Required | Restrictions | Description |
-| ------ | ----------------------------------------------------------- | -------- | ------------ | ----------- |
-| config | [loginRequestMethodConfig](#schemaloginrequestmethodconfig) | true     | none         | none        |
-| method | [CredentialsType](#schemacredentialstype)                   | true     | none         | and so on.  |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|config|[loginFlowMethodConfig](#schemaloginflowmethodconfig)|true|none|none|
+|method|[CredentialsType](#schemacredentialstype)|true|none|and so on.|
 
-<a id="tocSloginrequestmethodconfig">loginRequestMethodConfig</a>
-#### loginRequestMethodConfig
+<a id="tocSloginflowmethodconfig"></a>
 
-<a id="schemaloginrequestmethodconfig"></a>
+#### loginFlowMethodConfig
+
+<a id="schemaloginflowmethodconfig"></a>
 
 ```json
 {
@@ -6409,22 +9396,76 @@ _Error response_
     }
   ]
 }
+
 ```
 
 #### Properties
 
-| Name      | Type                            | Required | Restrictions | Description                                                                                 |
-| --------- | ------------------------------- | -------- | ------------ | ------------------------------------------------------------------------------------------- |
-| action    | string                          | true     | none         | Action should be used as the form action URL `<form action="{{ .Action }}" method="post">`. |
-| fields    | [formFields](#schemaformfields) | true     | none         | Fields contains multiple fields                                                             |
-| messages  | [Messages](#schemamessages)     | false    | none         | none                                                                                        |
-| method    | string                          | true     | none         | Method is the form method (e.g. POST)                                                       |
-| providers | [[formField](#schemaformfield)] | false    | none         | Providers is set for the "oidc" request method.                                             |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|action|string|true|none|Action should be used as the form action URL `<form action="{{ .Action }}" method="post">`.|
+|fields|[formFields](#schemaformfields)|true|none|Fields contains multiple fields|
+|messages|[Messages](#schemamessages)|false|none|none|
+|method|string|true|none|Method is the form method (e.g. POST)|
+|providers|[[formField](#schemaformfield)]|false|none|Providers is set for the "oidc" flow method.|
 
-<a id="tocSrecoveryrequest">recoveryRequest</a>
-#### recoveryRequest
+<a id="tocSloginviaapiresponse"></a>
 
-<a id="schemarecoveryrequest"></a>
+#### loginViaApiResponse
+
+<a id="schemaloginviaapiresponse"></a>
+
+```json
+{
+  "session": {
+    "active": true,
+    "authenticated_at": "2019-08-24T14:15:22Z",
+    "expires_at": "2019-08-24T14:15:22Z",
+    "id": "string",
+    "identity": {
+      "id": "string",
+      "recovery_addresses": [
+        {
+          "id": "string",
+          "value": "string",
+          "via": "string"
+        }
+      ],
+      "schema_id": "string",
+      "schema_url": "string",
+      "traits": {},
+      "verifiable_addresses": [
+        {
+          "id": "string",
+          "status": "string",
+          "value": "string",
+          "verified": true,
+          "verified_at": "2019-08-24T14:15:22Z",
+          "via": "string"
+        }
+      ]
+    },
+    "issued_at": "2019-08-24T14:15:22Z"
+  },
+  "session_token": "string"
+}
+
+```
+
+*The Response for Login Flows via API*
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|session|[session](#schemasession)|true|none|none|
+|session_token|string|true|none|The Session Token<br><br>A session token is equivalent to a session cookie, but it can be sent in the HTTP Authorization<br>Header:<br><br>Authorization: bearer <session-token><br><br>The session token is only issued for API flows, not for Browser flows!|
+
+<a id="tocSrecoveryflow"></a>
+
+#### recoveryFlow
+
+<a id="schemarecoveryflow"></a>
 
 ```json
 {
@@ -6509,30 +9550,34 @@ _Error response_
     }
   },
   "request_url": "string",
-  "state": "string"
+  "state": "string",
+  "type": "string"
 }
+
 ```
 
-_Request presents a recovery request_
+*A Recovery Flow*
 
 #### Properties
 
-| Name                       | Type                                                  | Required | Restrictions | Description                                                                                                                                                                           |
-| -------------------------- | ----------------------------------------------------- | -------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| active                     | string                                                | false    | none         | Active, if set, contains the registration method that is being used. It is initially not set.                                                                                         |
-| expires_at                 | string(date-time)                                     | true     | none         | ExpiresAt is the time (UTC) when the request expires. If the user still wishes to update the setting, a new request has to be initiated.                                              |
-| id                         | [UUID](#schemauuid)                                   | true     | none         | none                                                                                                                                                                                  |
-| issued_at                  | string(date-time)                                     | true     | none         | IssuedAt is the time (UTC) when the request occurred.                                                                                                                                 |
-| messages                   | [Messages](#schemamessages)                           | false    | none         | none                                                                                                                                                                                  |
-| methods                    | object                                                | true     | none         | Methods contains context for all account recovery methods. If a registration request has been processed, but for example the password is incorrect, this will contain error messages. |
-| » **additionalProperties** | [recoveryRequestMethod](#schemarecoveryrequestmethod) | false    | none         | none                                                                                                                                                                                  |
-| request_url                | string                                                | true     | none         | RequestURL is the initial URL that was requested from ORY Kratos. It can be used to forward information contained in the URL's path or query for example.                             |
-| state                      | [State](#schemastate)                                 | true     | none         | none                                                                                                                                                                                  |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|active|string|false|none|Active, if set, contains the registration method that is being used. It is initially<br>not set.|
+|expires_at|string(date-time)|true|none|ExpiresAt is the time (UTC) when the request expires. If the user still wishes to update the setting,<br>a new request has to be initiated.|
+|id|[UUID](#schemauuid)|true|none|none|
+|issued_at|string(date-time)|true|none|IssuedAt is the time (UTC) when the request occurred.|
+|messages|[Messages](#schemamessages)|false|none|none|
+|methods|object|true|none|Methods contains context for all account recovery methods. If a registration request has been<br>processed, but for example the password is incorrect, this will contain error messages.|
+|» **additionalProperties**|[recoveryFlowMethod](#schemarecoveryflowmethod)|false|none|none|
+|request_url|string|true|none|RequestURL is the initial URL that was requested from ORY Kratos. It can be used<br>to forward information contained in the URL's path or query for example.|
+|state|[State](#schemastate)|true|none|none|
+|type|[Type](#schematype)|false|none|The flow type can either be `api` or `browser`.|
 
-<a id="tocSrecoveryrequestmethod">recoveryRequestMethod</a>
-#### recoveryRequestMethod
+<a id="tocSrecoveryflowmethod"></a>
 
-<a id="schemarecoveryrequestmethod"></a>
+#### recoveryFlowMethod
+
+<a id="schemarecoveryflowmethod"></a>
 
 ```json
 {
@@ -6568,19 +9613,91 @@ _Request presents a recovery request_
   },
   "method": "string"
 }
+
 ```
 
 #### Properties
 
-| Name   | Type                                              | Required | Restrictions | Description                                   |
-| ------ | ------------------------------------------------- | -------- | ------------ | --------------------------------------------- |
-| config | [RequestMethodConfig](#schemarequestmethodconfig) | false    | none         | none                                          |
-| method | string                                            | false    | none         | Method contains the request credentials type. |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|config|[recoveryFlowMethodConfig](#schemarecoveryflowmethodconfig)|false|none|none|
+|method|string|false|none|Method contains the request credentials type.|
 
-<a id="tocSregistrationrequest">registrationRequest</a>
-#### registrationRequest
+<a id="tocSrecoveryflowmethodconfig"></a>
 
-<a id="schemaregistrationrequest"></a>
+#### recoveryFlowMethodConfig
+
+<a id="schemarecoveryflowmethodconfig"></a>
+
+```json
+{
+  "action": "string",
+  "fields": [
+    {
+      "disabled": true,
+      "messages": [
+        {
+          "context": {},
+          "id": 0,
+          "text": "string",
+          "type": "string"
+        }
+      ],
+      "name": "string",
+      "pattern": "string",
+      "required": true,
+      "type": "string",
+      "value": {}
+    }
+  ],
+  "messages": [
+    {
+      "context": {},
+      "id": 0,
+      "text": "string",
+      "type": "string"
+    }
+  ],
+  "method": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|action|string|true|none|Action should be used as the form action URL `<form action="{{ .Action }}" method="post">`.|
+|fields|[formFields](#schemaformfields)|true|none|Fields contains multiple fields|
+|messages|[Messages](#schemamessages)|false|none|none|
+|method|string|true|none|Method is the form method (e.g. POST)|
+
+<a id="tocSrecoverylink"></a>
+
+#### recoveryLink
+
+<a id="schemarecoverylink"></a>
+
+```json
+{
+  "expires_at": "2019-08-24T14:15:22Z",
+  "recovery_link": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|expires_at|string(date-time)|false|none|Recovery Link Expires At<br><br>The timestamp when the recovery link expires.|
+|recovery_link|string|true|none|Recovery Link<br><br>This link can be used to recover the account.|
+
+<a id="tocSregistrationflow"></a>
+
+#### registrationFlow
+
+<a id="schemaregistrationflow"></a>
 
 ```json
 {
@@ -6700,27 +9817,31 @@ _Request presents a recovery request_
       "method": "string"
     }
   },
-  "request_url": "string"
+  "request_url": "string",
+  "type": "string"
 }
+
 ```
 
 #### Properties
 
-| Name                       | Type                                                          | Required | Restrictions | Description                                                                                                                                                                               |
-| -------------------------- | ------------------------------------------------------------- | -------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| active                     | [CredentialsType](#schemacredentialstype)                     | false    | none         | and so on.                                                                                                                                                                                |
-| expires_at                 | string(date-time)                                             | true     | none         | ExpiresAt is the time (UTC) when the request expires. If the user still wishes to log in, a new request has to be initiated.                                                              |
-| id                         | [UUID](#schemauuid)                                           | true     | none         | none                                                                                                                                                                                      |
-| issued_at                  | string(date-time)                                             | true     | none         | IssuedAt is the time (UTC) when the request occurred.                                                                                                                                     |
-| messages                   | [Messages](#schemamessages)                                   | false    | none         | none                                                                                                                                                                                      |
-| methods                    | object                                                        | true     | none         | Methods contains context for all enabled registration methods. If a registration request has been processed, but for example the password is incorrect, this will contain error messages. |
-| » **additionalProperties** | [registrationRequestMethod](#schemaregistrationrequestmethod) | false    | none         | none                                                                                                                                                                                      |
-| request_url                | string                                                        | true     | none         | RequestURL is the initial URL that was requested from ORY Kratos. It can be used to forward information contained in the URL's path or query for example.                                 |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|active|[CredentialsType](#schemacredentialstype)|false|none|and so on.|
+|expires_at|string(date-time)|true|none|ExpiresAt is the time (UTC) when the flow expires. If the user still wishes to log in,<br>a new flow has to be initiated.|
+|id|[UUID](#schemauuid)|true|none|none|
+|issued_at|string(date-time)|true|none|IssuedAt is the time (UTC) when the flow occurred.|
+|messages|[Messages](#schemamessages)|false|none|none|
+|methods|object|true|none|Methods contains context for all enabled registration methods. If a registration flow has been<br>processed, but for example the password is incorrect, this will contain error messages.|
+|» **additionalProperties**|[registrationFlowMethod](#schemaregistrationflowmethod)|false|none|none|
+|request_url|string|true|none|RequestURL is the initial URL that was requested from ORY Kratos. It can be used<br>to forward information contained in the URL's path or query for example.|
+|type|[Type](#schematype)|false|none|The flow type can either be `api` or `browser`.|
 
-<a id="tocSregistrationrequestmethod">registrationRequestMethod</a>
-#### registrationRequestMethod
+<a id="tocSregistrationflowmethod"></a>
 
-<a id="schemaregistrationrequestmethod"></a>
+#### registrationFlowMethod
+
+<a id="schemaregistrationflowmethod"></a>
 
 ```json
 {
@@ -6774,19 +9895,21 @@ _Request presents a recovery request_
   },
   "method": "string"
 }
+
 ```
 
 #### Properties
 
-| Name   | Type                                                                      | Required | Restrictions | Description |
-| ------ | ------------------------------------------------------------------------- | -------- | ------------ | ----------- |
-| config | [registrationRequestMethodConfig](#schemaregistrationrequestmethodconfig) | false    | none         | none        |
-| method | [CredentialsType](#schemacredentialstype)                                 | false    | none         | and so on.  |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|config|[registrationFlowMethodConfig](#schemaregistrationflowmethodconfig)|false|none|none|
+|method|[CredentialsType](#schemacredentialstype)|false|none|and so on.|
 
-<a id="tocSregistrationrequestmethodconfig">registrationRequestMethodConfig</a>
-#### registrationRequestMethodConfig
+<a id="tocSregistrationflowmethodconfig"></a>
 
-<a id="schemaregistrationrequestmethodconfig"></a>
+#### registrationFlowMethodConfig
+
+<a id="schemaregistrationflowmethodconfig"></a>
 
 ```json
 {
@@ -6837,27 +9960,126 @@ _Request presents a recovery request_
     }
   ]
 }
+
 ```
 
 #### Properties
 
-| Name      | Type                            | Required | Restrictions | Description                                                                                 |
-| --------- | ------------------------------- | -------- | ------------ | ------------------------------------------------------------------------------------------- |
-| action    | string                          | true     | none         | Action should be used as the form action URL `<form action="{{ .Action }}" method="post">`. |
-| fields    | [formFields](#schemaformfields) | true     | none         | Fields contains multiple fields                                                             |
-| messages  | [Messages](#schemamessages)     | false    | none         | none                                                                                        |
-| method    | string                          | true     | none         | Method is the form method (e.g. POST)                                                       |
-| providers | [[formField](#schemaformfield)] | false    | none         | Providers is set for the "oidc" request method.                                             |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|action|string|true|none|Action should be used as the form action URL `<form action="{{ .Action }}" method="post">`.|
+|fields|[formFields](#schemaformfields)|true|none|Fields contains multiple fields|
+|messages|[Messages](#schemamessages)|false|none|none|
+|method|string|true|none|Method is the form method (e.g. POST)|
+|providers|[[formField](#schemaformfield)]|false|none|Providers is set for the "oidc" registration method.|
 
-<a id="tocSsession">session</a>
+<a id="tocSregistrationviaapiresponse"></a>
+
+#### registrationViaApiResponse
+
+<a id="schemaregistrationviaapiresponse"></a>
+
+```json
+{
+  "identity": {
+    "id": "string",
+    "recovery_addresses": [
+      {
+        "id": "string",
+        "value": "string",
+        "via": "string"
+      }
+    ],
+    "schema_id": "string",
+    "schema_url": "string",
+    "traits": {},
+    "verifiable_addresses": [
+      {
+        "id": "string",
+        "status": "string",
+        "value": "string",
+        "verified": true,
+        "verified_at": "2019-08-24T14:15:22Z",
+        "via": "string"
+      }
+    ]
+  },
+  "session": {
+    "active": true,
+    "authenticated_at": "2019-08-24T14:15:22Z",
+    "expires_at": "2019-08-24T14:15:22Z",
+    "id": "string",
+    "identity": {
+      "id": "string",
+      "recovery_addresses": [
+        {
+          "id": "string",
+          "value": "string",
+          "via": "string"
+        }
+      ],
+      "schema_id": "string",
+      "schema_url": "string",
+      "traits": {},
+      "verifiable_addresses": [
+        {
+          "id": "string",
+          "status": "string",
+          "value": "string",
+          "verified": true,
+          "verified_at": "2019-08-24T14:15:22Z",
+          "via": "string"
+        }
+      ]
+    },
+    "issued_at": "2019-08-24T14:15:22Z"
+  },
+  "session_token": "string"
+}
+
+```
+
+*The Response for Registration Flows via API*
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|identity|[Identity](#schemaidentity)|true|none|none|
+|session|[session](#schemasession)|false|none|none|
+|session_token|string|true|none|The Session Token<br><br>This field is only set when the session hook is configured as a post-registration hook.<br><br>A session token is equivalent to a session cookie, but it can be sent in the HTTP Authorization<br>Header:<br><br>Authorization: bearer <session-token><br><br>The session token is only issued for API flows, not for Browser flows!|
+
+<a id="tocSrevokesession"></a>
+
+#### revokeSession
+
+<a id="schemarevokesession"></a>
+
+```json
+{
+  "session_token": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|session_token|string|true|none|The Session Token<br><br>Invalidate this session token.|
+
+<a id="tocSsession"></a>
+
 #### session
 
 <a id="schemasession"></a>
 
 ```json
 {
+  "active": true,
   "authenticated_at": "2019-08-24T14:15:22Z",
   "expires_at": "2019-08-24T14:15:22Z",
+  "id": "string",
   "identity": {
     "id": "string",
     "recovery_addresses": [
@@ -6872,8 +10094,8 @@ _Request presents a recovery request_
     "traits": {},
     "verifiable_addresses": [
       {
-        "expires_at": "2019-08-24T14:15:22Z",
         "id": "string",
+        "status": "string",
         "value": "string",
         "verified": true,
         "verified_at": "2019-08-24T14:15:22Z",
@@ -6881,25 +10103,27 @@ _Request presents a recovery request_
       }
     ]
   },
-  "issued_at": "2019-08-24T14:15:22Z",
-  "sid": "string"
+  "issued_at": "2019-08-24T14:15:22Z"
 }
+
 ```
 
 #### Properties
 
-| Name             | Type                        | Required | Restrictions | Description |
-| ---------------- | --------------------------- | -------- | ------------ | ----------- |
-| authenticated_at | string(date-time)           | true     | none         | none        |
-| expires_at       | string(date-time)           | true     | none         | none        |
-| identity         | [Identity](#schemaidentity) | true     | none         | none        |
-| issued_at        | string(date-time)           | true     | none         | none        |
-| sid              | [UUID](#schemauuid)         | true     | none         | none        |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|active|boolean|false|none|none|
+|authenticated_at|string(date-time)|true|none|none|
+|expires_at|string(date-time)|true|none|none|
+|id|[UUID](#schemauuid)|true|none|none|
+|identity|[Identity](#schemaidentity)|true|none|none|
+|issued_at|string(date-time)|true|none|none|
 
-<a id="tocSsettingsrequest">settingsRequest</a>
-#### settingsRequest
+<a id="tocSsettingsflow"></a>
 
-<a id="schemasettingsrequest"></a>
+#### settingsFlow
+
+<a id="schemasettingsflow"></a>
 
 ```json
 {
@@ -6920,8 +10144,8 @@ _Request presents a recovery request_
     "traits": {},
     "verifiable_addresses": [
       {
-        "expires_at": "2019-08-24T14:15:22Z",
         "id": "string",
+        "status": "string",
         "value": "string",
         "verified": true,
         "verified_at": "2019-08-24T14:15:22Z",
@@ -7007,31 +10231,35 @@ _Request presents a recovery request_
     }
   },
   "request_url": "string",
-  "state": "string"
+  "state": "string",
+  "type": "string"
 }
+
 ```
 
-_Request presents a settings request_
+*Flow represents a Settings Flow*
 
 #### Properties
 
-| Name                       | Type                                                  | Required | Restrictions | Description                                                                                                                                                                               |
-| -------------------------- | ----------------------------------------------------- | -------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| active                     | string                                                | false    | none         | Active, if set, contains the registration method that is being used. It is initially not set.                                                                                             |
-| expires_at                 | string(date-time)                                     | true     | none         | ExpiresAt is the time (UTC) when the request expires. If the user still wishes to update the setting, a new request has to be initiated.                                                  |
-| id                         | [UUID](#schemauuid)                                   | true     | none         | none                                                                                                                                                                                      |
-| identity                   | [Identity](#schemaidentity)                           | true     | none         | none                                                                                                                                                                                      |
-| issued_at                  | string(date-time)                                     | true     | none         | IssuedAt is the time (UTC) when the request occurred.                                                                                                                                     |
-| messages                   | [Messages](#schemamessages)                           | false    | none         | none                                                                                                                                                                                      |
-| methods                    | object                                                | true     | none         | Methods contains context for all enabled registration methods. If a registration request has been processed, but for example the password is incorrect, this will contain error messages. |
-| » **additionalProperties** | [settingsRequestMethod](#schemasettingsrequestmethod) | false    | none         | none                                                                                                                                                                                      |
-| request_url                | string                                                | true     | none         | RequestURL is the initial URL that was requested from ORY Kratos. It can be used to forward information contained in the URL's path or query for example.                                 |
-| state                      | [State](#schemastate)                                 | true     | none         | none                                                                                                                                                                                      |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|active|string|false|none|Active, if set, contains the registration method that is being used. It is initially<br>not set.|
+|expires_at|string(date-time)|true|none|ExpiresAt is the time (UTC) when the flow expires. If the user still wishes to update the setting,<br>a new flow has to be initiated.|
+|id|[UUID](#schemauuid)|true|none|none|
+|identity|[Identity](#schemaidentity)|true|none|none|
+|issued_at|string(date-time)|true|none|IssuedAt is the time (UTC) when the flow occurred.|
+|messages|[Messages](#schemamessages)|false|none|none|
+|methods|object|true|none|Methods contains context for all enabled registration methods. If a settings flow has been<br>processed, but for example the first name is empty, this will contain error messages.|
+|» **additionalProperties**|[settingsFlowMethod](#schemasettingsflowmethod)|false|none|none|
+|request_url|string|true|none|RequestURL is the initial URL that was requested from ORY Kratos. It can be used<br>to forward information contained in the URL's path or query for example.|
+|state|[State](#schemastate)|true|none|none|
+|type|[Type](#schematype)|false|none|The flow type can either be `api` or `browser`.|
 
-<a id="tocSsettingsrequestmethod">settingsRequestMethod</a>
-#### settingsRequestMethod
+<a id="tocSsettingsflowmethod"></a>
 
-<a id="schemasettingsrequestmethod"></a>
+#### settingsFlowMethod
+
+<a id="schemasettingsflowmethod"></a>
 
 ```json
 {
@@ -7067,24 +10295,289 @@ _Request presents a settings request_
   },
   "method": "string"
 }
+
 ```
 
 #### Properties
 
-| Name   | Type                                              | Required | Restrictions | Description                                   |
-| ------ | ------------------------------------------------- | -------- | ------------ | --------------------------------------------- |
-| config | [RequestMethodConfig](#schemarequestmethodconfig) | false    | none         | none                                          |
-| method | string                                            | false    | none         | Method contains the request credentials type. |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|config|[FlowMethodConfig](#schemaflowmethodconfig)|false|none|none|
+|method|string|false|none|Method is the name of this flow method.|
 
-<a id="tocSverificationrequest">verificationRequest</a>
-#### verificationRequest
+<a id="tocSsettingsviaapiresponse"></a>
 
-<a id="schemaverificationrequest"></a>
+#### settingsViaApiResponse
+
+<a id="schemasettingsviaapiresponse"></a>
 
 ```json
 {
+  "flow": {
+    "active": "string",
+    "expires_at": "2019-08-24T14:15:22Z",
+    "id": "string",
+    "identity": {
+      "id": "string",
+      "recovery_addresses": [
+        {
+          "id": "string",
+          "value": "string",
+          "via": "string"
+        }
+      ],
+      "schema_id": "string",
+      "schema_url": "string",
+      "traits": {},
+      "verifiable_addresses": [
+        {
+          "id": "string",
+          "status": "string",
+          "value": "string",
+          "verified": true,
+          "verified_at": "2019-08-24T14:15:22Z",
+          "via": "string"
+        }
+      ]
+    },
+    "issued_at": "2019-08-24T14:15:22Z",
+    "messages": [
+      {
+        "context": {},
+        "id": 0,
+        "text": "string",
+        "type": "string"
+      }
+    ],
+    "methods": {
+      "property1": {
+        "config": {
+          "action": "string",
+          "fields": [
+            {
+              "disabled": true,
+              "messages": [
+                {
+                  "context": {},
+                  "id": 0,
+                  "text": "string",
+                  "type": "string"
+                }
+              ],
+              "name": "string",
+              "pattern": "string",
+              "required": true,
+              "type": "string",
+              "value": {}
+            }
+          ],
+          "messages": [
+            {
+              "context": {},
+              "id": 0,
+              "text": "string",
+              "type": "string"
+            }
+          ],
+          "method": "string"
+        },
+        "method": "string"
+      },
+      "property2": {
+        "config": {
+          "action": "string",
+          "fields": [
+            {
+              "disabled": true,
+              "messages": [
+                {
+                  "context": {},
+                  "id": 0,
+                  "text": "string",
+                  "type": "string"
+                }
+              ],
+              "name": "string",
+              "pattern": "string",
+              "required": true,
+              "type": "string",
+              "value": {}
+            }
+          ],
+          "messages": [
+            {
+              "context": {},
+              "id": 0,
+              "text": "string",
+              "type": "string"
+            }
+          ],
+          "method": "string"
+        },
+        "method": "string"
+      }
+    },
+    "request_url": "string",
+    "state": "string",
+    "type": "string"
+  },
+  "identity": {
+    "id": "string",
+    "recovery_addresses": [
+      {
+        "id": "string",
+        "value": "string",
+        "via": "string"
+      }
+    ],
+    "schema_id": "string",
+    "schema_url": "string",
+    "traits": {},
+    "verifiable_addresses": [
+      {
+        "id": "string",
+        "status": "string",
+        "value": "string",
+        "verified": true,
+        "verified_at": "2019-08-24T14:15:22Z",
+        "via": "string"
+      }
+    ]
+  }
+}
+
+```
+
+*The Response for Settings Flows via API*
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|flow|[settingsFlow](#schemasettingsflow)|true|none|This flow is used when an identity wants to update settings<br>(e.g. profile data, passwords, ...) in a selfservice manner.<br><br>We recommend reading the [User Settings Documentation](../self-service/flows/user-settings)|
+|identity|[Identity](#schemaidentity)|true|none|none|
+
+<a id="tocSverificationflow"></a>
+
+#### verificationFlow
+
+<a id="schemaverificationflow"></a>
+
+```json
+{
+  "active": "string",
   "expires_at": "2019-08-24T14:15:22Z",
-  "form": {
+  "id": "string",
+  "issued_at": "2019-08-24T14:15:22Z",
+  "messages": [
+    {
+      "context": {},
+      "id": 0,
+      "text": "string",
+      "type": "string"
+    }
+  ],
+  "methods": {
+    "property1": {
+      "config": {
+        "action": "string",
+        "fields": [
+          {
+            "disabled": true,
+            "messages": [
+              {
+                "context": {},
+                "id": 0,
+                "text": "string",
+                "type": "string"
+              }
+            ],
+            "name": "string",
+            "pattern": "string",
+            "required": true,
+            "type": "string",
+            "value": {}
+          }
+        ],
+        "messages": [
+          {
+            "context": {},
+            "id": 0,
+            "text": "string",
+            "type": "string"
+          }
+        ],
+        "method": "string"
+      },
+      "method": "string"
+    },
+    "property2": {
+      "config": {
+        "action": "string",
+        "fields": [
+          {
+            "disabled": true,
+            "messages": [
+              {
+                "context": {},
+                "id": 0,
+                "text": "string",
+                "type": "string"
+              }
+            ],
+            "name": "string",
+            "pattern": "string",
+            "required": true,
+            "type": "string",
+            "value": {}
+          }
+        ],
+        "messages": [
+          {
+            "context": {},
+            "id": 0,
+            "text": "string",
+            "type": "string"
+          }
+        ],
+        "method": "string"
+      },
+      "method": "string"
+    }
+  },
+  "request_url": "string",
+  "state": "string",
+  "type": "string"
+}
+
+```
+
+*A Verification Flow*
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|active|string|false|none|Active, if set, contains the registration method that is being used. It is initially<br>not set.|
+|expires_at|string(date-time)|false|none|ExpiresAt is the time (UTC) when the request expires. If the user still wishes to verify the address,<br>a new request has to be initiated.|
+|id|[UUID](#schemauuid)|false|none|none|
+|issued_at|string(date-time)|false|none|IssuedAt is the time (UTC) when the request occurred.|
+|messages|[Messages](#schemamessages)|false|none|none|
+|methods|object|true|none|Methods contains context for all account verification methods. If a registration request has been<br>processed, but for example the password is incorrect, this will contain error messages.|
+|» **additionalProperties**|[verificationFlowMethod](#schemaverificationflowmethod)|false|none|none|
+|request_url|string|false|none|RequestURL is the initial URL that was requested from ORY Kratos. It can be used<br>to forward information contained in the URL's path or query for example.|
+|state|[State](#schemastate)|true|none|none|
+|type|[Type](#schematype)|false|none|The flow type can either be `api` or `browser`.|
+
+<a id="tocSverificationflowmethod"></a>
+
+#### verificationFlowMethod
+
+<a id="schemaverificationflowmethod"></a>
+
+```json
+{
+  "config": {
     "action": "string",
     "fields": [
       {
@@ -7114,8 +10607,45 @@ _Request presents a settings request_
     ],
     "method": "string"
   },
-  "id": "string",
-  "issued_at": "2019-08-24T14:15:22Z",
+  "method": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|config|[verificationFlowMethodConfig](#schemaverificationflowmethodconfig)|false|none|none|
+|method|string|false|none|Method contains the request credentials type.|
+
+<a id="tocSverificationflowmethodconfig"></a>
+
+#### verificationFlowMethodConfig
+
+<a id="schemaverificationflowmethodconfig"></a>
+
+```json
+{
+  "action": "string",
+  "fields": [
+    {
+      "disabled": true,
+      "messages": [
+        {
+          "context": {},
+          "id": 0,
+          "text": "string",
+          "type": "string"
+        }
+      ],
+      "name": "string",
+      "pattern": "string",
+      "required": true,
+      "type": "string",
+      "value": {}
+    }
+  ],
   "messages": [
     {
       "context": {},
@@ -7124,28 +10654,22 @@ _Request presents a settings request_
       "type": "string"
     }
   ],
-  "request_url": "string",
-  "success": true,
-  "via": "string"
+  "method": "string"
 }
-```
 
-_Request presents a verification request_
+```
 
 #### Properties
 
-| Name        | Type                                                  | Required | Restrictions | Description                                                                                                                                               |
-| ----------- | ----------------------------------------------------- | -------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| expires_at  | string(date-time)                                     | false    | none         | ExpiresAt is the time (UTC) when the request expires. If the user still wishes to verify the address, a new request has to be initiated.                  |
-| form        | [form](#schemaform)                                   | false    | none         | HTMLForm represents a HTML Form. The container can work with both HTTP Form and JSON requests                                                             |
-| id          | [UUID](#schemauuid)                                   | false    | none         | none                                                                                                                                                      |
-| issued_at   | string(date-time)                                     | false    | none         | IssuedAt is the time (UTC) when the request occurred.                                                                                                     |
-| messages    | [Messages](#schemamessages)                           | false    | none         | none                                                                                                                                                      |
-| request_url | string                                                | false    | none         | RequestURL is the initial URL that was requested from ORY Kratos. It can be used to forward information contained in the URL's path or query for example. |
-| success     | boolean                                               | false    | none         | Success, if true, implies that the request was completed successfully.                                                                                    |
-| via         | [VerifiableAddressType](#schemaverifiableaddresstype) | false    | none         | none                                                                                                                                                      |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|action|string|true|none|Action should be used as the form action URL `<form action="{{ .Action }}" method="post">`.|
+|fields|[formFields](#schemaformfields)|true|none|Fields contains multiple fields|
+|messages|[Messages](#schemamessages)|false|none|none|
+|method|string|true|none|Method is the form method (e.g. POST)|
 
-<a id="tocSversion">version</a>
+<a id="tocSversion"></a>
+
 #### version
 
 <a id="schemaversion"></a>
@@ -7154,10 +10678,12 @@ _Request presents a verification request_
 {
   "version": "string"
 }
+
 ```
 
 #### Properties
 
-| Name    | Type   | Required | Restrictions | Description                       |
-| ------- | ------ | -------- | ------------ | --------------------------------- |
-| version | string | false    | none         | Version is the service's version. |
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|version|string|false|none|Version is the service's version.|
+

--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -7,29 +7,27 @@ title: Configuration
 OPEN AN ISSUE IF YOU WOULD LIKE TO MAKE ADJUSTMENTS HERE AND MAINTAINERS WILL HELP YOU LOCATE THE RIGHT
 FILE -->
 
-If file `$HOME/.kratos.yaml` exists, it will be used as a configuration file
-which supports all configuration settings listed below.
+If file `$HOME/.kratos.yaml` exists, it will be used as a configuration file which supports all
+configuration settings listed below.
 
-You can load the config file from another source using the
-`-c path/to/config.yaml` or `--config path/to/config.yaml` flag:
-`kratos --config path/to/config.yaml`.
+You can load the config file from another source using the `-c path/to/config.yaml` or `--config path/to/config.yaml`
+flag: `kratos --config path/to/config.yaml`.
 
-Config files can be formatted as JSON, YAML and TOML. Some configuration values
-support reloading without server restart. All configuration values can be set
-using environment variables, as documented below.
+Config files can be formatted as JSON, YAML and TOML. Some configuration values support reloading without server restart.
+All configuration values can be set using environment variables, as documented below.
 
-To find out more about edge cases like setting string array values through
-environmental variables head to the
-[Configuring ORY services](https://www.ory.sh/docs/ecosystem/configuring)
-section.
+To find out more about edge cases like setting string array values through environmental variables head to the
+[Configuring ORY services](https://www.ory.sh/docs/ecosystem/configuring) section.
 
 ```yaml
 ## ORY Kratos Configuration
 #
 
+
 ## identity ##
 #
 identity:
+  
   ## JSON Schema URL for default identity traits ##
   #
   # Path to the JSON Schema which describes a default identity's traits.
@@ -37,14 +35,14 @@ identity:
   # Examples:
   # - file://path/to/identity.traits.schema.json
   # - https://foo.bar.com/path/to/identity.traits.schema.json
-  #
+  # 
   # Set this value using environment variables on
   # - Linux/macOS:
   #    $ export IDENTITY_DEFAULT_SCHEMA_URL=<value>
   # - Windows Command Line (CMD):
   #    > set IDENTITY_DEFAULT_SCHEMA_URL=<value>
   #
-  default_schema_url: https://foo.bar.com/path/to/identity.traits.schema.json
+  default_schema_url: file://path/to/identity.traits.schema.json
 
   ## Additional JSON Schemas for Identity Traits ##
   #
@@ -55,7 +53,7 @@ identity:
   #     url: https://foo.bar.com/path/to/employee.traits.schema.json
   #   - id: employee-v2
   #     url: https://foo.bar.com/path/to/employee.v2.traits.schema.json
-  #
+  # 
   # Set this value using environment variables on
   # - Linux/macOS:
   #    $ export IDENTITY_SCHEMAS=<value>
@@ -81,7 +79,7 @@ identity:
 # - mysql://user:secret@tcp(mysqld:3306)/database?max_conns=20&max_idle_conns=4
 # - cockroach://user@cockroachdb:26257/database?sslmode=disable&max_conns=20&max_idle_conns=4
 # - sqlite:///var/lib/sqlite/db.sqlite?_fk=true&mode=rwc
-#
+# 
 # Set this value using environment variables on
 # - Linux/macOS:
 #    $ export DSN=<value>
@@ -95,13 +93,15 @@ dsn: "postgres://user:
 ## selfservice ##
 #
 selfservice:
+  
   ## Redirect browsers to set URL per default ##
   #
   # ORY Kratos redirects to this URL per default on completion of self-service flows and other browser interaction. Read this [article for more information on browser redirects](https://www.ory.sh/kratos/docs/concepts/browser-redirect-flow-completion).
   #
   # Examples:
   # - https://my-app.com/dashboard
-  #
+  # - /dashboard
+  # 
   # Set this value using environment variables on
   # - Linux/macOS:
   #    $ export SELFSERVICE_DEFAULT_BROWSER_RETURN_URL=<value>
@@ -116,8 +116,9 @@ selfservice:
   #
   # Examples:
   # - - https://app.my-app.com/dashboard
+  #   - /dashboard
   #   - https://www.my-app.com/
-  #
+  # 
   # Set this value using environment variables on
   # - Linux/macOS:
   #    $ export SELFSERVICE_WHITELISTED_RETURN_URLS=<value>
@@ -126,14 +127,17 @@ selfservice:
   #
   whitelisted_return_urls:
     - https://app.my-app.com/dashboard
+    - /dashboard
     - https://www.my-app.com/
 
   ## flows ##
   #
   flows:
+    
     ## settings ##
     #
     settings:
+      
       ## URL of the Settings page. ##
       #
       # URL where the Settings UI is hosted. Check the [reference implementation](https://github.com/ory/kratos-selfservice-ui-node).
@@ -142,7 +146,7 @@ selfservice:
       #
       # Examples:
       # - https://my-app.com/user/settings
-      #
+      # 
       # Set this value using environment variables on
       # - Linux/macOS:
       #    $ export SELFSERVICE_FLOWS_SETTINGS_UI_URL=<value>
@@ -159,7 +163,7 @@ selfservice:
       # - 1h
       # - 1m
       # - 1s
-      #
+      # 
       # Set this value using environment variables on
       # - Linux/macOS:
       #    $ export SELFSERVICE_FLOWS_SETTINGS_LIFESPAN=<value>
@@ -176,7 +180,7 @@ selfservice:
       # - 1h
       # - 1m
       # - 1s
-      #
+      # 
       # Set this value using environment variables on
       # - Linux/macOS:
       #    $ export SELFSERVICE_FLOWS_SETTINGS_PRIVILEGED_SESSION_MAX_AGE=<value>
@@ -188,31 +192,35 @@ selfservice:
       ## after ##
       #
       after:
+        
         ## Redirect browsers to set URL per default ##
         #
         # ORY Kratos redirects to this URL per default on completion of self-service flows and other browser interaction. Read this [article for more information on browser redirects](https://www.ory.sh/kratos/docs/concepts/browser-redirect-flow-completion).
         #
         # Examples:
         # - https://my-app.com/dashboard
-        #
+        # - /dashboard
+        # 
         # Set this value using environment variables on
         # - Linux/macOS:
         #    $ export SELFSERVICE_FLOWS_SETTINGS_AFTER_DEFAULT_BROWSER_RETURN_URL=<value>
         # - Windows Command Line (CMD):
         #    > set SELFSERVICE_FLOWS_SETTINGS_AFTER_DEFAULT_BROWSER_RETURN_URL=<value>
         #
-        default_browser_return_url: https://my-app.com/dashboard
+        default_browser_return_url: /dashboard
 
         ## password ##
         #
         password:
+          
           ## Redirect browsers to set URL per default ##
           #
           # ORY Kratos redirects to this URL per default on completion of self-service flows and other browser interaction. Read this [article for more information on browser redirects](https://www.ory.sh/kratos/docs/concepts/browser-redirect-flow-completion).
           #
           # Examples:
           # - https://my-app.com/dashboard
-          #
+          # - /dashboard
+          # 
           # Set this value using environment variables on
           # - Linux/macOS:
           #    $ export SELFSERVICE_FLOWS_SETTINGS_AFTER_PASSWORD_DEFAULT_BROWSER_RETURN_URL=<value>
@@ -235,20 +243,22 @@ selfservice:
         ## profile ##
         #
         profile:
+          
           ## Redirect browsers to set URL per default ##
           #
           # ORY Kratos redirects to this URL per default on completion of self-service flows and other browser interaction. Read this [article for more information on browser redirects](https://www.ory.sh/kratos/docs/concepts/browser-redirect-flow-completion).
           #
           # Examples:
           # - https://my-app.com/dashboard
-          #
+          # - /dashboard
+          # 
           # Set this value using environment variables on
           # - Linux/macOS:
           #    $ export SELFSERVICE_FLOWS_SETTINGS_AFTER_PROFILE_DEFAULT_BROWSER_RETURN_URL=<value>
           # - Windows Command Line (CMD):
           #    > set SELFSERVICE_FLOWS_SETTINGS_AFTER_PROFILE_DEFAULT_BROWSER_RETURN_URL=<value>
           #
-          default_browser_return_url: https://my-app.com/dashboard
+          default_browser_return_url: /dashboard
 
           ## hooks ##
           #
@@ -264,27 +274,31 @@ selfservice:
     ## logout ##
     #
     logout:
+      
       ## after ##
       #
       after:
+        
         ## Redirect browsers to set URL per default ##
         #
         # ORY Kratos redirects to this URL per default on completion of self-service flows and other browser interaction. Read this [article for more information on browser redirects](https://www.ory.sh/kratos/docs/concepts/browser-redirect-flow-completion).
         #
         # Examples:
         # - https://my-app.com/dashboard
-        #
+        # - /dashboard
+        # 
         # Set this value using environment variables on
         # - Linux/macOS:
         #    $ export SELFSERVICE_FLOWS_LOGOUT_AFTER_DEFAULT_BROWSER_RETURN_URL=<value>
         # - Windows Command Line (CMD):
         #    > set SELFSERVICE_FLOWS_LOGOUT_AFTER_DEFAULT_BROWSER_RETURN_URL=<value>
         #
-        default_browser_return_url: https://my-app.com/dashboard
+        default_browser_return_url: /dashboard
 
     ## registration ##
     #
     registration:
+      
       ## Registration UI URL ##
       #
       # URL where the Registration UI is hosted. Check the [reference implementation](https://github.com/ory/kratos-selfservice-ui-node).
@@ -293,7 +307,7 @@ selfservice:
       #
       # Examples:
       # - https://my-app.com/signup
-      #
+      # 
       # Set this value using environment variables on
       # - Linux/macOS:
       #    $ export SELFSERVICE_FLOWS_REGISTRATION_UI_URL=<value>
@@ -310,25 +324,27 @@ selfservice:
       # - 1h
       # - 1m
       # - 1s
-      #
+      # 
       # Set this value using environment variables on
       # - Linux/macOS:
       #    $ export SELFSERVICE_FLOWS_REGISTRATION_LIFESPAN=<value>
       # - Windows Command Line (CMD):
       #    > set SELFSERVICE_FLOWS_REGISTRATION_LIFESPAN=<value>
       #
-      lifespan: 1m
+      lifespan: 1h
 
       ## after ##
       #
       after:
+        
         ## Redirect browsers to set URL per default ##
         #
         # ORY Kratos redirects to this URL per default on completion of self-service flows and other browser interaction. Read this [article for more information on browser redirects](https://www.ory.sh/kratos/docs/concepts/browser-redirect-flow-completion).
         #
         # Examples:
         # - https://my-app.com/dashboard
-        #
+        # - /dashboard
+        # 
         # Set this value using environment variables on
         # - Linux/macOS:
         #    $ export SELFSERVICE_FLOWS_REGISTRATION_AFTER_DEFAULT_BROWSER_RETURN_URL=<value>
@@ -340,20 +356,22 @@ selfservice:
         ## password ##
         #
         password:
+          
           ## Redirect browsers to set URL per default ##
           #
           # ORY Kratos redirects to this URL per default on completion of self-service flows and other browser interaction. Read this [article for more information on browser redirects](https://www.ory.sh/kratos/docs/concepts/browser-redirect-flow-completion).
           #
           # Examples:
           # - https://my-app.com/dashboard
-          #
+          # - /dashboard
+          # 
           # Set this value using environment variables on
           # - Linux/macOS:
           #    $ export SELFSERVICE_FLOWS_REGISTRATION_AFTER_PASSWORD_DEFAULT_BROWSER_RETURN_URL=<value>
           # - Windows Command Line (CMD):
           #    > set SELFSERVICE_FLOWS_REGISTRATION_AFTER_PASSWORD_DEFAULT_BROWSER_RETURN_URL=<value>
           #
-          default_browser_return_url: https://my-app.com/dashboard
+          default_browser_return_url: /dashboard
 
           ## hooks ##
           #
@@ -369,20 +387,22 @@ selfservice:
         ## oidc ##
         #
         oidc:
+          
           ## Redirect browsers to set URL per default ##
           #
           # ORY Kratos redirects to this URL per default on completion of self-service flows and other browser interaction. Read this [article for more information on browser redirects](https://www.ory.sh/kratos/docs/concepts/browser-redirect-flow-completion).
           #
           # Examples:
           # - https://my-app.com/dashboard
-          #
+          # - /dashboard
+          # 
           # Set this value using environment variables on
           # - Linux/macOS:
           #    $ export SELFSERVICE_FLOWS_REGISTRATION_AFTER_OIDC_DEFAULT_BROWSER_RETURN_URL=<value>
           # - Windows Command Line (CMD):
           #    > set SELFSERVICE_FLOWS_REGISTRATION_AFTER_OIDC_DEFAULT_BROWSER_RETURN_URL=<value>
           #
-          default_browser_return_url: https://my-app.com/dashboard
+          default_browser_return_url: /dashboard
 
           ## hooks ##
           #
@@ -398,6 +418,7 @@ selfservice:
     ## login ##
     #
     login:
+      
       ## Login UI URL ##
       #
       # URL where the Login UI is hosted. Check the [reference implementation](https://github.com/ory/kratos-selfservice-ui-node).
@@ -406,14 +427,14 @@ selfservice:
       #
       # Examples:
       # - https://my-app.com/login
-      #
+      # 
       # Set this value using environment variables on
       # - Linux/macOS:
       #    $ export SELFSERVICE_FLOWS_LOGIN_UI_URL=<value>
       # - Windows Command Line (CMD):
       #    > set SELFSERVICE_FLOWS_LOGIN_UI_URL=<value>
       #
-      ui_url: https://my-app.com/login
+      ui_url: https://www.ory.sh/kratos/docs/fallback/login
 
       ## lifespan ##
       #
@@ -423,7 +444,7 @@ selfservice:
       # - 1h
       # - 1m
       # - 1s
-      #
+      # 
       # Set this value using environment variables on
       # - Linux/macOS:
       #    $ export SELFSERVICE_FLOWS_LOGIN_LIFESPAN=<value>
@@ -435,31 +456,35 @@ selfservice:
       ## after ##
       #
       after:
+        
         ## Redirect browsers to set URL per default ##
         #
         # ORY Kratos redirects to this URL per default on completion of self-service flows and other browser interaction. Read this [article for more information on browser redirects](https://www.ory.sh/kratos/docs/concepts/browser-redirect-flow-completion).
         #
         # Examples:
         # - https://my-app.com/dashboard
-        #
+        # - /dashboard
+        # 
         # Set this value using environment variables on
         # - Linux/macOS:
         #    $ export SELFSERVICE_FLOWS_LOGIN_AFTER_DEFAULT_BROWSER_RETURN_URL=<value>
         # - Windows Command Line (CMD):
         #    > set SELFSERVICE_FLOWS_LOGIN_AFTER_DEFAULT_BROWSER_RETURN_URL=<value>
         #
-        default_browser_return_url: https://my-app.com/dashboard
+        default_browser_return_url: /dashboard
 
         ## password ##
         #
         password:
+          
           ## Redirect browsers to set URL per default ##
           #
           # ORY Kratos redirects to this URL per default on completion of self-service flows and other browser interaction. Read this [article for more information on browser redirects](https://www.ory.sh/kratos/docs/concepts/browser-redirect-flow-completion).
           #
           # Examples:
           # - https://my-app.com/dashboard
-          #
+          # - /dashboard
+          # 
           # Set this value using environment variables on
           # - Linux/macOS:
           #    $ export SELFSERVICE_FLOWS_LOGIN_AFTER_PASSWORD_DEFAULT_BROWSER_RETURN_URL=<value>
@@ -482,20 +507,22 @@ selfservice:
         ## oidc ##
         #
         oidc:
+          
           ## Redirect browsers to set URL per default ##
           #
           # ORY Kratos redirects to this URL per default on completion of self-service flows and other browser interaction. Read this [article for more information on browser redirects](https://www.ory.sh/kratos/docs/concepts/browser-redirect-flow-completion).
           #
           # Examples:
           # - https://my-app.com/dashboard
-          #
+          # - /dashboard
+          # 
           # Set this value using environment variables on
           # - Linux/macOS:
           #    $ export SELFSERVICE_FLOWS_LOGIN_AFTER_OIDC_DEFAULT_BROWSER_RETURN_URL=<value>
           # - Windows Command Line (CMD):
           #    > set SELFSERVICE_FLOWS_LOGIN_AFTER_OIDC_DEFAULT_BROWSER_RETURN_URL=<value>
           #
-          default_browser_return_url: https://my-app.com/dashboard
+          default_browser_return_url: /dashboard
 
           ## hooks ##
           #
@@ -511,6 +538,7 @@ selfservice:
     ## Email and Phone Verification and Account Activation Configuration ##
     #
     verification:
+      
       ## Enable Email/Phone Verification ##
       #
       # If set to true will enable [Email and Phone Verification and Account Activation](https://www.ory.sh/kratos/docs/self-service/flows/verify-email-account-activation/).
@@ -533,7 +561,7 @@ selfservice:
       #
       # Examples:
       # - https://my-app.com/verify
-      #
+      # 
       # Set this value using environment variables on
       # - Linux/macOS:
       #    $ export SELFSERVICE_FLOWS_VERIFICATION_UI_URL=<value>
@@ -545,20 +573,22 @@ selfservice:
       ## after ##
       #
       after:
+        
         ## Redirect browsers to set URL per default ##
         #
         # ORY Kratos redirects to this URL per default on completion of self-service flows and other browser interaction. Read this [article for more information on browser redirects](https://www.ory.sh/kratos/docs/concepts/browser-redirect-flow-completion).
         #
         # Examples:
         # - https://my-app.com/dashboard
-        #
+        # - /dashboard
+        # 
         # Set this value using environment variables on
         # - Linux/macOS:
         #    $ export SELFSERVICE_FLOWS_VERIFICATION_AFTER_DEFAULT_BROWSER_RETURN_URL=<value>
         # - Windows Command Line (CMD):
         #    > set SELFSERVICE_FLOWS_VERIFICATION_AFTER_DEFAULT_BROWSER_RETURN_URL=<value>
         #
-        default_browser_return_url: https://my-app.com/dashboard
+        default_browser_return_url: /dashboard
 
       ## Self-Service Verification Request Lifespan ##
       #
@@ -570,18 +600,19 @@ selfservice:
       # - 1h
       # - 1m
       # - 1s
-      #
+      # 
       # Set this value using environment variables on
       # - Linux/macOS:
       #    $ export SELFSERVICE_FLOWS_VERIFICATION_LIFESPAN=<value>
       # - Windows Command Line (CMD):
       #    > set SELFSERVICE_FLOWS_VERIFICATION_LIFESPAN=<value>
       #
-      lifespan: 1m
+      lifespan: 1h
 
     ## Account Recovery Configuration ##
     #
     recovery:
+      
       ## Enable Account Recovery ##
       #
       # If set to true will enable [Account Recovery](https://www.ory.sh/kratos/docs/self-service/flows/password-reset-account-recovery/).
@@ -594,7 +625,7 @@ selfservice:
       # - Windows Command Line (CMD):
       #    > set SELFSERVICE_FLOWS_RECOVERY_ENABLED=<value>
       #
-      enabled: false
+      enabled: true
 
       ## Recovery UI URL ##
       #
@@ -604,7 +635,7 @@ selfservice:
       #
       # Examples:
       # - https://my-app.com/verify
-      #
+      # 
       # Set this value using environment variables on
       # - Linux/macOS:
       #    $ export SELFSERVICE_FLOWS_RECOVERY_UI_URL=<value>
@@ -616,20 +647,22 @@ selfservice:
       ## after ##
       #
       after:
+        
         ## Redirect browsers to set URL per default ##
         #
         # ORY Kratos redirects to this URL per default on completion of self-service flows and other browser interaction. Read this [article for more information on browser redirects](https://www.ory.sh/kratos/docs/concepts/browser-redirect-flow-completion).
         #
         # Examples:
         # - https://my-app.com/dashboard
-        #
+        # - /dashboard
+        # 
         # Set this value using environment variables on
         # - Linux/macOS:
         #    $ export SELFSERVICE_FLOWS_RECOVERY_AFTER_DEFAULT_BROWSER_RETURN_URL=<value>
         # - Windows Command Line (CMD):
         #    > set SELFSERVICE_FLOWS_RECOVERY_AFTER_DEFAULT_BROWSER_RETURN_URL=<value>
         #
-        default_browser_return_url: https://my-app.com/dashboard
+        default_browser_return_url: /dashboard
 
       ## Self-Service Recovery Request Lifespan ##
       #
@@ -641,18 +674,19 @@ selfservice:
       # - 1h
       # - 1m
       # - 1s
-      #
+      # 
       # Set this value using environment variables on
       # - Linux/macOS:
       #    $ export SELFSERVICE_FLOWS_RECOVERY_LIFESPAN=<value>
       # - Windows Command Line (CMD):
       #    > set SELFSERVICE_FLOWS_RECOVERY_LIFESPAN=<value>
       #
-      lifespan: 1s
+      lifespan: 1h
 
     ## error ##
     #
     error:
+      
       ## ORY Kratos Error UI URL ##
       #
       # URL where the ORY Kratos Error UI is hosted. Check the [reference implementation](https://github.com/ory/kratos-selfservice-ui-node).
@@ -661,132 +695,169 @@ selfservice:
       #
       # Examples:
       # - https://my-app.com/kratos-error
-      #
+      # 
       # Set this value using environment variables on
       # - Linux/macOS:
       #    $ export SELFSERVICE_FLOWS_ERROR_UI_URL=<value>
       # - Windows Command Line (CMD):
       #    > set SELFSERVICE_FLOWS_ERROR_UI_URL=<value>
       #
-      ui_url: https://my-app.com/kratos-error
+      ui_url: https://www.ory.sh/kratos/docs/fallback/error
 
-  ## strategies ##
+  ## methods ##
   #
-  strategies:
+  methods:
+    
     ## profile ##
     #
     profile:
-      ## Enables Profile Management Strategy ##
+      
+      ## Enables Profile Management Method ##
       #
       # Default value: true
       #
       # Set this value using environment variables on
       # - Linux/macOS:
-      #    $ export SELFSERVICE_STRATEGIES_PROFILE_ENABLED=<value>
+      #    $ export SELFSERVICE_METHODS_PROFILE_ENABLED=<value>
       # - Windows Command Line (CMD):
-      #    > set SELFSERVICE_STRATEGIES_PROFILE_ENABLED=<value>
+      #    > set SELFSERVICE_METHODS_PROFILE_ENABLED=<value>
       #
-      enabled: false
+      enabled: true
 
     ## recovery_token ##
     #
     recovery_token:
-      ## Enables Token-based Account Recovery Strategy ##
+      
+      ## Enables Token-based Account Recovery Method ##
       #
       # Default value: true
       #
       # Set this value using environment variables on
       # - Linux/macOS:
-      #    $ export SELFSERVICE_STRATEGIES_RECOVERY_TOKEN_ENABLED=<value>
+      #    $ export SELFSERVICE_METHODS_RECOVERY_TOKEN_ENABLED=<value>
       # - Windows Command Line (CMD):
-      #    > set SELFSERVICE_STRATEGIES_RECOVERY_TOKEN_ENABLED=<value>
+      #    > set SELFSERVICE_METHODS_RECOVERY_TOKEN_ENABLED=<value>
       #
-      enabled: false
+      enabled: true
 
     ## password ##
     #
     password:
-      ## Enables Password Strategy ##
+      
+      ## Enables Username/Email and Password Method ##
       #
       # Default value: true
       #
       # Set this value using environment variables on
       # - Linux/macOS:
-      #    $ export SELFSERVICE_STRATEGIES_PASSWORD_ENABLED=<value>
+      #    $ export SELFSERVICE_METHODS_PASSWORD_ENABLED=<value>
       # - Windows Command Line (CMD):
-      #    > set SELFSERVICE_STRATEGIES_PASSWORD_ENABLED=<value>
+      #    > set SELFSERVICE_METHODS_PASSWORD_ENABLED=<value>
       #
-      enabled: false
+      enabled: true
 
     ## oidc ##
     #
     oidc:
-      ## Enables OpenID Connect Strategy ##
+      
+      ## Enables OpenID Connect Method ##
       #
       # Default value: false
       #
       # Set this value using environment variables on
       # - Linux/macOS:
-      #    $ export SELFSERVICE_STRATEGIES_OIDC_ENABLED=<value>
+      #    $ export SELFSERVICE_METHODS_OIDC_ENABLED=<value>
       # - Windows Command Line (CMD):
-      #    > set SELFSERVICE_STRATEGIES_OIDC_ENABLED=<value>
+      #    > set SELFSERVICE_METHODS_OIDC_ENABLED=<value>
       #
       enabled: false
 
       ## config ##
       #
       config:
+        
         ## OpenID Connect and OAuth2 Providers ##
         #
         # A list and configuration of OAuth2 and OpenID Connect providers ORY Kratos should integrate with.
         #
         # Set this value using environment variables on
         # - Linux/macOS:
-        #    $ export SELFSERVICE_STRATEGIES_OIDC_CONFIG_PROVIDERS=<value>
+        #    $ export SELFSERVICE_METHODS_OIDC_CONFIG_PROVIDERS=<value>
         # - Windows Command Line (CMD):
-        #    > set SELFSERVICE_STRATEGIES_OIDC_CONFIG_PROVIDERS=<value>
+        #    > set SELFSERVICE_METHODS_OIDC_CONFIG_PROVIDERS=<value>
         #
         providers:
           - id: google
             provider: google
-            client_id: sit
-            client_secret: adipisicing ut in sit
+            client_id: aliquip sint esse
+            client_secret: consequat
             mapper_url: base64://bG9jYWwgc3ViamVjdCA9I...
             issuer_url: https://accounts.google.com
             auth_url: https://accounts.google.com/o/oauth2/v2/auth
             token_url: https://www.googleapis.com/oauth2/v4/token
             scope:
               - profile
-            tenant: contoso.onmicrosoft.com
+              - profile
+              - offline_access
+            tenant: 8eaef023-2b34-4da1-9baa-8bc8c9d6a490
           - id: google
             provider: google
-            client_id: id velit sit
-            client_secret: ad cupidatat laboris sunt
-            mapper_url: https://foo.bar.com/path/to/oidc.jsonnet
+            client_id: nostrud
+            client_secret: exercitation
+            mapper_url: base64://bG9jYWwgc3ViamVjdCA9I...
+            issuer_url: https://accounts.google.com
+            auth_url: https://accounts.google.com/o/oauth2/v2/auth
+            token_url: https://www.googleapis.com/oauth2/v4/token
+            scope:
+              - profile
+              - offline_access
+              - profile
+              - profile
+            tenant: 8eaef023-2b34-4da1-9baa-8bc8c9d6a490
+          - id: google
+            provider: google
+            client_id: velit magna aute
+            client_secret: occaecat nisi ea cupidatat dolor
+            mapper_url: base64://bG9jYWwgc3ViamVjdCA9I...
             issuer_url: https://accounts.google.com
             auth_url: https://accounts.google.com/o/oauth2/v2/auth
             token_url: https://www.googleapis.com/oauth2/v4/token
             scope:
               - offline_access
-            tenant: contoso.onmicrosoft.com
+            tenant: organizations
+          - id: google
+            provider: google
+            client_id: occaecat
+            client_secret: dolor veniam enim
+            mapper_url: file://path/to/oidc.jsonnet
+            issuer_url: https://accounts.google.com
+            auth_url: https://accounts.google.com/o/oauth2/v2/auth
+            token_url: https://www.googleapis.com/oauth2/v4/token
+            scope:
+              - offline_access
+              - profile
+              - offline_access
+            tenant: consumers
 
 ## Courier configuration ##
 #
 # The courier is responsible for sending and delivering messages over email, sms, and other means.
 #
 courier:
+  
   ## SMTP Configuration ##
   #
   # Configures outgoing emails using the SMTP protocol.
   #
   smtp:
+    
     ## SMTP connection string ##
     #
     # This URI will be used to connect to the SMTP server. Use the query parameter to allow (`?skip_ssl_verify=true`) or disallow (`?skip_ssl_verify=false`) self-signed TLS certificates. Please keep in mind that any host other than localhost / 127.0.0.1 must use smtp over TLS (smtps) or the connection will not be possible.
     #
     # Examples:
     # - smtps://foo:bar@my-mailserver:1234/?skip_ssl_verify=false
-    #
+    # 
     # Set this value using environment variables on
     # - Linux/macOS:
     #    $ export COURIER_SMTP_CONNECTION_URI=<value>
@@ -807,7 +878,7 @@ courier:
     # - Windows Command Line (CMD):
     #    > set COURIER_SMTP_FROM_ADDRESS=<value>
     #
-    from_address: V7cf2ygb0H@dgtERYRNqoqpVwWZSvoSvpnX.hn
+    from_address: Sp2Zvmu1R@hCnSjk.kz
 
   ## Override message templates ##
   #
@@ -815,7 +886,7 @@ courier:
   #
   # Examples:
   # - /conf/courier-templates
-  #
+  # 
   # Set this value using environment variables on
   # - Linux/macOS:
   #    $ export COURIER_TEMPLATE_OVERRIDE_PATH=<value>
@@ -827,16 +898,18 @@ courier:
 ## serve ##
 #
 serve:
+  
   ## admin ##
   #
   admin:
+    
     ## Admin Base URL ##
     #
     # The URL where the admin endpoint is exposed at.
     #
     # Examples:
     # - https://kratos.private-network:4434/
-    #
+    # 
     # Set this value using environment variables on
     # - Linux/macOS:
     #    $ export SERVE_ADMIN_BASE_URL=<value>
@@ -857,7 +930,7 @@ serve:
     # - Windows Command Line (CMD):
     #    > set SERVE_ADMIN_HOST=<value>
     #
-    host: dolore dolor consequat officia cupidatat
+    host: incididunt eiusmod veniam esse pariatur
 
     ## Admin Port ##
     #
@@ -871,7 +944,7 @@ serve:
     #
     # Examples:
     # - 4434
-    #
+    # 
     # Set this value using environment variables on
     # - Linux/macOS:
     #    $ export SERVE_ADMIN_PORT=<value>
@@ -883,20 +956,22 @@ serve:
   ## public ##
   #
   public:
+    
     ## Public Base URL ##
     #
     # The URL where the public endpoint is exposed at.
     #
     # Examples:
     # - https://my-app.com/.ory/kratos/public
-    #
+    # - /.ory/kratos/public/
+    # 
     # Set this value using environment variables on
     # - Linux/macOS:
     #    $ export SERVE_PUBLIC_BASE_URL=<value>
     # - Windows Command Line (CMD):
     #    > set SERVE_PUBLIC_BASE_URL=<value>
     #
-    base_url: https://my-app.com/.ory/kratos/public
+    base_url: /.ory/kratos/public/
 
     ## Public Host ##
     #
@@ -910,7 +985,7 @@ serve:
     # - Windows Command Line (CMD):
     #    > set SERVE_PUBLIC_HOST=<value>
     #
-    host: et
+    host: eiusmod Lorem
 
     ## Public Port ##
     #
@@ -924,7 +999,7 @@ serve:
     #
     # Examples:
     # - 4433
-    #
+    # 
     # Set this value using environment variables on
     # - Linux/macOS:
     #    $ export SERVE_PUBLIC_PORT=<value>
@@ -936,6 +1011,7 @@ serve:
 ## log ##
 #
 log:
+  
   ## level ##
   #
   # One of:
@@ -946,21 +1022,33 @@ log:
   # - error
   # - fatal
   # - panic
-  #
+  # 
   # Set this value using environment variables on
   # - Linux/macOS:
   #    $ export LOG_LEVEL=<value>
   # - Windows Command Line (CMD):
   #    > set LOG_LEVEL=<value>
   #
-  level: warning
+  level: info
+
+  ## Leak Sensitive Log Values ##
+  #
+  # If set will leak sensitive values (e.g. emails) in the logs.
+  #
+  # Set this value using environment variables on
+  # - Linux/macOS:
+  #    $ export LOG_LEAK_SENSITIVE_VALUES=<value>
+  # - Windows Command Line (CMD):
+  #    > set LOG_LEAK_SENSITIVE_VALUES=<value>
+  #
+  leak_sensitive_values: true
 
   ## format ##
   #
   # One of:
   # - json
   # - text
-  #
+  # 
   # Set this value using environment variables on
   # - Linux/macOS:
   #    $ export LOG_FORMAT=<value>
@@ -972,6 +1060,7 @@ log:
 ## secrets ##
 #
 secrets:
+  
   ## Default Encryption Signing Secrets ##
   #
   # The first secret in the array is used for singing and encrypting things while all other keys are used to verify and decrypt older things that were signed with that old secret.
@@ -983,10 +1072,8 @@ secrets:
   #    > set SECRETS_DEFAULT=<value>
   #
   default:
-    - mollit voluptate
-    - magnaaute irure voluptate aliqua dolor
-    - et voluptate qui ipsum
-    - nulla voluptate non
+    - adipisicing sed in quis minim
+    - nulla nostrud voluptate consectetur
 
   ## Singing Keys for Cookies ##
   #
@@ -999,18 +1086,18 @@ secrets:
   #    > set SECRETS_COOKIE=<value>
   #
   cookie:
-    - dolor consequat in commodo ut
-    - culpa enim incididunt
-    - non eiusmod amet
-    - Excepteur aliquip in nostrud
-    - veniam cupidatat reprehenderit
+    - dolor id Lorem commodo
+    - sint Excepteur enim exercitation
+    - consectetur eu enim nulla incididunt
 
 ## Hashing Algorithm Configuration ##
 #
 hashers:
+  
   ## Configuration for the Argon2id hasher. ##
   #
   argon2:
+    
     ## memory ##
     #
     # Minimum value: 16384
@@ -1021,7 +1108,7 @@ hashers:
     # - Windows Command Line (CMD):
     #    > set HASHERS_ARGON2_MEMORY=<value>
     #
-    memory: 9923292
+    memory: 65460581
 
     ## iterations ##
     #
@@ -1033,7 +1120,7 @@ hashers:
     # - Windows Command Line (CMD):
     #    > set HASHERS_ARGON2_ITERATIONS=<value>
     #
-    iterations: 93455383
+    iterations: 41435289
 
     ## parallelism ##
     #
@@ -1045,7 +1132,7 @@ hashers:
     # - Windows Command Line (CMD):
     #    > set HASHERS_ARGON2_PARALLELISM=<value>
     #
-    parallelism: 57113235
+    parallelism: 1244352
 
     ## salt_length ##
     #
@@ -1057,7 +1144,7 @@ hashers:
     # - Windows Command Line (CMD):
     #    > set HASHERS_ARGON2_SALT_LENGTH=<value>
     #
-    salt_length: 87632070
+    salt_length: 19486480
 
     ## key_length ##
     #
@@ -1069,44 +1156,97 @@ hashers:
     # - Windows Command Line (CMD):
     #    > set HASHERS_ARGON2_KEY_LENGTH=<value>
     #
-    key_length: 3894910
+    key_length: 45280802
 
 ## session ##
 #
 session:
+  
   ## Session Lifespan ##
   #
-  # Defines how long a session is active. This value is ignored if the "remember me" feature is used.
+  # Defines how long a session is active. Once that lifespan has been reached, the user needs to sign in again.
   #
-  # Default value: 1h
+  # Default value: 24h
   #
   # Examples:
   # - 1h
   # - 1m
   # - 1s
-  #
+  # 
   # Set this value using environment variables on
   # - Linux/macOS:
   #    $ export SESSION_LIFESPAN=<value>
   # - Windows Command Line (CMD):
   #    > set SESSION_LIFESPAN=<value>
   #
-  lifespan: 1h
+  lifespan: 1s
 
-  ## Cookie Same Site Configuration ##
+  ## cookie ##
   #
-  # Default value: Lax
-  #
-  # One of:
-  # - Strict
-  # - Lax
-  # - None
-  #
-  # Set this value using environment variables on
-  # - Linux/macOS:
-  #    $ export SESSION_COOKIE_SAME_SITE=<value>
-  # - Windows Command Line (CMD):
-  #    > set SESSION_COOKIE_SAME_SITE=<value>
-  #
-  cookie_same_site: Lax
+  cookie:
+    
+    ## Session Cookie Domain ##
+    #
+    # Sets the session cookie domain. Useful when dealing with subdomains. Use with care!
+    #
+    domain:
+      title: Session Cookie Domain
+      description: Sets the session cookie domain. Useful when dealing with
+        subdomains. Use with care!
+
+    ## Make Session Cookie Persistent ##
+    #
+    # If set to true will persist the cookie in the end-user's browser using the `max-age` parameter which is set to the `session.lifespan` value. Persistent cookies are not deleted when the browser is closed (e.g. on reboot or alt+f4).
+    #
+    # Default value: true
+    #
+    # Set this value using environment variables on
+    # - Linux/macOS:
+    #    $ export SESSION_COOKIE_PERSISTENT=<value>
+    # - Windows Command Line (CMD):
+    #    > set SESSION_COOKIE_PERSISTENT=<value>
+    #
+    persistent: true
+
+    ## Session Cookie Path ##
+    #
+    # Sets the session cookie path. Use with care!
+    #
+    # Default value: /
+    #
+    # Set this value using environment variables on
+    # - Linux/macOS:
+    #    $ export SESSION_COOKIE_PATH=<value>
+    # - Windows Command Line (CMD):
+    #    > set SESSION_COOKIE_PATH=<value>
+    #
+    path: sunt laborum nulla sed dolore
+
+    ## Cookie Same Site Configuration ##
+    #
+    # Default value: Lax
+    #
+    # One of:
+    # - Strict
+    # - Lax
+    # - None
+    # 
+    # Set this value using environment variables on
+    # - Linux/macOS:
+    #    $ export SESSION_COOKIE_SAME_SITE=<value>
+    # - Windows Command Line (CMD):
+    #    > set SESSION_COOKIE_SAME_SITE=<value>
+    #
+    same_site: Lax
+
+## version ##
+#
+# Set this value using environment variables on
+# - Linux/macOS:
+#    $ export VERSION=<value>
+# - Windows Command Line (CMD):
+#    > set VERSION=<value>
+#
+version: v91333221585.262418.0+qDWwJmAz.2e.tvyE9.buy6nC.THs
+
 ```

--- a/internal/httpclient/models/login_via_api_response.go
+++ b/internal/httpclient/models/login_via_api_response.go
@@ -26,7 +26,7 @@ type LoginViaAPIResponse struct {
 	// A session token is equivalent to a session cookie, but it can be sent in the HTTP Authorization
 	// Header:
 	//
-	// Authorization: bearer <session-token>
+	// 		Authorization: bearer ${session-token}
 	//
 	// The session token is only issued for API flows, not for Browser flows!
 	// Required: true

--- a/internal/httpclient/models/login_via_api_response.go
+++ b/internal/httpclient/models/login_via_api_response.go
@@ -26,7 +26,7 @@ type LoginViaAPIResponse struct {
 	// A session token is equivalent to a session cookie, but it can be sent in the HTTP Authorization
 	// Header:
 	//
-	// 		Authorization: bearer ${session-token}
+	// Authorization: bearer ${session-token}
 	//
 	// The session token is only issued for API flows, not for Browser flows!
 	// Required: true

--- a/internal/httpclient/models/registration_via_api_response.go
+++ b/internal/httpclient/models/registration_via_api_response.go
@@ -31,7 +31,7 @@ type RegistrationViaAPIResponse struct {
 	// A session token is equivalent to a session cookie, but it can be sent in the HTTP Authorization
 	// Header:
 	//
-	// 		Authorization: bearer ${session-token}
+	// Authorization: bearer ${session-token}
 	//
 	// The session token is only issued for API flows, not for Browser flows!
 	// Required: true

--- a/internal/httpclient/models/registration_via_api_response.go
+++ b/internal/httpclient/models/registration_via_api_response.go
@@ -31,7 +31,7 @@ type RegistrationViaAPIResponse struct {
 	// A session token is equivalent to a session cookie, but it can be sent in the HTTP Authorization
 	// Header:
 	//
-	// Authorization: bearer <session-token>
+	// 		Authorization: bearer ${session-token}
 	//
 	// The session token is only issued for API flows, not for Browser flows!
 	// Required: true

--- a/selfservice/flow/login/session.go
+++ b/selfservice/flow/login/session.go
@@ -11,7 +11,7 @@ type APIFlowResponse struct {
 	// A session token is equivalent to a session cookie, but it can be sent in the HTTP Authorization
 	// Header:
 	//
-	// 		Authorization: bearer <session-token>
+	// 		Authorization: bearer ${session-token}
 	//
 	// The session token is only issued for API flows, not for Browser flows!
 	//

--- a/selfservice/flow/registration/session.go
+++ b/selfservice/flow/registration/session.go
@@ -16,7 +16,7 @@ type APIFlowResponse struct {
 	// A session token is equivalent to a session cookie, but it can be sent in the HTTP Authorization
 	// Header:
 	//
-	// 		Authorization: bearer <session-token>
+	// 		Authorization: bearer ${session-token}
 	//
 	// The session token is only issued for API flows, not for Browser flows!
 	//


### PR DESCRIPTION
## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
