### PR TITLE
chore: update repository template to d3a24380

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
-  - name: ORY Kratos Forum
-    url: https://github.com/ory/kratos/discussions
+  - name: ORY ${PROJECT} Forum
+    url: https://github.com/${REPOSITORY}/discussions
     about: Please ask and answer questions here, show your implementations and discuss ideas.
   - name: ORY Chat
     url: https://www.ory.sh/chat
     about: Hang out with other ORY community members and ask and answer questions.
   - name: ORY Support for Business
     url: https://github.com/ory/open-source-support/blob/master/README.md
-    about: Buy professional support for ORY Kratos.
+    about: Buy professional support for ORY ${PROJECT}.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ https://github.com/ory/meta/blob/master/templates/repository/common/CONTRIBUTING
 
 -->
 
-# Contributing to ORY Kratos
+# Contributing to ORY ${PROJECT}
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -33,8 +33,8 @@ There are many ways in which you can contribute, beyond writing code. The goal
 of this document is to provide a high-level overview of how you can get
 involved.
 
-_Please note_: We take ORY Kratos's security and our users' trust very
-seriously. If you believe you have found a security issue in ORY Kratos,
+_Please note_: We take ORY ${PROJECT}'s security and our users' trust very
+seriously. If you believe you have found a security issue in ORY ${PROJECT},
 please responsibly disclose by contacting us at security@ory.sh.
 
 First: As a potential contributor, your changes and ideas are welcome at any
@@ -49,43 +49,43 @@ contributions, and don't want a wall of rules to get in the way of that.
 That said, if you want to ensure that a pull request is likely to be merged,
 talk to us! You can find out our thoughts and ensure that your contribution
 won't clash or be obviated by ORY
-Kratos's normal direction. A great way to
+${PROJECT}'s normal direction. A great way to
 do this is via
