### PR TITLE
docs: fix link to Self-Service Flows overview

### DIFF
--- a/docs/docs/self-service/flows/user-login.mdx
+++ b/docs/docs/self-service/flows/user-login.mdx
@@ -20,7 +20,7 @@ import RenderFlow from '@theme/Code/RenderFlow'
 
 :::info
 
-Please read the [Self-Service Flows](../../self-service) overview before
+Please read the [Self-Service Flows](../..) overview before
 continuing with this document.
 
 :::

--- a/docs/docs/self-service/flows/user-login.mdx
+++ b/docs/docs/self-service/flows/user-login.mdx
@@ -20,7 +20,7 @@ import RenderFlow from '@theme/Code/RenderFlow'
 
 :::info
 
-Please read the [Self-Service Flows](../..) overview before
+Please read the [Self-Service Flows](../../self-service.mdx) overview before
 continuing with this document.
 
 :::


### PR DESCRIPTION
## Related issue

No related issue, minor fix in the documentation.

## Proposed changes

Fixes an incorrect link in the infobox at the top on https://www.ory.sh/kratos/docs/self-service/flows/user-login/

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments

no further comments, have a great day everybody!