### PR TITLE
docs: Remove contraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ ORY Kratos is the first and only cloud native Identity and User Management Syste
 **Table of Contents**
 
 - [What is ORY Kratos?](#what-is-ory-kratos)
-  - [Who's using it?](#whos-using-it)
+  - [Who is using it?](#who-is-using-it)
 - [Getting Started](#getting-started)
   - [Quickstart](#quickstart)
   - [Installation](#installation)
@@ -82,7 +82,7 @@ We highly recommend reading the [ORY Kratos introduction docs](https://www.ory.s
 to learn more about ORY Krato's background, feature set, and differentiation
 from other products.
 
-### Who's using it?
+### Who is using it?
 
 <!--BEGIN ADOPTERS-->
 


### PR DESCRIPTION
## Proposed changes

Contractions (shortening "who is" to "who's") are very informal and typically only used in oral language. I think written documentation can be casual but should maintain a written style.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).
