### PR TITLE
docs: Fix PHONY spelling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ cover:
 		go test ./... -coverprofile=cover.out
 		go tool cover -func=cover.out
 
-.PHONE: mocks
+.PHONY: mocks
 mocks: .bin/mockgen
 		mockgen -mock_names Manager=MockLoginExecutorDependencies -package internal -destination internal/hook_login_executor_dependencies.go github.com/ory/kratos/selfservice loginExecutorDependencies
 


### PR DESCRIPTION
## Related issue

no related issue

## Proposed changes

Fix misspelled Make keyword `.PHONE` to `.PHONY` to match the rest of the document.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments

I noticed this bug while working on #567. Extracting this into a separate pull request since it is an unrelated change that should be discussed and shipped separately.