### PR TITLE
docs: remove leftover category from reference sidebar

### DIFF
--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -78,24 +78,6 @@
         "cli/kratos-serve", 
         "cli/kratos-version"
       ]
-    }, 
-    {
-      "items": [
-        "cli/kratos", 
-        "cli/kratos-identities", 
-        "cli/kratos-identities-delete", 
-        "cli/kratos-identities-get", 
-        "cli/kratos-identities-import", 
-        "cli/kratos-identities-list", 
-        "cli/kratos-identities-patch", 
-        "cli/kratos-identities-validate", 
-        "cli/kratos-jsonnet", 
-        "cli/kratos-jsonnet-format", 
-        "cli/kratos-jsonnet-lint", 
-        "cli/kratos-remote", 
-        "cli/kratos-remote-status", 
-        "cli/kratos-remote-version"
-      ]
     }
   ],
   "Debug & Help": [

--- a/docs/versioned_sidebars/version-v0.5-sidebars.json
+++ b/docs/versioned_sidebars/version-v0.5-sidebars.json
@@ -277,69 +277,6 @@
               "id": "version-v0.5/cli/kratos-remote-version"
             }
           ]
-        },
-        {
-          "collapsed": true,
-          "type": "category",
-          "label": "items",
-          "items": [
-            {
-              "type": "doc",
-              "id": "version-v0.5/cli/kratos"
-            },
-            {
-              "type": "doc",
-              "id": "version-v0.5/cli/kratos-identities"
-            },
-            {
-              "type": "doc",
-              "id": "version-v0.5/cli/kratos-identities-delete"
-            },
-            {
-              "type": "doc",
-              "id": "version-v0.5/cli/kratos-identities-get"
-            },
-            {
-              "type": "doc",
-              "id": "version-v0.5/cli/kratos-identities-import"
-            },
-            {
-              "type": "doc",
-              "id": "version-v0.5/cli/kratos-identities-list"
-            },
-            {
-              "type": "doc",
-              "id": "version-v0.5/cli/kratos-identities-patch"
-            },
-            {
-              "type": "doc",
-              "id": "version-v0.5/cli/kratos-identities-validate"
-            },
-            {
-              "type": "doc",
-              "id": "version-v0.5/cli/kratos-jsonnet"
-            },
-            {
-              "type": "doc",
-              "id": "version-v0.5/cli/kratos-jsonnet-format"
-            },
-            {
-              "type": "doc",
-              "id": "version-v0.5/cli/kratos-jsonnet-lint"
-            },
-            {
-              "type": "doc",
-              "id": "version-v0.5/cli/kratos-remote"
-            },
-            {
-              "type": "doc",
-              "id": "version-v0.5/cli/kratos-remote-status"
-            },
-            {
-              "type": "doc",
-              "id": "version-v0.5/cli/kratos-remote-version"
-            }
-          ]
         }
       ]
     },


### PR DESCRIPTION
## Related issue
There was a leftover category in the sidebar from old CLI docs generation.