### PR TITLE
docs: fix oidc config examples

### DIFF
--- a/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
+++ b/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
@@ -42,13 +42,13 @@ To set up "Sign in with Discord" you must create a [Discord OAuth2 Application](
 Set the "Redirect URI" to:
 
 ```
-http://127.0.0.1:4455/.ory/kratos/public/self-service/browser/flows/strategies/oidc/callback/discord
+http://127.0.0.1:4433/self-service/methods/oidc/callback/discord
 ```
 
 The pattern of this URL is:
 
 ```
-http(s)://<domain-of-ory-kratos>:<public-port>/self-service/browser/flows/strategies/oidc/callback/<provider-id>
+http(s)://<domain-of-ory-kratos>:<public-port>/self-service/methods/oidc/callback/<provider-id>
 ```
 
 The provider ID must point to the provider's ID set in the ORY Kratos
@@ -110,7 +110,7 @@ Now, enable the Discord provider in the ORY Kratos config located at
 ```yaml title="contrib/quickstart/kratos/email-password/.kratos.yml"
 # $ kratos -c path/to/my/kratos/config.yml serve
 selfservice:
-  strategies:
+  methods:
     oidc:
       enabled: true
       config:
@@ -225,13 +225,13 @@ To set up "Sign in with GitLab" you must create a [GitLab OAuth2 Application](ht
 Set the "Redirect URI" to:
 
 ```
-http://127.0.0.1:4455/.ory/kratos/public/self-service/browser/flows/strategies/oidc/callback/gitlab
+http://127.0.0.1:4433/self-service/methods/oidc/callback/gitlab
 ```
 
 The pattern of this URL is:
 
 ```
-http(s)://<domain-of-ory-kratos>:<public-port>/self-service/browser/flows/strategies/oidc/callback/<provider-id>
+http(s)://<domain-of-ory-kratos>:<public-port>/self-service/methods/oidc/callback/<provider-id>
 ```
 
 :::note
@@ -266,7 +266,7 @@ Now, enable the GitLab provider in the ORY Kratos config located at
 ```yaml title="contrib/quickstart/kratos/email-password/.kratos.yml"
 # $ kratos -c path/to/my/kratos/config.yml serve
 selfservice:
-  strategies:
+  methods:
     oidc:
       enabled: true
       config:
@@ -377,13 +377,13 @@ To set up "Sign in with Twitch" you must create a [Twitch OAuth2 Application](ht
 Set the "Redirect URI" to:
 
 ```
-http://127.0.0.1:4455/.ory/kratos/public/self-service/browser/flows/strategies/oidc/callback/twitch
+http://127.0.0.1:4433/self-service/methods/oidc/callback/twitch
 ```
 
 The pattern of this URL is:
 
 ```
-http(s)://<domain-of-ory-kratos>:<public-port>/self-service/browser/flows/strategies/oidc/callback/<provider-id>
+http(s)://<domain-of-ory-kratos>:<public-port>/self-service/methods/oidc/callback/<provider-id>
 ```
 
 The provider ID must point to the provider's ID set in the ORY Kratos

--- a/docs/versioned_docs/version-v0.5/guides/sign-in-with-github-google-facebook-linkedin.mdx
+++ b/docs/versioned_docs/version-v0.5/guides/sign-in-with-github-google-facebook-linkedin.mdx
@@ -42,13 +42,13 @@ To set up "Sign in with Discord" you must create a [Discord OAuth2 Application](
 Set the "Redirect URI" to:
 
 ```
-http://127.0.0.1:4455/.ory/kratos/public/self-service/browser/flows/strategies/oidc/callback/discord
+http://127.0.0.1:4433/self-service/methods/oidc/callback/discord
 ```
 
 The pattern of this URL is:
 
 ```
-http(s)://<domain-of-ory-kratos>:<public-port>/self-service/browser/flows/strategies/oidc/callback/<provider-id>
+http(s)://<domain-of-ory-kratos>:<public-port>/self-service/methods/oidc/callback/<provider-id>
 ```
 
 The provider ID must point to the provider's ID set in the ORY Kratos
@@ -110,7 +110,7 @@ Now, enable the Discord provider in the ORY Kratos config located at
 ```yaml title="contrib/quickstart/kratos/email-password/.kratos.yml"
 # $ kratos -c path/to/my/kratos/config.yml serve
 selfservice:
-  strategies:
+  methods:
     oidc:
       enabled: true
       config:
@@ -225,13 +225,13 @@ To set up "Sign in with GitLab" you must create a [GitLab OAuth2 Application](ht
 Set the "Redirect URI" to:
 
 ```
-http://127.0.0.1:4455/.ory/kratos/public/self-service/browser/flows/strategies/oidc/callback/gitlab
+http://127.0.0.1:4433/self-service/methods/oidc/callback/gitlab
 ```
 
 The pattern of this URL is:
 
 ```
-http(s)://<domain-of-ory-kratos>:<public-port>/self-service/browser/flows/strategies/oidc/callback/<provider-id>
+http(s)://<domain-of-ory-kratos>:<public-port>/self-service/methods/oidc/callback/<provider-id>
 ```
 
 :::note
@@ -266,7 +266,7 @@ Now, enable the GitLab provider in the ORY Kratos config located at
 ```yaml title="contrib/quickstart/kratos/email-password/.kratos.yml"
 # $ kratos -c path/to/my/kratos/config.yml serve
 selfservice:
-  strategies:
+  methods:
     oidc:
       enabled: true
       config:
@@ -377,13 +377,13 @@ To set up "Sign in with Twitch" you must create a [Twitch OAuth2 Application](ht
 Set the "Redirect URI" to:
 
 ```
-http://127.0.0.1:4455/.ory/kratos/public/self-service/browser/flows/strategies/oidc/callback/twitch
+http://127.0.0.1:4433/self-service/methods/oidc/callback/twitch
 ```
 
 The pattern of this URL is:
 
 ```
-http(s)://<domain-of-ory-kratos>:<public-port>/self-service/browser/flows/strategies/oidc/callback/<provider-id>
+http(s)://<domain-of-ory-kratos>:<public-port>/self-service/methods/oidc/callback/<provider-id>
 ```
 
 The provider ID must point to the provider's ID set in the ORY Kratos


### PR DESCRIPTION
## Related issue

None

## Proposed changes

It looks like some of the docs for the oidc login method still reflect url patterns and `yaml` structure used before 89851896 and 9369d1bb

Update those docs to match the code.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

None