### PR TITLE
fix: use csrf none mode only when --dev is enabled

### DIFF
--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -174,6 +174,31 @@
         "cli/kratos-serve", 
         "cli/kratos-version"
       ]
+    }, 
+    {
+      "items": [
+        "cli/kratos", 
+        "cli/kratos-hashers", 
+        "cli/kratos-hashers-argon2", 
+        "cli/kratos-hashers-argon2-calibrate", 
+        "cli/kratos-identities", 
+        "cli/kratos-identities-delete", 
+        "cli/kratos-identities-get", 
+        "cli/kratos-identities-import", 
+        "cli/kratos-identities-list", 
+        "cli/kratos-identities-patch", 
+        "cli/kratos-identities-validate", 
+        "cli/kratos-jsonnet", 
+        "cli/kratos-jsonnet-format", 
+        "cli/kratos-jsonnet-lint", 
+        "cli/kratos-migrate", 
+        "cli/kratos-migrate-sql", 
+        "cli/kratos-remote", 
+        "cli/kratos-remote-status", 
+        "cli/kratos-remote-version", 
+        "cli/kratos-serve", 
+        "cli/kratos-version"
+      ]
     }
   ],
   "Introduction": [

--- a/x/nosurf.go
+++ b/x/nosurf.go
@@ -91,9 +91,9 @@ func NewCSRFHandler(
 ) *nosurf.CSRFHandler {
 	n := nosurf.New(router)
 
-	samesiteattribute := http.SameSiteNoneMode
+	samesiteattribute := http.SameSiteLaxMode
 	if !secure {
-		samesiteattribute = http.SameSiteLaxMode
+		samesiteattribute = http.SameSiteNoneMode
 	}
 
 	n.SetBaseCookie(http.Cookie{


### PR DESCRIPTION
Do not merge this yet. `SameSite` should be `Strict` for CSRF unless the TLD of ORY Kratos and the TLD of the UI do not share a domain. Instead, we should probably allow customizing the CSRF cookie:

- Allow setting the domain and path of the CSRF cookie
- Allow setting samesite of the CSRF cookie
- Fail setting `SameSite=None` when `--dev` is used.