### PR TITLE
docs: small improvements to discord oidc provider guide

### DIFF
--- a/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
+++ b/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
@@ -59,9 +59,11 @@ configuration file (explained in further detail at
 
 Discord does not implement OpenID Connect. Therefore, ORY Kratos makes a request to
 [Discord's User API](https://discord.com/developers/docs/resources/user#get-current-user)
-and adds the following claims to `std.extVar('claims')`:
+and adds that data to `std.extVar('claims')`.
+However, not all fields are supported. Check the list of supported fields
+[in Kratos' source code](https://github.com/ory/kratos/blob/v0.5.1-alpha.1/selfservice/strategy/oidc/provider_discord.go#L81-L91).
 
-With scope `identify`:
+The `identify` scope will add following fields:
 
 ```text
 iss                 # always https://discord.com/api/v6/oauth2/
@@ -73,11 +75,10 @@ picture             # avatar url
 locale              # user locale
 ```
 
-With Scope `email`:
+Additionally, the `email` scope will add:
 
 ```text
-iss                 # always https://discord.com/api/v6/oauth2/
-email               # email
+email               # user email
 email_verified      # whether email is verified
 ```
 


### PR DESCRIPTION
## Proposed changes

* Adds reference to where the claims struct is built
* Removes statement that `iss` claim is added by `email` scope. It is only be added by the `identify` scope
* Makes it more clear that the `email` scope is an addition to the `identify` scope. `email` does not work / has no function without `identify`

## Checklist

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [X] I have added or changed [the documentation](docs/docs).