### PR TITLE
fix: case in settings handler method

### DIFF
--- a/selfservice/flow/settings/handler.go
+++ b/selfservice/flow/settings/handler.go
@@ -77,7 +77,7 @@ func (h *Handler) RegisterPublicRoutes(public *x.RouterPublic) {
 	public.GET(RouteInitBrowserFlow, h.d.SessionHandler().IsAuthenticated(h.initBrowserFlow, redirect))
 	public.GET(RouteInitAPIFlow, h.d.SessionHandler().IsAuthenticated(h.initApiFlow, nil))
 
-	public.GET(RouteGetFlow, h.d.SessionHandler().IsAuthenticated(h.fetchPublicFLow, OnUnauthenticated(h.c, h.d)))
+	public.GET(RouteGetFlow, h.d.SessionHandler().IsAuthenticated(h.fetchPublicFlow, OnUnauthenticated(h.c, h.d)))
 }
 
 func (h *Handler) RegisterAdminRoutes(admin *x.RouterAdmin) {
@@ -228,7 +228,7 @@ type getSelfServiceSettingsFlowParameters struct {
 //       404: genericError
 //       410: genericError
 //       500: genericError
-func (h *Handler) fetchPublicFLow(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+func (h *Handler) fetchPublicFlow(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	if err := h.fetchFlow(w, r, true); err != nil {
 		h.d.Writer().WriteError(w, r, err)
 		return


### PR DESCRIPTION
## Related issue

None.

## Proposed changes

Fixes a spelling error in the selfservice settings handler method `fetchPublicFlow`. This method is not part of any interface, thus I _guess_ that it is private (i.e., not exposed to anything outside the file).

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

None.