### PR TITLE
fix: dereference pointer types from new flow structures

### DIFF
--- a/cmd/identities/definitions.go
+++ b/cmd/identities/definitions.go
@@ -21,7 +21,7 @@ func (_ *outputIdentity) Header() []string {
 
 func (i *outputIdentity) Columns() []string {
 	data := [5]string{
-		string(i.ID),
+		string(*i.ID),
 		cmdx.None,
 		cmdx.None,
 		cmdx.None,
@@ -67,7 +67,7 @@ func (c *outputIdentityCollection) Table() [][]string {
 	rows := make([][]string, len(c.identities))
 	for i, ident := range c.identities {
 		data := [5]string{
-			string(ident.ID),
+			string(*ident.ID),
 			cmdx.None,
 			cmdx.None,
 			cmdx.None,

--- a/docs/docs/sdk.md
+++ b/docs/docs/sdk.md
@@ -21,7 +21,9 @@ repositories:
 - [Dart](https://pub.dev/packages/ory_kratos_client)
 - [Go](https://github.com/ory/kratos-client-go)
 - [Java](https://search.maven.org/artifact/sh.ory.kratos/kratos-client)
-- [JavaScript](https://www.npmjs.com/package/@ory/kratos-client) with TypeScript definitions and compatible with: NodeJS, ReactJS, AnuglarJS, Vue.js, and many more.
+- [JavaScript](https://www.npmjs.com/package/@ory/kratos-client) with TypeScript
+  definitions and compatible with: NodeJS, ReactJS, AnuglarJS, Vue.js, and many
+  more.
 - [PHP](https://packagist.org/packages/ory/kratos-client)
 - [Python](https://pypi.org/project/ory-kratos-client/)
 - [Ruby](https://rubygems.org/gems/ory-kratos-client)

--- a/selfservice/strategy/oidc/strategy_settings_test.go
+++ b/selfservice/strategy/oidc/strategy_settings_test.go
@@ -440,7 +440,7 @@ func TestSettingsStrategy(t *testing.T) {
 				NewGetSelfServiceSettingsFlowParams().WithHTTPClient(agents[agent]).
 				WithID(string(*req.ID)), nil)
 			require.NoError(t, err)
-			require.EqualValues(t, settings.StateSuccess, rs.Payload.State)
+			require.EqualValues(t, settings.StateSuccess, *rs.Payload.State)
 
 			testhelpers.JSONEq(t, append(models.FormFields{csrfField}, models.FormFields{
 				{Type: pointerx.String("submit"), Name: pointerx.String("unlink"), Value: "ory"},

--- a/selfservice/strategy/oidc/strategy_settings_test.go
+++ b/selfservice/strategy/oidc/strategy_settings_test.go
@@ -109,7 +109,7 @@ func TestSettingsStrategy(t *testing.T) {
 
 	var newProfileFlow = func(t *testing.T, client *http.Client, redirectTo string, exp time.Duration) *settings.Flow {
 		req, err := reg.SettingsFlowPersister().GetSettingsFlow(context.Background(),
-			x.ParseUUID(string(testhelpers.InitializeSettingsFlowViaBrowser(t, client, publicTS).Payload.ID)))
+			x.ParseUUID(string(*testhelpers.InitializeSettingsFlowViaBrowser(t, client, publicTS).Payload.ID)))
 		require.NoError(t, err)
 		assert.Empty(t, req.Active)
 
@@ -273,7 +273,7 @@ func TestSettingsStrategy(t *testing.T) {
 		var unlinkInvalid = func(agent, provider string, expectedFields models.FormFields) func(t *testing.T) {
 			return func(t *testing.T) {
 				body, res, req := unlink(t, agent, provider)
-				assert.Contains(t, res.Request.URL.String(), uiTS.URL+"/settings?flow="+string(req.ID))
+				assert.Contains(t, res.Request.URL.String(), uiTS.URL+"/settings?flow="+string(*req.ID))
 
 				assert.EqualValues(t, identity.CredentialsTypeOIDC.String(), gjson.GetBytes(body, "active").String())
 				assert.Contains(t, gjson.GetBytes(body, "methods.oidc.config.action").String(), publicTS.URL+oidc.SettingsPath+"?flow=")
@@ -301,7 +301,7 @@ func TestSettingsStrategy(t *testing.T) {
 			t.Cleanup(reset(t))
 
 			body, res, req := unlink(t, agent, provider)
-			assert.Contains(t, res.Request.URL.String(), uiTS.URL+"/settings?flow="+string(req.ID))
+			assert.Contains(t, res.Request.URL.String(), uiTS.URL+"/settings?flow="+string(*req.ID))
 			require.Equal(t, "success", gjson.GetBytes(body, "state").String(), "%s", body)
 
 			checkCredentials(t, false, users[agent].ID, provider, "hackerman+github+"+testID)
@@ -319,7 +319,7 @@ func TestSettingsStrategy(t *testing.T) {
 
 				rs, err := admin.Public.GetSelfServiceSettingsFlow(sdkp.
 					NewGetSelfServiceSettingsFlowParams().WithHTTPClient(agents[agent]).
-					WithID(string(req.ID)), nil)
+					WithID(string(*req.ID)), nil)
 				require.NoError(t, err)
 				require.EqualValues(t, settings.StateShowForm, rs.Payload.State)
 
@@ -340,7 +340,7 @@ func TestSettingsStrategy(t *testing.T) {
 
 				body, res := testhelpers.HTTPPostForm(t, agents[agent], action(req),
 					&url.Values{"csrf_token": {x.FakeCSRFToken}, "unlink": {provider}})
-				assert.Contains(t, res.Request.URL.String(), uiTS.URL+"/settings?flow="+string(req.ID))
+				assert.Contains(t, res.Request.URL.String(), uiTS.URL+"/settings?flow="+string(*req.ID))
 
 				assert.Equal(t, "success", gjson.GetBytes(body, "state").String())
 
@@ -360,7 +360,7 @@ func TestSettingsStrategy(t *testing.T) {
 		var linkInvalid = func(agent, provider string, expectedFields models.FormFields) func(t *testing.T) {
 			return func(t *testing.T) {
 				body, res, req := link(t, agent, provider)
-				assert.Contains(t, res.Request.URL.String(), uiTS.URL+"/settings?flow="+string(req.ID))
+				assert.Contains(t, res.Request.URL.String(), uiTS.URL+"/settings?flow="+string(*req.ID))
 
 				assert.EqualValues(t, identity.CredentialsTypeOIDC.String(), gjson.GetBytes(body, "active").String())
 				assert.Contains(t, gjson.GetBytes(body, "methods.oidc.config.action").String(), publicTS.URL+oidc.SettingsPath+"?flow=")
@@ -438,7 +438,7 @@ func TestSettingsStrategy(t *testing.T) {
 
 			rs, err := admin.Public.GetSelfServiceSettingsFlow(sdkp.
 				NewGetSelfServiceSettingsFlowParams().WithHTTPClient(agents[agent]).
-				WithID(string(req.ID)), nil)
+				WithID(string(*req.ID)), nil)
 			require.NoError(t, err)
 			require.EqualValues(t, settings.StateSuccess, rs.Payload.State)
 
@@ -463,7 +463,7 @@ func TestSettingsStrategy(t *testing.T) {
 
 			rs, err := admin.Public.GetSelfServiceSettingsFlow(sdkp.
 				NewGetSelfServiceSettingsFlowParams().WithHTTPClient(agents[agent]).
-				WithID(string(req.ID)), nil)
+				WithID(string(*req.ID)), nil)
 			require.NoError(t, err)
 			require.EqualValues(t, settings.StateSuccess, rs.Payload.State)
 
@@ -489,7 +489,7 @@ func TestSettingsStrategy(t *testing.T) {
 
 				rs, err := admin.Public.GetSelfServiceSettingsFlow(sdkp.
 					NewGetSelfServiceSettingsFlowParams().WithHTTPClient(agents[agent]).
-					WithID(string(req.ID)), nil)
+					WithID(string(*req.ID)), nil)
 				require.NoError(t, err)
 				require.EqualValues(t, settings.StateShowForm, rs.Payload.State)
 
@@ -510,7 +510,7 @@ func TestSettingsStrategy(t *testing.T) {
 
 				body, res := testhelpers.HTTPPostForm(t, agents[agent], action(req),
 					&url.Values{"csrf_token": {x.FakeCSRFToken}, "unlink": {provider}})
-				assert.Contains(t, res.Request.URL.String(), uiTS.URL+"/settings?flow="+string(req.ID))
+				assert.Contains(t, res.Request.URL.String(), uiTS.URL+"/settings?flow="+string(*req.ID))
 
 				assert.Equal(t, "success", gjson.GetBytes(body, "state").String())
 

--- a/selfservice/strategy/oidc/strategy_settings_test.go
+++ b/selfservice/strategy/oidc/strategy_settings_test.go
@@ -465,7 +465,7 @@ func TestSettingsStrategy(t *testing.T) {
 				NewGetSelfServiceSettingsFlowParams().WithHTTPClient(agents[agent]).
 				WithID(string(*req.ID)), nil)
 			require.NoError(t, err)
-			require.EqualValues(t, settings.StateSuccess, rs.Payload.State)
+			require.EqualValues(t, settings.StateSuccess, *rs.Payload.State)
 
 			testhelpers.JSONEq(t, append(models.FormFields{csrfField}, models.FormFields{
 				{Type: pointerx.String("submit"), Name: pointerx.String("link"), Value: "ory"},
@@ -491,7 +491,7 @@ func TestSettingsStrategy(t *testing.T) {
 					NewGetSelfServiceSettingsFlowParams().WithHTTPClient(agents[agent]).
 					WithID(string(*req.ID)), nil)
 				require.NoError(t, err)
-				require.EqualValues(t, settings.StateShowForm, rs.Payload.State)
+				require.EqualValues(t, settings.StateShowForm, *rs.Payload.State)
 
 				checkCredentials(t, false, users[agent].ID, provider, subject)
 

--- a/selfservice/strategy/oidc/strategy_settings_test.go
+++ b/selfservice/strategy/oidc/strategy_settings_test.go
@@ -184,9 +184,9 @@ func TestSettingsStrategy(t *testing.T) {
 		assert.EqualValues(t, users["password"].Traits, req.Identity.Traits)
 		assert.EqualValues(t, users["password"].SchemaID, req.Identity.SchemaID)
 
-		assert.EqualValues(t, req.ID.String(), rs.Payload.ID)
+		assert.EqualValues(t, req.ID.String(), *rs.Payload.ID)
 		assert.EqualValues(t, req.RequestURL, *rs.Payload.RequestURL)
-		assert.EqualValues(t, req.Identity.ID.String(), rs.Payload.Identity.ID)
+		assert.EqualValues(t, req.Identity.ID.String(), *rs.Payload.Identity.ID)
 		assert.EqualValues(t, req.IssuedAt, time.Time(*rs.Payload.IssuedAt))
 
 		require.NotNil(t, identity.CredentialsTypeOIDC.String(), rs.Payload.Methods[identity.CredentialsTypeOIDC.String()])

--- a/selfservice/strategy/oidc/strategy_settings_test.go
+++ b/selfservice/strategy/oidc/strategy_settings_test.go
@@ -321,7 +321,7 @@ func TestSettingsStrategy(t *testing.T) {
 					NewGetSelfServiceSettingsFlowParams().WithHTTPClient(agents[agent]).
 					WithID(string(*req.ID)), nil)
 				require.NoError(t, err)
-				require.EqualValues(t, settings.StateShowForm, rs.Payload.State)
+				require.EqualValues(t, settings.StateShowForm, *rs.Payload.State)
 
 				checkCredentials(t, true, users[agent].ID, provider, "hackerman+github+"+testID)
 

--- a/selfservice/strategy/profile/strategy_test.go
+++ b/selfservice/strategy/profile/strategy_test.go
@@ -154,7 +154,7 @@ func TestStrategyTraits(t *testing.T) {
 	t.Run("description=hydrate the proper fields", func(t *testing.T) {
 		var run = func(t *testing.T, id *identity.Identity, payload *models.SettingsFlow, route string) {
 			assert.NotEmpty(t, payload.Identity)
-			assert.Equal(t, id.ID.String(), string(payload.Identity.ID))
+			assert.Equal(t, id.ID.String(), string(*payload.Identity.ID))
 			assert.JSONEq(t, string(id.Traits), x.MustEncodeJSON(t, payload.Identity.Traits))
 			assert.Equal(t, id.SchemaID, pointerx.StringR(payload.Identity.SchemaID))
 			assert.Equal(t, publicTS.URL+route, pointerx.StringR(payload.RequestURL))
@@ -162,7 +162,7 @@ func TestStrategyTraits(t *testing.T) {
 			f := testhelpers.GetSettingsFlowMethodConfig(t, payload, settings.StrategyProfile)
 
 			assertx.EqualAsJSON(t, &models.SettingsFlowMethodConfig{
-				Action: pointerx.String(publicTS.URL + profile.RouteSettings + "?flow=" + string(payload.ID)),
+				Action: pointerx.String(publicTS.URL + profile.RouteSettings + "?flow=" + string(*payload.ID)),
 				Method: pointerx.String("POST"),
 				Fields: models.FormFields{
 					&models.FormField{Name: pointerx.String(form.CSRFTokenName), Required: true, Type: pointerx.String("hidden"), Value: x.FakeCSRFToken},


### PR DESCRIPTION
## Related issue

Fixes #1018

## Proposed changes

- Changes `string(i.ID)` to `string(*i.ID)` in `cmd/identities/definitions.go`
- Fixes breaking CI tests where pointer types are being compared to string types.
- Autoformat docs to fix prettier in CI

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

Traced backwards and noticed that if the redirect for `github.com/ory/kratos-client-go` wasn't used it's working fine. Noticed that the redirect to https://github.com/ory/kratos/blob/master/internal/httpclient/models/identity.go changes it to a `*UUID` instead of a `UUID` here https://github.com/ory/kratos-client-go/blob/master/models/identity.go.

Dereferencing the `ID` method before calling `string` allows `make install` to pass successfully.


