### PR TITLE
docs: Add missing TOC entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ ORY Kratos is the first and only cloud native Identity and User Management Syste
   - [Quickstart](#quickstart)
   - [Installation](#installation)
 - [Ecosystem](#ecosystem)
-  - [ORY Security Console: Administrative User Interface](#ory-security-console-administrative-user-interface)
+  - [ORY Kratos: Identity and User Infrastructure and Management](#ory-kratos-identity-and-user-infrastructure-and-management)
+  - [ORY Hydra: OAuth2 & OpenID Connect Server](#ory-hydra-oauth2--openid-connect-server)
   - [ORY Oathkeeper: Identity & Access Proxy](#ory-oathkeeper-identity--access-proxy)
   - [ORY Keto: Access Control Policies as a Server](#ory-keto-access-control-policies-as-a-server)
 - [Security](#security)
@@ -46,10 +47,12 @@ ORY Kratos is the first and only cloud native Identity and User Management Syste
   - [Develop](#develop)
     - [Dependencies](#dependencies)
       - [Install Tools](#install-tools)
+    - [Install from source](#install-from-source)
     - [Formatting Code](#formatting-code)
     - [Running Tests](#running-tests)
       - [Short Tests](#short-tests)
       - [Regular Tests](#regular-tests)
+      - [End-to-End Tests](#end-to-end-tests)
     - [Build Docker](#build-docker)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->


### PR DESCRIPTION
## Proposed changes

The TOC in this file is outdated. Are you still using doctoc as the comments in various MD files indicate? It's not included in `package.json`. Setting it up seems not straightforward since it adds TOCs everywhere so I wanted to check in about this first before hacking on this.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).
