### PR TITLE
Use working cache-control header for cdn/proxies/cache

### DIFF
--- a/x/nocache.go
+++ b/x/nocache.go
@@ -6,12 +6,12 @@ import (
 	"github.com/julienschmidt/httprouter"
 )
 
-// NoCache adds `Cache-Control: 0` to the response header.
+// NoCache adds `Cache-Control: private, no-cache, no-store, must-revalidate` to the response header.
 func NoCache(w http.ResponseWriter) {
-	w.Header().Set("Cache-Control", "0")
+	w.Header().Set("Cache-Control", "private, no-cache, no-store, must-revalidate")
 }
 
-// NoCacheHandler wraps httprouter.Handle with `Cache-Control: 0` headers.
+// NoCacheHandler wraps httprouter.Handle with `Cache-Control: private, no-cache, no-store, must-revalidate` headers.
 func NoCacheHandler(handle httprouter.Handle) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 		NoCache(w)


### PR DESCRIPTION
## Related issue

#601 

## Proposed changes

Cache-control: 0 has, to my understanding, no specific meaning, and in the case of using a CDN such as CloudFront, doesn't actually limit caching of values - this leads to re-use of CSRF cookies and flow session ID's.

Using a more-specific set of cache-control directives prevents CloudFront from caching the result of those URL's that explicitly want no caching, including CDN's.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

I've worked around this by setting up a specific non-caching behavior for ORY Kratos url's, but the patch above should work across CDN's and caching proxies.