### PR TITLE
fix: set samesite attribute to lax if in dev mode

### DIFF
--- a/x/nosurf.go
+++ b/x/nosurf.go
@@ -90,14 +90,19 @@ func NewCSRFHandler(
 	secure bool,
 ) *nosurf.CSRFHandler {
 	n := nosurf.New(router)
+
+	samesiteattribute := http.SameSiteNoneMode
+	if !secure {
+		samesiteattribute = http.SameSiteLaxMode
+	}
+
 	n.SetBaseCookie(http.Cookie{
 		MaxAge:   nosurf.MaxAge,
 		Path:     path,
 		Domain:   domain,
 		HttpOnly: true,
 		Secure:   secure,
-		// SameSiteNoneMode is set because
-		SameSite: http.SameSiteNoneMode,
+		SameSite: samesiteattribute,
 	})
 	n.SetFailureHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		logger.


### PR DESCRIPTION
## Related issue

https://github.com/ory/kratos/issues/821

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

This PR will set the SameSite attribute to Lax if ran in dev mode.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

This lacks tests. Help with those would be appreciated.
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
