### PR TITLE
chore: update repository template to af2114f8

### DIFF
--- a/.github/workflows/closed_references.yml
+++ b/.github/workflows/closed_references.yml
@@ -22,6 +22,5 @@ jobs:
       - uses: ory/closed-reference-notifier@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ignore: ".git,**/node_modules,docs,CHANGELOG.md,.bin,*.md"
-          issueLabels: upstream
+          issueLabels: upstream,good first issue,help wanted
           issueLimit: ${{ github.event.inputs.issueLimit || '5' }}

--- a/.reference-ignore
+++ b/.reference-ignore
@@ -1,0 +1,3 @@
+**/node_modules
+docs
+CHANGELOG.md


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/af2114f86f06ec1328d210c3034b405641a74a27.