### PR TITLE
fix: :memo: quickfix ory home directory path in section docker of the documentation

### DIFF
--- a/docs/versioned_docs/version-v0.5/guides/docker.md
+++ b/docs/versioned_docs/version-v0.5/guides/docker.md
@@ -82,7 +82,7 @@ below:
 
 ```dockerfile
 FROM oryd/kratos:latest
-COPY contrib/quickstart/kratos/email-password/.kratos.yml /ory/home
+COPY contrib/quickstart/kratos/email-password/.kratos.yml /home/ory
 ```
 
 ### Examples


### PR DESCRIPTION
## Related issue

No issue, I was just reading the doc and took the initiative to fix wrong code section

## Proposed changes

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).
