### PR TITLE
chore: update repository template to acd797ac

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: ORY Community
-    url: https://community.ory.sh/
-    about: Please ask and answer questions here.
+    url: https://www.github.com/Kratos/discussions
+    about: Please ask and answer questions here, show your implementations and discuss ideas.
   - name: ORY Chat
     url: https://www.ory.sh/chat
     about: Hang out with other ORY community members and ask and answer questions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,8 +49,9 @@ contributions, and don't want a wall of rules to get in the way of that.
 That said, if you want to ensure that a pull request is likely to be merged,
 talk to us! You can find out our thoughts and ensure that your contribution
 won't clash or be obviated by ORY Kratos's normal direction. A great way to
-do this is via the [ORY Community](https://community.ory.sh/) or join the
-[ORY Chat](https://www.ory.sh/chat).
+do this is via
+[ORY Kratos Discussions](https://github.com/ory/Kratos/discussions) or
+the [ORY Chat](https://www.ory.sh/chat).
 
 ## FAQ
 
@@ -110,8 +111,10 @@ a few things you can do to help out:
 We use [Slack](https://www.ory.sh/chat). You are welcome to drop in and ask
 questions, discuss bugs and feature requests, talk to other users of ORY, etc.
 
-We have a [forum](https://community.ory.sh/). This is a great place for in-depth
-discussions and lots of code examples, logs and similar data.
+Check out
+[ORY Kratos Discussions](https://github.com/ory/Kratos/discussions).
+This is a great place for in-depth discussions and lots of code examples, logs
+and similar data.
 
 You can also join our community hangout, if you want to speak to the ORY team
 directly or ask some questions. You can find more info on the hangouts in

--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -54,8 +54,8 @@ contributions, and don't want a wall of rules to get in the way of that.
 That said, if you want to ensure that a pull request is likely to be merged,
 talk to us! You can find out our thoughts and ensure that your contribution
 won't clash or be obviated by ORY Kratos's normal direction. A great way to do
-this is via the [ORY Community](https://community.ory.sh/) or join the
-[ORY Chat](https://www.ory.sh/chat).
+this is via [ORY Kratos Discussions](https://github.com/ory/Kratos/discussions)
+or the [ORY Chat](https://www.ory.sh/chat).
 
 ## FAQ
 
@@ -115,8 +115,9 @@ a few things you can do to help out:
 We use [Slack](https://www.ory.sh/chat). You are welcome to drop in and ask
 questions, discuss bugs and feature requests, talk to other users of ORY, etc.
 
-We have a [forum](https://community.ory.sh/). This is a great place for in-depth
-discussions and lots of code examples, logs and similar data.
+Check out [ORY Kratos Discussions](https://github.com/ory/Kratos/discussions).
+This is a great place for in-depth discussions and lots of code examples, logs
+and similar data.
 
 You can also join our community hangout, if you want to speak to the ORY team
 directly or ask some questions. You can find more info on the hangouts in

--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -24,6 +24,31 @@
         "cli/kratos-serve", 
         "cli/kratos-version"
       ]
+    }, 
+    {
+      "items": [
+        "cli/kratos", 
+        "cli/kratos-hashers", 
+        "cli/kratos-hashers-argon2", 
+        "cli/kratos-hashers-argon2-calibrate", 
+        "cli/kratos-identities", 
+        "cli/kratos-identities-delete", 
+        "cli/kratos-identities-get", 
+        "cli/kratos-identities-import", 
+        "cli/kratos-identities-list", 
+        "cli/kratos-identities-patch", 
+        "cli/kratos-identities-validate", 
+        "cli/kratos-jsonnet", 
+        "cli/kratos-jsonnet-format", 
+        "cli/kratos-jsonnet-lint", 
+        "cli/kratos-migrate", 
+        "cli/kratos-migrate-sql", 
+        "cli/kratos-remote", 
+        "cli/kratos-remote-status", 
+        "cli/kratos-remote-version", 
+        "cli/kratos-serve", 
+        "cli/kratos-version"
+      ]
     }
   ],
   "Introduction": [


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/acd797aca2a50531371de69a166a606141104227.