### PR TITLE
docs: fix formatting

### DIFF
--- a/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
+++ b/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
@@ -237,12 +237,14 @@ The pattern of this URL is:
 http(s)://<domain-of-ory-kratos>:<public-port>/self-service/methods/oidc/callback/<provider-id>
 ```
 
-:::note While you can use
+:::note 
+While you can use
 [GitLab as an OIDC identity provider](https://docs.gitlab.com/ee/integration/openid_connect_provider.html),
 GitLab only returns the sub and sub_legacy claims in the ID token. Therefore,
 ORY Kratos makes a request to
 [GitLab's /oauth/userinfo API](https://gitlab.com/oauth/userinfo) and adds the
-user info to `std.extVar('claims')`. :::
+user info to `std.extVar('claims')`. 
+:::
 
 ```json title="contrib/quickstart/kratos/email-password/oidc.gitlab.jsonnet"
 local claims = {

--- a/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
+++ b/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
@@ -244,6 +244,7 @@ GitLab only returns the sub and sub_legacy claims in the ID token. Therefore,
 ORY Kratos makes a request to
 [GitLab's /oauth/userinfo API](https://gitlab.com/oauth/userinfo) and adds the
 user info to `std.extVar('claims')`. 
+
 :::
 
 ```json title="contrib/quickstart/kratos/email-password/oidc.gitlab.jsonnet"

--- a/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
+++ b/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
@@ -237,7 +237,8 @@ The pattern of this URL is:
 http(s)://<domain-of-ory-kratos>:<public-port>/self-service/methods/oidc/callback/<provider-id>
 ```
 
-:::note 
+:::note
+
 While you can use
 [GitLab as an OIDC identity provider](https://docs.gitlab.com/ee/integration/openid_connect_provider.html),
 GitLab only returns the sub and sub_legacy claims in the ID token. Therefore,


### PR DESCRIPTION
The :::note::: consumed the whole rest of the page.

The build is failing because of the sidebar.json issue I mentioned in Slack.

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