-[ORY Kratos Discussions](https://github.com/ory/kratos/discussions)
+[ORY ${PROJECT} Discussions](https://github.com/${REPOSITORY}/discussions)
 or the [ORY Chat](https://www.ory.sh/chat).
 
 ## FAQ
 
 - I am new to the community. Where can I find the
-  [ORY Community Code of Conduct?](https://github.com/ory/kratos/blob/master/CODE_OF_CONDUCT.md)
+  [ORY Community Code of Conduct?](https://github.com/${REPOSITORY}/blob/master/CODE_OF_CONDUCT.md)
 
 - I have a question. Where can I get
-  [answers to questions regarding ORY Kratos?](#communication)
+  [answers to questions regarding ORY ${PROJECT}?](#communication)
 
 - I would like to contribute but I am not sure how. Are there
   [easy ways to contribute?](#how-can-i-contribute)
   [Or good first issues?](https://github.com/search?l=&o=desc&q=label%3A%22help+wanted%22+label%3A%22good+first+issue%22+is%3Aopen+user%3Aory+user%3Aory-corp&s=updated&type=Issues)
 
-- I want to talk to other ORY Kratos users.
+- I want to talk to other ORY ${PROJECT} users.
   [How can I become a part of the community?](#communication)
 
 - I would like to know what I am agreeing to when I contribute to ORY
-  Kratos. Does ORY have
+  ${PROJECT}. Does ORY have
   [a Contributors License Agreement?](https://cla-assistant.io/ory/)
 
-- I would like updates about new versions of ORY Kratos.
+- I would like updates about new versions of ORY ${PROJECT}.
   [How are new releases announced?](https://ory.us10.list-manage.com/subscribe?u=ffb1a878e4ec6c0ed312a3480&id=f605a41b53)
 
 ## How can I contribute?
 
 If you want to start contributing code right away, we have a
-[list of good first issues](https://github.com/ory/kratos/labels/good%20first%20issue).
+[list of good first issues](https://github.com/${REPOSITORY}/labels/good%20first%20issue).
 
 There are many other ways you can contribute without writing any code. Here are
 a few things you can do to help out:
 
 - **Give us a star.** It may not seem like much, but it really makes a
-  difference. This is something that everyone can do to help out ORY Kratos.
+  difference. This is something that everyone can do to help out ORY ${PROJECT}.
   Github stars help the project gain visibility and stand out.
 
 - **Join the community.** Sometimes helping people can be as easy as listening
@@ -93,7 +93,7 @@ a few things you can do to help out:
   look at discussions in the forum and take part in our weekly hangout. More
   info on this in [Communication](#communication).
 
-- **Helping with open issues.** We have a lot of open issues for ORY Kratos
+- **Helping with open issues.** We have a lot of open issues for ORY ${PROJECT}
   and some of them may lack necessary information, some are duplicates of older
   issues. You can help out by guiding people through the process of filling out
   the issue template, asking for clarifying information, or pointing them to
@@ -113,7 +113,7 @@ We use [Slack](https://www.ory.sh/chat). You are welcome to drop in and ask
 questions, discuss bugs and feature requests, talk to other users of ORY, etc.
 
 Check out
-[ORY Kratos Discussions](https://github.com/ory/kratos/discussions). This
+[ORY ${PROJECT} Discussions](https://github.com/${REPOSITORY}/discussions). This
 is a great place for in-depth discussions and lots of code examples, logs and
 similar data.
 
@@ -121,7 +121,7 @@ You can also join our community hangout, if you want to speak to the ORY team
 directly or ask some questions. You can find more info on the hangouts in
 [Slack](https://www.ory.sh/chat).
 
-If you want to receive regular notifications about updates to ORY Kratos,
+If you want to receive regular notifications about updates to ORY ${PROJECT},
 consider joining the mailing list. We will _only_ send you vital information on
 the projects that you are interested in.
 
@@ -131,7 +131,7 @@ Also [follow us on twitter](https://twitter.com/orycorp).
 
 Unless you are fixing a known bug, we **strongly** recommend discussing it with
 the core team via a GitHub issue or [in our chat](https://www.ory.sh/chat)
-before getting started to ensure your work is consistent with ORY Kratos's
+before getting started to ensure your work is consistent with ORY ${PROJECT}'s
 roadmap and architecture.
 
 All contributions are made via pull request. Note that **all patches from all
@@ -162,11 +162,11 @@ should be merged by the submitter after review.
 
 Please provide documentation when changing, removing, or adding features.
 Documentation resides in the project's
-[docs](https://github.com/ory/kratos/tree/master/docs) folder. Generate API
+[docs](https://github.com/${REPOSITORY}/tree/master/docs) folder. Generate API
 and configuration reference documentation using `cd docs; npm run gen`.
 
 For further instructions please head over to
-[docs/README.md](https://github.com/ory/kratos/blob/master/README.md).
+[docs/README.md](https://github.com/${REPOSITORY}/blob/master/README.md).
 
 ## Disclosing vulnerabilities
 
@@ -209,10 +209,10 @@ please include a note in your commit message explaining why.
 
 ```
 # First you clone the original repository
-git clone git@github.com:ory/Kratos.git
+git clone git@github.com:ory/${PROJECT}.git
 
 # Next you add a git remote that is your fork:
-git remote add fork git@github.com:<YOUR-GITHUB-USERNAME-HERE>/Kratos.git
+git remote add fork git@github.com:<YOUR-GITHUB-USERNAME-HERE>/${PROJECT}.git
 
 # Next you fetch the latest changes from origin for master:
 git fetch origin
@@ -249,7 +249,7 @@ community a safe place for you and we've got your back.
 - Private harassment is also unacceptable. No matter who you are, if you feel
   you have been or are being harassed or made uncomfortable by a community
   member, please contact one of the channel ops or a member of the ORY
-  Kratos core team immediately.
+  ${PROJECT} core team immediately.
 - Likewise any spamming, trolling, flaming, baiting or other attention-stealing
   behaviour is not welcome.
 

--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -13,7 +13,7 @@ https://github.com/ory/meta/blob/master/templates/repository/common/CONTRIBUTING
 
 -->
 
-# Contributing to ORY Kratos
+# Contributing to ORY ${PROJECT}
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -38,9 +38,9 @@ There are many ways in which you can contribute, beyond writing code. The goal
 of this document is to provide a high-level overview of how you can get
 involved.
 
-_Please note_: We take ORY Kratos's security and our users' trust very
-seriously. If you believe you have found a security issue in ORY Kratos, please
-responsibly disclose by contacting us at security@ory.sh.
+_Please note_: We take ORY ${PROJECT}'s security and our users' trust very
+seriously. If you believe you have found a security issue in ORY ${PROJECT},
+please responsibly disclose by contacting us at security@ory.sh.
 
 First: As a potential contributor, your changes and ideas are welcome at any
 hour of the day or night, weekdays, weekends, and holidays. Please do not ever
@@ -53,42 +53,44 @@ contributions, and don't want a wall of rules to get in the way of that.
 
 That said, if you want to ensure that a pull request is likely to be merged,
 talk to us! You can find out our thoughts and ensure that your contribution
-won't clash or be obviated by ORY Kratos's normal direction. A great way to do
-this is via [ORY Kratos Discussions](https://github.com/ory/kratos/discussions)
+won't clash or be obviated by ORY
+${PROJECT}'s normal direction. A great way to
+do this is via
+[ORY ${PROJECT} Discussions](https://github.com/${REPOSITORY}/discussions)
 or the [ORY Chat](https://www.ory.sh/chat).
 
 ## FAQ
 
 - I am new to the community. Where can I find the
-  [ORY Community Code of Conduct?](https://github.com/ory/kratos/blob/master/CODE_OF_CONDUCT.md)
+  [ORY Community Code of Conduct?](https://github.com/${REPOSITORY}/blob/master/CODE_OF_CONDUCT.md)
 
 - I have a question. Where can I get
-  [answers to questions regarding ORY Kratos?](#communication)
+  [answers to questions regarding ORY ${PROJECT}?](#communication)
 
 - I would like to contribute but I am not sure how. Are there
   [easy ways to contribute?](#how-can-i-contribute)
   [Or good first issues?](https://github.com/search?l=&o=desc&q=label%3A%22help+wanted%22+label%3A%22good+first+issue%22+is%3Aopen+user%3Aory+user%3Aory-corp&s=updated&type=Issues)
 
-- I want to talk to other ORY Kratos users.
+- I want to talk to other ORY ${PROJECT} users.
   [How can I become a part of the community?](#communication)
 
-- I would like to know what I am agreeing to when I contribute to ORY Kratos.
-  Does ORY have
+- I would like to know what I am agreeing to when I contribute to ORY
+  ${PROJECT}. Does ORY have
   [a Contributors License Agreement?](https://cla-assistant.io/ory/)
 
-- I would like updates about new versions of ORY Kratos.
+- I would like updates about new versions of ORY ${PROJECT}.
   [How are new releases announced?](https://ory.us10.list-manage.com/subscribe?u=ffb1a878e4ec6c0ed312a3480&id=f605a41b53)
 
 ## How can I contribute?
 
 If you want to start contributing code right away, we have a
-[list of good first issues](https://github.com/ory/kratos/labels/good%20first%20issue).
+[list of good first issues](https://github.com/${REPOSITORY}/labels/good%20first%20issue).
 
 There are many other ways you can contribute without writing any code. Here are
 a few things you can do to help out:
 
 - **Give us a star.** It may not seem like much, but it really makes a
-  difference. This is something that everyone can do to help out ORY Kratos.
+  difference. This is something that everyone can do to help out ORY ${PROJECT}.
   Github stars help the project gain visibility and stand out.
 
 - **Join the community.** Sometimes helping people can be as easy as listening
@@ -96,8 +98,8 @@ a few things you can do to help out:
   look at discussions in the forum and take part in our weekly hangout. More
   info on this in [Communication](#communication).
 
-- **Helping with open issues.** We have a lot of open issues for ORY Kratos and
-  some of them may lack necessary information, some are duplicates of older
+- **Helping with open issues.** We have a lot of open issues for ORY ${PROJECT}
+  and some of them may lack necessary information, some are duplicates of older
   issues. You can help out by guiding people through the process of filling out
   the issue template, asking for clarifying information, or pointing them to
   existing issues that match their description of the problem.
@@ -115,15 +117,16 @@ a few things you can do to help out:
 We use [Slack](https://www.ory.sh/chat). You are welcome to drop in and ask
 questions, discuss bugs and feature requests, talk to other users of ORY, etc.
 
-Check out [ORY Kratos Discussions](https://github.com/ory/kratos/discussions).
-This is a great place for in-depth discussions and lots of code examples, logs
-and similar data.
+Check out
+[ORY ${PROJECT} Discussions](https://github.com/${REPOSITORY}/discussions). This
+is a great place for in-depth discussions and lots of code examples, logs and
+similar data.
 
 You can also join our community hangout, if you want to speak to the ORY team
 directly or ask some questions. You can find more info on the hangouts in
 [Slack](https://www.ory.sh/chat).
 
-If you want to receive regular notifications about updates to ORY Kratos,
+If you want to receive regular notifications about updates to ORY ${PROJECT},
 consider joining the mailing list. We will _only_ send you vital information on
 the projects that you are interested in.
 
@@ -133,7 +136,7 @@ Also [follow us on twitter](https://twitter.com/orycorp).
 
 Unless you are fixing a known bug, we **strongly** recommend discussing it with
 the core team via a GitHub issue or [in our chat](https://www.ory.sh/chat)
-before getting started to ensure your work is consistent with ORY Kratos's
+before getting started to ensure your work is consistent with ORY ${PROJECT}'s
 roadmap and architecture.
 
 All contributions are made via pull request. Note that **all patches from all
@@ -164,11 +167,11 @@ should be merged by the submitter after review.
 
 Please provide documentation when changing, removing, or adding features.
 Documentation resides in the project's
-[docs](https://github.com/ory/kratos/tree/master/docs) folder. Generate API and
-configuration reference documentation using `cd docs; npm run gen`.
+[docs](https://github.com/${REPOSITORY}/tree/master/docs) folder. Generate API
+and configuration reference documentation using `cd docs; npm run gen`.
 
 For further instructions please head over to
-[docs/README.md](https://github.com/ory/kratos/blob/master/README.md).
+[docs/README.md](https://github.com/${REPOSITORY}/blob/master/README.md).
 
 ## Disclosing vulnerabilities
 
@@ -211,10 +214,10 @@ please include a note in your commit message explaining why.
 
 ```
 # First you clone the original repository
-git clone git@github.com:ory/Kratos.git
+git clone git@github.com:ory/${PROJECT}.git
 
 # Next you add a git remote that is your fork:
-git remote add fork git@github.com:<YOUR-GITHUB-USERNAME-HERE>/Kratos.git
+git remote add fork git@github.com:<YOUR-GITHUB-USERNAME-HERE>/${PROJECT}.git
 
 # Next you fetch the latest changes from origin for master:
 git fetch origin
@@ -250,8 +253,8 @@ community a safe place for you and we've got your back.
   marginalized groups.
 - Private harassment is also unacceptable. No matter who you are, if you feel
   you have been or are being harassed or made uncomfortable by a community
-  member, please contact one of the channel ops or a member of the ORY Kratos
-  core team immediately.
+  member, please contact one of the channel ops or a member of the ORY
+  ${PROJECT} core team immediately.
 - Likewise any spamming, trolling, flaming, baiting or other attention-stealing
   behaviour is not welcome.
 

--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -274,6 +274,31 @@
         "cli/kratos-serve", 
         "cli/kratos-version"
       ]
+    }, 
+    {
+      "items": [
+        "cli/kratos", 
+        "cli/kratos-hashers", 
+        "cli/kratos-hashers-argon2", 
+        "cli/kratos-hashers-argon2-calibrate", 
+        "cli/kratos-identities", 
+        "cli/kratos-identities-delete", 
+        "cli/kratos-identities-get", 
+        "cli/kratos-identities-import", 
+        "cli/kratos-identities-list", 
+        "cli/kratos-identities-patch", 
+        "cli/kratos-identities-validate", 
+        "cli/kratos-jsonnet", 
+        "cli/kratos-jsonnet-format", 
+        "cli/kratos-jsonnet-lint", 
+        "cli/kratos-migrate", 
+        "cli/kratos-migrate-sql", 
+        "cli/kratos-remote", 
+        "cli/kratos-remote-status", 
+        "cli/kratos-remote-version", 
+        "cli/kratos-serve", 
+        "cli/kratos-version"
+      ]
     }
   ],
   "Introduction": [


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/d3a2438027877f14e8433bb44431544b9b91d210.