### PR TITLE
fix: Courier message dequeuing race condition

### DIFF
--- a/courier/courier.go
+++ b/courier/courier.go
@@ -146,6 +146,12 @@ func (m *Courier) watchMessages(ctx context.Context, errChan chan error) {
 							// WithField("email_to", msg.Recipient).
 							WithField("message_from", from).
 							Error("Unable to send email using SMTP connection.")
+						if err := m.d.CourierPersister().SetMessageStatus(ctx, msg.ID, MessageStatusQueued); err != nil {
+							m.d.Logger().
+								WithError(err).
+								WithField("message_id", msg.ID).
+								Error(`Unable to reset the failed message's status to "queued".`)
+						}
 						continue
 					}
 

--- a/courier/message.go
+++ b/courier/message.go
@@ -14,6 +14,7 @@ type MessageStatus int
 const (
 	MessageStatusQueued MessageStatus = iota + 1
 	MessageStatusSent
+	MessageStatusProcessing
 )
 
 type MessageType int

--- a/courier/persistence.go
+++ b/courier/persistence.go
@@ -64,6 +64,7 @@ func TestPersister(p Persister) func(t *testing.T) {
 
 		t.Run("case=pull messages from the queue", func(t *testing.T) {
 			for k, expected := range messages {
+				expected.Status = MessageStatusProcessing
 				t.Run(fmt.Sprintf("message=%d", k), func(t *testing.T) {
 					messages, err := p.NextMessages(ctx, 1)
 					require.NoError(t, err)
@@ -76,8 +77,6 @@ func TestPersister(p Persister) func(t *testing.T) {
 					assert.Equal(t, expected.Status, actual.Status)
 					assert.Equal(t, expected.Type, actual.Type)
 					assert.Equal(t, expected.Recipient, actual.Recipient)
-
-					require.NoError(t, p.SetMessageStatus(ctx, actual.ID, MessageStatusSent))
 				})
 			}
 

--- a/persistence/sql/persister_courier.go
+++ b/persistence/sql/persister_courier.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 
+	"github.com/gobuffalo/pop/v5"
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 
@@ -21,10 +22,18 @@ func (p *Persister) AddMessage(ctx context.Context, m *courier.Message) error {
 
 func (p *Persister) NextMessages(ctx context.Context, limit uint8) ([]courier.Message, error) {
 	var m []courier.Message
-	if err := p.GetConnection(ctx).
-		Eager().
-		Where("status != ?", courier.MessageStatusSent).
-		Order("created_at ASC").Limit(int(limit)).All(&m); err != nil {
+	if err := p.Transaction(ctx, func(ctx context.Context, tx *pop.Connection) error {
+		if err := tx.
+			Eager().
+			Where("status = ?", courier.MessageStatusQueued).
+			Order("created_at ASC").Limit(int(limit)).All(&m); err != nil {
+			return err
+		}
+		for i := range m {
+			m[i].Status = courier.MessageStatusProcessing
+		}
+		return tx.UpdateColumns(&m, "status")
+	}); err != nil {
 		if errors.Cause(err) == sql.ErrNoRows {
 			return nil, errors.WithStack(courier.ErrQueueEmpty)
 		}
@@ -42,7 +51,7 @@ func (p *Persister) LatestQueuedMessage(ctx context.Context) (*courier.Message, 
 	var m courier.Message
 	if err := p.GetConnection(ctx).
 		Eager().
-		Where("status != ?", courier.MessageStatusSent).
+		Where("status = ?", courier.MessageStatusQueued).
 		Order("created_at DESC").First(&m); err != nil {
 		if errors.Cause(err) == sql.ErrNoRows {
 			return nil, errors.WithStack(courier.ErrQueueEmpty)

--- a/selfservice/strategy/link/sender_test.go
+++ b/selfservice/strategy/link/sender_test.go
@@ -64,14 +64,14 @@ func TestManager(t *testing.T) {
 
 		messages, err := reg.CourierPersister().NextMessages(context.Background(), 12)
 		require.NoError(t, err)
-		require.Len(t, messages, 4)
+		require.Len(t, messages, 2)
 
-		assert.EqualValues(t, "tracked@ory.sh", messages[2].Recipient)
-		assert.Contains(t, messages[2].Subject, "Please verify")
-		assert.Contains(t, messages[2].Body, urlx.AppendPaths(conf.SelfPublicURL(), link.RouteVerification).String()+"?token=")
+		assert.EqualValues(t, "tracked@ory.sh", messages[0].Recipient)
+		assert.Contains(t, messages[0].Subject, "Please verify")
+		assert.Contains(t, messages[0].Body, urlx.AppendPaths(conf.SelfPublicURL(), link.RouteVerification).String()+"?token=")
 
 		assert.EqualValues(t, "not-tracked@ory.sh", messages[1].Recipient)
-		assert.Contains(t, messages[3].Subject, "tried to verify")
-		assert.NotContains(t, messages[3].Body, urlx.AppendPaths(conf.SelfPublicURL(), link.RouteVerification).String()+"?token=")
+		assert.Contains(t, messages[1].Subject, "tried to verify")
+		assert.NotContains(t, messages[1].Body, urlx.AppendPaths(conf.SelfPublicURL(), link.RouteVerification).String()+"?token=")
 	})
 }


### PR DESCRIPTION
## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [ORY Chat](https://www.ory.sh/chat).
-->
~~#402~~ #652, #732 
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->
Fixes the courier message dequeuing race condition by modifying `*sql.Persister.NextMessages(ctx context.Context, limit uint8)` to retrieve only messages with status `MessageStatusQueued` and update the status of the retrieved messages to `MessageStatusProcessing` within a transaction. On message send failure, the message's status is reset to `MessageStatusQueued`, so that the message can be dequeued in a subsequent `NextMessages` call. On message send success, the status is updated to `MessageStatusSent` (no change there).

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
I updated the existing message pulling test to demonstrate that messages won't be dequeued twice.

*Caveat*: This does necessitate the DB having an isolation level equivalent to [repeatable reads](https://en.wikipedia.org/wiki/Isolation_(database_systems)#Repeatable_reads) or better. MySQL's default isolation level is repeatable read, CockroachDB's is serializable, so these two will be free from race conditions by default. PostgreSQL's default isolation level is read committed, so it would still be susceptible to this race condition if the isolation level were not updated. sqlx supports setting per-transaction isolation levels natively, ~~but pop doesn't expose this functionality.~~ pop *does* support per-transaction isolation levels as pointed out by @zepatrik, so no need to enforce some DB-level config. 