### PR TITLE
fix: Add ory-prettier-styles to main repo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2020,6 +2020,12 @@
       "integrity": "sha512-Xk3hsB0PzB4dzr/r/FdmK+VfQbZH7lQQ2iipMS1/1eoz1wUvh5R7rmOakYvw0bQJJE6PYrOLx8UHsYmzgTr+YQ==",
       "dev": true
     },
+    "ory-prettier-styles": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ory-prettier-styles/-/ory-prettier-styles-1.0.1.tgz",
+      "integrity": "sha512-YIJMrd5K2LzxoC01n3sNgsNa1u4IRBdWpE5bTlKqFy+kTtQy8pCv0JKw8wXwpdHfkOIeXt4wcVM3zYGRlmPGbQ==",
+      "dev": true
+    },
     "os-locale": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,12 @@
 {
   "private": true,
   "prettier": "ory-prettier-styles",
+  "consts": {
+    "prettierTarget": "test/e2e/cypress/**/*.js"
+  },
   "scripts": {
-    "format": "prettier --write \"test/e2e/cypress/**/*.js\"",
+    "format": "prettier --write ${npm_package_consts_prettierTarget}",
+    "format:check": "prettier --check ${npm_package_consts_prettierTarget}",
     "test": "cypress run",
     "test:watch": "cypress open",
     "wait-on": "wait-on"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "prettier": "ory-prettier-styles",
   "scripts": {
-    "format": "prettier --no-semi --single-quote --trailing-comma es5 --write \"test/e2e/cypress/**/*.js\"",
+    "format": "prettier --write \"test/e2e/cypress/**/*.js\"",
     "test": "cypress run",
     "test:watch": "cypress open",
     "wait-on": "wait-on"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "private": true,
+  "prettier": "ory-prettier-styles",
   "scripts": {
     "format": "prettier --no-semi --single-quote --trailing-comma es5 --write \"test/e2e/cypress/**/*.js\"",
     "test": "cypress run",
@@ -9,6 +10,7 @@
   "devDependencies": {
     "cypress": "4.5.0",
     "openapi-generator": "^0.1.36",
+    "ory-prettier-styles": "^1.0.1",
     "prettier": "2.0.4",
     "wait-on": "4.0.2"
   }


### PR DESCRIPTION
## Proposed changes

Add `ory-prettier-styles` to main repo so that `npm run format` works there.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

