### PR TITLE
docs: fix note block in third party login guide

### DIFF
--- a/docs/versioned_docs/version-v0.5/guides/sign-in-with-github-google-facebook-linkedin.mdx
+++ b/docs/versioned_docs/version-v0.5/guides/sign-in-with-github-google-facebook-linkedin.mdx
@@ -237,12 +237,16 @@ The pattern of this URL is:
 http(s)://<domain-of-ory-kratos>:<public-port>/self-service/methods/oidc/callback/<provider-id>
 ```
 
-:::note While you can use
+:::note
+
+While you can use
 [GitLab as an OIDC identity provider](https://docs.gitlab.com/ee/integration/openid_connect_provider.html),
 GitLab only returns the sub and sub_legacy claims in the ID token. Therefore,
 ORY Kratos makes a request to
 [GitLab's /oauth/userinfo API](https://gitlab.com/oauth/userinfo) and adds the
-user info to `std.extVar('claims')`. :::
+user info to `std.extVar('claims')`.
+
+:::
 
 ```json title="contrib/quickstart/kratos/email-password/oidc.gitlab.jsonnet"
 local claims = {


### PR DESCRIPTION
## Proposed changes

This fixes a mistake in formatting for the documentation for third party logins, introduced in commit 62b4d63. A `:::note` block encapsulated more content than it was supposed to and thus altered the structure of the document.

![image](https://user-images.githubusercontent.com/5056880/102503326-e449d400-407f-11eb-956f-5126bfa7a9f5.png)


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [X] I have added or changed [the documentation](docs/docs).
