### PR TITLE
docs: Extract Prettier configuration file

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,8 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "consts": {
-    "prettierTarget": "{docs/**,docs,scripts,static,contrib}/*.{md,mdx,json,js,css,html}|*.{js,md}",
-    "prettierArgs": "--no-semi --single-quote --trailing-comma none"
+    "prettierTarget": "{docs/**,docs,scripts,static,contrib}/*.{md,mdx,json,js,css,html}|*.{js,md}"
   },
   "scripts": {
     "gen": "npm run widdershins && cd .. && node ./docs/scripts/fix-api.js ./docs/docs/reference/api.mdx && node ./docs/scripts/config.js docs/config.js",
@@ -15,8 +14,8 @@
     "swizzle": "docusaurus swizzle",
     "serve": "docusaurus serve",
     "deploy": "docusaurus deploy",
-    "format": "prettier --write ${npm_package_consts_prettierTarget} ${npm_package_consts_prettierArgs} || true",
-    "format:check": "prettier --check ${npm_package_consts_prettierTarget} ${npm_package_consts_prettierArgs}",
+    "format": "prettier --config=../.prettierrc.json --write ${npm_package_consts_prettierTarget} || true",
+    "format:check": "prettier --config=../.prettierrc.json --check ${npm_package_consts_prettierTarget}",
     "postinstall": "patch-package"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "format": "prettier --no-semi --single-quote --trailing-comma es5 --write \"test/e2e/cypress/**/*.js\"",
+    "format": "prettier --write \"test/e2e/cypress/**/*.js\"",
     "test": "cypress run",
     "test:watch": "cypress open",
     "wait-on": "wait-on"


### PR DESCRIPTION
## Related issue

no related issue

## Proposed changes

Extract the Prettier configuration into a dedicated configuration file. Advantages are that the Prettier configuration is now:
- redundancy-free in a single place (later we could even [share the same formatting style across all ORY projects](https://prettier.io/docs/en/configuration.html#sharing-configurations))
- available to [Prettier IDE plugins](https://prettier.io/docs/en/editors.html) (which everybody should use at this point)
- available when scripts or humans run Prettier manually on a file 
- easier to find

I have chosen JSON as the format since it is faster, safer, and I know how much @aeneasr loves YML 😉 

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments
