### PR TITLE
ci: fix nancy check by stripping the local rewrite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
       - image: circleci/golang:1.15-node
         environment:
           GO111MODULE: 'on'
-    working_directory: /go/src/github.com/ory/hydra
+    working_directory: /go/src/github.com/ory/kratos
     steps:
       - checkout
       - golangci/lint
@@ -133,6 +133,23 @@ jobs:
       - run: |
           bash <(curl -s https://raw.githubusercontent.com/ory/ci/master/src/scripts/install/prettier.sh)
           npm run format:check
+
+  nancy:
+    docker:
+      - image: circleci/golang:1.15-node
+        environment:
+          GO111MODULE: 'on'
+    working_directory: /go/src/github.com/ory/kratos
+    steps:
+      - checkout
+      - run: |
+          set -euxo
+
+          # install nancy
+          curl -L -o $GOPATH/bin/nancy https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.5/nancy-linux.amd64-v1.0.5 && chmod +x $GOPATH/bin/nancy
+
+          # run nancy but without the internal client rewrite
+          go list -m all | sed -r 's/ => .\/internal\/httpclient//' | nancy sleuth --quiet
 
 workflows:
   tbr:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ orbs:
   goreleaser: ory/goreleaser@0.1.20
   slack: circleci/slack@3.4.2
   sdk: ory/sdk@0.1.38
-  nancy: ory/nancy@0.0.13
   docs: ory/docs@0.0.8
   golangci: ory/golangci@0.0.9
 
@@ -154,7 +153,11 @@ jobs:
 workflows:
   tbr:
     jobs:
-      - nancy/test
+      -
+        nancy:
+          filters:
+            tags:
+              only: /.*/
       -
         validate:
           filters:
@@ -165,7 +168,7 @@ workflows:
           flavor: sqlite
           requires:
             - test
-            - nancy/test
+            - nancy
             - validate
           filters:
             tags:

--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -274,6 +274,31 @@
         "cli/kratos-serve", 
         "cli/kratos-version"
       ]
+    }, 
+    {
+      "items": [
+        "cli/kratos", 
+        "cli/kratos-hashers", 
+        "cli/kratos-hashers-argon2", 
+        "cli/kratos-hashers-argon2-calibrate", 
+        "cli/kratos-identities", 
+        "cli/kratos-identities-delete", 
+        "cli/kratos-identities-get", 
+        "cli/kratos-identities-import", 
+        "cli/kratos-identities-list", 
+        "cli/kratos-identities-patch", 
+        "cli/kratos-identities-validate", 
+        "cli/kratos-jsonnet", 
+        "cli/kratos-jsonnet-format", 
+        "cli/kratos-jsonnet-lint", 
+        "cli/kratos-migrate", 
+        "cli/kratos-migrate-sql", 
+        "cli/kratos-remote", 
+        "cli/kratos-remote-status", 
+        "cli/kratos-remote-version", 
+        "cli/kratos-serve", 
+        "cli/kratos-version"
+      ]
     }
   ],
   "Introduction": [

--- a/go.sum
+++ b/go.sum
@@ -1149,6 +1149,7 @@ github.com/ory/herodot v0.9.0 h1:p/V+68/5CWmqEmbSVaLusDBECMt9xJjLtklqU/O63HM=
 github.com/ory/herodot v0.9.0/go.mod h1:GYF7mp8/WFRYDYJBR989lipjgx3NTjjdVdUC+hpB8mc=
 github.com/ory/jsonschema/v3 v3.0.1 h1:xzV7w2rt/Qn+jvh71joIXNKKOCqqNyTlaIxdxU0IQJc=
 github.com/ory/jsonschema/v3 v3.0.1/go.mod h1:jgLHekkFk0uiGdEWGleC+tOm6JSSP8cbf17PnBuGXlw=
+github.com/ory/kratos v0.5.5-alpha.1/go.mod h1:pqr5H6NOA90FxsviyJUj9WOCnXnslLmZvcTYx4GtQiw=
 github.com/ory/kratos v0.5.5-alpha.1.pre.1/go.mod h1:pqr5H6NOA90FxsviyJUj9WOCnXnslLmZvcTYx4GtQiw=
 github.com/ory/mail v2.3.1+incompatible h1:vHntHDHtQXamt2T+iwTTlCoBkDvILUeujE9Ocwe9md4=
 github.com/ory/mail v2.3.1+incompatible/go.mod h1:87D9/1gB6ewElQoN0lXJ0ayfqcj3cW3qCTXh+5E9mfU=

--- a/internal/httpclient/go.mod
+++ b/internal/httpclient/go.mod
@@ -8,5 +8,5 @@ require (
 	github.com/go-openapi/strfmt v0.19.11
 	github.com/go-openapi/swag v0.19.12
 	github.com/go-openapi/validate v0.20.0
-	github.com/ory/kratos v0.5.5-alpha.1.pre.1
+	github.com/ory/kratos v0.5.5-alpha.1
 )

--- a/internal/httpclient/go.sum
+++ b/internal/httpclient/go.sum
@@ -831,6 +831,7 @@ github.com/ory/herodot v0.7.0/go.mod h1:YXKOfAXYdQojDP5sD8m0ajowq3+QXNdtxA+QiUXB
 github.com/ory/herodot v0.8.3/go.mod h1:rvLjxOAlU5omtmgjCfazQX2N82EpMfl3BytBWc1jjsk=
 github.com/ory/herodot v0.9.0/go.mod h1:GYF7mp8/WFRYDYJBR989lipjgx3NTjjdVdUC+hpB8mc=
 github.com/ory/jsonschema/v3 v3.0.1/go.mod h1:jgLHekkFk0uiGdEWGleC+tOm6JSSP8cbf17PnBuGXlw=
+github.com/ory/kratos v0.5.5-alpha.1/go.mod h1:pqr5H6NOA90FxsviyJUj9WOCnXnslLmZvcTYx4GtQiw=
 github.com/ory/kratos v0.5.5-alpha.1.pre.1 h1:SRE75XEsXR+UNAyzTT2BjAsuMLKYrFAqO57W5VrIjNQ=
 github.com/ory/kratos v0.5.5-alpha.1.pre.1/go.mod h1:pqr5H6NOA90FxsviyJUj9WOCnXnslLmZvcTYx4GtQiw=
 github.com/ory/mail v2.3.1+incompatible/go.mod h1:87D9/1gB6ewElQoN0lXJ0ayfqcj3cW3qCTXh+5E9mfU=


### PR DESCRIPTION
## Related issue

Workaround for https://github.com/sonatype-nexus-community/nancy/issues/207
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

Use `sed` to remove the local rewrite. The dependencies of `./internal/httpclient` are included in `go list -m all` anyway (at least it looks like that when I compare the output locally).
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Further comments

As this is quite a special situation here in Kratos, I did not bother adding an option to the nancy pod. But we will have to do that when we consume the other the project's CLIs externally.