### PR TITLE
docs: Replace ampersand

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ ORY Kratos is the first and only cloud native Identity and User Management Syste
   - [Installation](#installation)
 - [Ecosystem](#ecosystem)
   - [ORY Security Console: Administrative User Interface](#ory-security-console-administrative-user-interface)
-  - [ORY Oathkeeper: Identity & Access Proxy](#ory-oathkeeper-identity--access-proxy)
+  - [ORY Oathkeeper: Identity and Access Proxy](#ory-oathkeeper-identity--access-proxy)
   - [ORY Keto: Access Control Policies as a Server](#ory-keto-access-control-policies-as-a-server)
 - [Security](#security)
   - [Disclosing vulnerabilities](#disclosing-vulnerabilities)
@@ -256,16 +256,16 @@ It implements core use cases that almost every software application needs to
 deal with: Self-service Login and Registration, Multi-Factor Authentication
 (MFA/2FA), Account Recovery and Verification, Profile and Account Management.
 
-### ORY Hydra: OAuth2 & OpenID Connect Server
+### ORY Hydra: OAuth2 and OpenID Connect Server
 
 [ORY Hydra](https://github.com/ory/hydra) is an OpenID Certified™ OAuth2 and
 OpenID Connect Provider can connect to any existing identity database (LDAP, AD,
 KeyCloak, PHP+MySQL, ...) and user interface.
 
-### ORY Oathkeeper: Identity & Access Proxy
+### ORY Oathkeeper: Identity and Access Proxy
 
 [ORY Oathkeeper](https://github.com/ory/oathkeeper) is a BeyondCorp/Zero Trust
-Identity & Access Proxy (IAP) with configurable authentication, authorization,
+Identity and Access Proxy (IAP) with configurable authentication, authorization,
 and request mutation rules for your web services: Authenticate JWT, Access
 Tokens, API Keys, mTLS; Check if the contained subject is allowed to perform the
 request; Encode resulting content into custom headers (`X-User-ID`), JSON Web


### PR DESCRIPTION
## Proposed changes

Replace `&` with `and` since "identity and access proxy" reads better than "identity & access proxy" to me. This is an extract from #567, it makes sense to discuss this separately. Not feeling strongly about this. If the `&` is part of the branding we can leave it in.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).
