### PR TITLE
build: Created required directories during install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,8 @@ mocks: .bin/mockgen
 		mockgen -mock_names Manager=MockLoginExecutorDependencies -package internal -destination internal/hook_login_executor_dependencies.go github.com/ory/kratos/selfservice loginExecutorDependencies
 
 .PHONY: install
-install: .bin/packr2 .bin/pack
+install:
+		$(shell mkdir -p {.bin/packr2,.bin/pack})
 		make pack
 		GO111MODULE=on go install -tags sqlite .
 		packr2 clean


### PR DESCRIPTION
## Related issue

#711 


## Describe Issue:

Following [Kratos Building from source](https://www.ory.sh/kratos/docs/install/#building-from-source) instructions to build after cloning the repo fails with the error:
`make: *** No rule to make target '.bin/packr2', needed by 'install'. Stop.`

## Proposed changes

I'm creating the 2 required directories as part of `make install`

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).
(No documentation added since the documentation is not listing those directories as pre requisite) 

Not sure how to write test for this change (it's my first time working with `make`).