### PR TITLE
fix: capitalize "import" to prevent docusaurus from interpreting line as a react import statement

### DIFF
--- a/docs/docs/cli/kratos-identities-import.md
+++ b/docs/docs/cli/kratos-identities-import.md
@@ -12,7 +12,7 @@ To improve this file please make your change against the appropriate "./cmd/*.go
 
 ## kratos identities import
 
-import identities from files or STD_IN
+Import identities from files or STD_IN
 
 ### Synopsis
 


### PR DESCRIPTION
## Proposed changes

Adds capitalization of the word "import" at one point in the documentation to prevent a `SyntaxError` with the command `docusaurus start` / `npm start`. Docusaurus seems to have interpreted the line as a reactive import statement.

The error:
```
ory/kratos/docs  master ✗                                                                                                                                                                                                                                                                           
▶ npm start 

[...]

./docs/cli/kratos-identities-import.md
SyntaxError: /home/nick/GolandProjects/ory/kratos/docs/docs/cli/kratos-identities-import.md: Unexpected token (1:23)

> 1 | import identities from files or STD_IN
    |                        ^
    at parser.next (<anonymous>)
 @ ./.docusaurus/registry.js 1:15579-15644 1:15392-15533
 @ ./node_modules/@docusaurus/core/lib/client/exports/ComponentCreator.js
 @ ./.docusaurus/routes.js
 @ ./node_modules/@docusaurus/core/lib/client/clientEntry.js
 @ multi ./node_modules/react-dev-utils/webpackHotDevClient.js ./node_modules/@docusaurus/core/lib/client/clientEntry.js
```

## Checklist

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [] I have added tests that prove my fix is effective or that my feature
      works.
- [X] I have added or changed [the documentation](docs/docs).

