### PR TITLE
docs: Update security mechanism specification to match code

### DIFF
--- a/swagger_meta.go
+++ b/swagger_meta.go
@@ -19,6 +19,14 @@
 //          type: apiKey
 //          name: X-Session-Token
 //          in: header
+//     sessionBearerToken:
+//          type: apiKey
+//          name: Authorization
+//          in: header
+//     sessionCookie:
+//          type: apiKey
+//          name: Cookie
+//          in: header
 //
 //     Extensions:
 //     ---


### PR DESCRIPTION
As seen in https://github.com/ory/kratos/blob/master/session/manager_http.go#L98 the session token can be extracted in one of three different ways from the request.  This change updates the swagger definition for security to show all three possibilities.

## Related issue
#938 

## Proposed changes
After this, the security sections of the various apis will need to be updated to support the three mechanisms

## Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments
This matters because of things like auto-generated rest clients based on the swagger specification