### PR TITLE
fix: CSRF token is required when using the Revoke Session API endpoint

### DIFF
--- a/session/handler.go
+++ b/session/handler.go
@@ -50,6 +50,7 @@ const (
 
 func (h *Handler) RegisterPublicRoutes(public *x.RouterPublic) {
 	h.r.CSRFHandler().ExemptPath(RouteWhoami)
+	h.r.CSRFHandler().ExemptPath(RouteRevoke)
 
 	for _, m := range []string{http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut, http.MethodPatch,
 		http.MethodDelete, http.MethodConnect, http.MethodOptions, http.MethodTrace} {


### PR DESCRIPTION
## Related issue

#838 

## Proposed changes

Exempt the Revoke Session endpoint from requiring a CSRF token.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

I followed the example of the `RouteWhoami` CSRF exemption in `session/handler.go`.

My go skills need some work, so any recommendations on tests or whatever would be welcome. :smile: 
