### PR TITLE
docs: fix typo

### DIFF
--- a/docs/docs/concepts/credentials/username-email-password.mdx
+++ b/docs/docs/concepts/credentials/username-email-password.mdx
@@ -111,7 +111,7 @@ special meaning for some E-Mail Providers (e.g. GMail) are not normalized:
 - `userNAME` is equal to `username`
 - `foo@BaR.com` is equal to `foo@bar.com`
 - `foo+baz@bar.com` is NOT equal to `foo@bar.com`
-- `foo.baz@bar.com` is NOT equal to `foobar@bar.com`
+- `foo.baz@bar.com` is NOT equal to `foobaz@bar.com`
 
 You need to decide which route you want to take.
 


### PR DESCRIPTION
## Related issue
## Proposed changes

Typo on the Username / Email & Password credentials docs page.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments
