### PR TITLE
Fix docosaurus admonitions

### DIFF
--- a/docs/docs/self-service/flows/account-recovery.mdx
+++ b/docs/docs/self-service/flows/account-recovery.mdx
@@ -21,7 +21,7 @@ import {
 } from './code/recovery'
 import RenderFlow from '@theme/Code/RenderFlow'
 
-:::information
+:::info
 
 Please read the [Self-Service Flows](../../self-service) overview before
 continuing with this document.

--- a/docs/docs/self-service/flows/user-login.mdx
+++ b/docs/docs/self-service/flows/user-login.mdx
@@ -18,7 +18,7 @@ import {
 } from './code/login'
 import RenderFlow from '@theme/Code/RenderFlow'
 
-:::information
+:::info
 
 Please read the [Self-Service Flows](../../self-service) overview before
 continuing with this document.

--- a/docs/docs/self-service/flows/user-registration.mdx
+++ b/docs/docs/self-service/flows/user-registration.mdx
@@ -20,7 +20,7 @@ import {
 } from './code/registration'
 import RenderFlow from '@theme/Code/RenderFlow'
 
-:::information
+:::info
 
 Please read the [Self-Service Flows](../../self-service.mdx) overview before
 continuing with this document. It is also advised to run the

--- a/docs/docs/self-service/flows/user-settings.mdx
+++ b/docs/docs/self-service/flows/user-settings.mdx
@@ -20,7 +20,7 @@ import {
 } from './code/settings'
 import RenderFlow from '@theme/Code/RenderFlow'
 
-:::information
+:::info
 
 Please read the [Self-Service Flows](../../self-service.mdx) overview before
 continuing with this document.

--- a/docs/docs/self-service/flows/verify-email-account-activation.mdx
+++ b/docs/docs/self-service/flows/verify-email-account-activation.mdx
@@ -21,7 +21,7 @@ import {
 } from './code/verification'
 import RenderFlow from '@theme/Code/RenderFlow'
 
-:::information
+:::info
 
 Please read the [Self-Service Flows](../../self-service) overview before
 continuing with this document.

--- a/docs/versioned_docs/version-v0.5/self-service/flows/account-recovery.mdx
+++ b/docs/versioned_docs/version-v0.5/self-service/flows/account-recovery.mdx
@@ -21,7 +21,7 @@ import {
 } from './code/recovery'
 import RenderFlow from '@theme/Code/RenderFlow'
 
-:::information
+:::info
 
 Please read the [Self-Service Flows](../../self-service) overview before
 continuing with this document.

--- a/docs/versioned_docs/version-v0.5/self-service/flows/user-login.mdx
+++ b/docs/versioned_docs/version-v0.5/self-service/flows/user-login.mdx
@@ -18,7 +18,7 @@ import {
 } from './code/login'
 import RenderFlow from '@theme/Code/RenderFlow'
 
-:::information
+:::info
 
 Please read the [Self-Service Flows](../../self-service) overview before
 continuing with this document.

--- a/docs/versioned_docs/version-v0.5/self-service/flows/user-registration.mdx
+++ b/docs/versioned_docs/version-v0.5/self-service/flows/user-registration.mdx
@@ -20,7 +20,7 @@ import {
 } from './code/registration'
 import RenderFlow from '@theme/Code/RenderFlow'
 
-:::information
+:::info
 
 Please read the [Self-Service Flows](../../self-service.mdx) overview before
 continuing with this document. It is also advised to run the

--- a/docs/versioned_docs/version-v0.5/self-service/flows/user-settings.mdx
+++ b/docs/versioned_docs/version-v0.5/self-service/flows/user-settings.mdx
@@ -20,7 +20,7 @@ import {
 } from './code/settings'
 import RenderFlow from '@theme/Code/RenderFlow'
 
-:::information
+:::info
 
 Please read the [Self-Service Flows](../../self-service.mdx) overview before
 continuing with this document.

--- a/docs/versioned_docs/version-v0.5/self-service/flows/verify-email-account-activation.mdx
+++ b/docs/versioned_docs/version-v0.5/self-service/flows/verify-email-account-activation.mdx
@@ -21,7 +21,7 @@ import {
 } from './code/verification'
 import RenderFlow from '@theme/Code/RenderFlow'
 
-:::information
+:::info
 
 Please read the [Self-Service Flows](../../self-service) overview before
 continuing with this document.


### PR DESCRIPTION
## Related issue

None.

## Proposed changes

Trivial documentation fix: Use correct syntax for `info` [docosaurus admonitions](https://v2.docusaurus.io/docs/markdown-features/#calloutsadmonitions)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments

None.