### PR TITLE
fix: give specific message instead of only 404 when method disabled

### DIFF
--- a/driver/registry_default.go
+++ b/driver/registry_default.go
@@ -256,9 +256,7 @@ func (m *RegistryDefault) RegistrationStrategies() registration.Strategies {
 	if len(m.registrationStrategies) == 0 {
 		for _, strategy := range m.selfServiceStrategies() {
 			if s, ok := strategy.(registration.Strategy); ok {
-				if m.c.SelfServiceStrategy(string(s.ID())).Enabled {
-					m.registrationStrategies = append(m.registrationStrategies, s)
-				}
+				m.registrationStrategies = append(m.registrationStrategies, s)
 			}
 		}
 	}
@@ -269,9 +267,7 @@ func (m *RegistryDefault) LoginStrategies() login.Strategies {
 	if len(m.loginStrategies) == 0 {
 		for _, strategy := range m.selfServiceStrategies() {
 			if s, ok := strategy.(login.Strategy); ok {
-				if m.c.SelfServiceStrategy(string(s.ID())).Enabled {
-					m.loginStrategies = append(m.loginStrategies, s)
-				}
+				m.loginStrategies = append(m.loginStrategies, s)
 			}
 		}
 	}

--- a/driver/registry_default.go
+++ b/driver/registry_default.go
@@ -144,15 +144,15 @@ func (m *RegistryDefault) RegisterPublicRoutes(router *x.RouterPublic) {
 	m.RegistrationHandler().RegisterPublicRoutes(router)
 	m.LogoutHandler().RegisterPublicRoutes(router)
 	m.SettingsHandler().RegisterPublicRoutes(router)
-	m.LoginStrategies().RegisterPublicRoutes(router)
-	m.SettingsStrategies().RegisterPublicRoutes(router)
-	m.RegistrationStrategies().RegisterPublicRoutes(router)
+	m.AllLoginStrategies().RegisterPublicRoutes(router)
+	m.AllSettingsStrategies().RegisterPublicRoutes(router)
+	m.AllRegistrationStrategies().RegisterPublicRoutes(router)
 	m.SessionHandler().RegisterPublicRoutes(router)
 	m.SelfServiceErrorHandler().RegisterPublicRoutes(router)
 	m.SchemaHandler().RegisterPublicRoutes(router)
 
 	if m.c.SelfServiceFlowRecoveryEnabled() {
-		m.RecoveryStrategies().RegisterPublicRoutes(router)
+		m.AllRecoveryStrategies().RegisterPublicRoutes(router)
 		m.RecoveryHandler().RegisterPublicRoutes(router)
 	}
 
@@ -173,7 +173,7 @@ func (m *RegistryDefault) RegisterAdminRoutes(router *x.RouterAdmin) {
 
 	if m.c.SelfServiceFlowRecoveryEnabled() {
 		m.RecoveryHandler().RegisterAdminRoutes(router)
-		m.RecoveryStrategies().RegisterAdminRoutes(router)
+		m.AllRecoveryStrategies().RegisterAdminRoutes(router)
 	}
 
 	m.VerificationHandler().RegisterAdminRoutes(router)
@@ -256,22 +256,47 @@ func (m *RegistryDefault) RegistrationStrategies() registration.Strategies {
 	if len(m.registrationStrategies) == 0 {
 		for _, strategy := range m.selfServiceStrategies() {
 			if s, ok := strategy.(registration.Strategy); ok {
-				m.registrationStrategies = append(m.registrationStrategies, s)
+				if m.c.SelfServiceStrategy(string(s.ID())).Enabled {
+					m.registrationStrategies = append(m.registrationStrategies, s)
+				}
 			}
 		}
 	}
 	return m.registrationStrategies
 }
 
+func (m *RegistryDefault) AllRegistrationStrategies() registration.Strategies {
+	var registrationStrategies []registration.Strategy
+
+	for _, strategy := range m.selfServiceStrategies() {
+		if s, ok := strategy.(registration.Strategy); ok {
+			registrationStrategies = append(registrationStrategies, s)
+		}
+	}
+	return registrationStrategies
+}
+
 func (m *RegistryDefault) LoginStrategies() login.Strategies {
 	if len(m.loginStrategies) == 0 {
 		for _, strategy := range m.selfServiceStrategies() {
 			if s, ok := strategy.(login.Strategy); ok {
-				m.loginStrategies = append(m.loginStrategies, s)
+				if m.c.SelfServiceStrategy(string(s.ID())).Enabled {
+					m.loginStrategies = append(m.loginStrategies, s)
+				}
 			}
 		}
 	}
 	return m.loginStrategies
+}
+
+func (m *RegistryDefault) AllLoginStrategies() login.Strategies {
+	var loginStrategies []login.Strategy
+	for _, strategy := range m.selfServiceStrategies() {
+		if s, ok := strategy.(login.Strategy); ok {
+			loginStrategies = append(loginStrategies, s)
+		}
+	}
+	return loginStrategies
 }
 
 func (m *RegistryDefault) VerificationStrategies() verification.Strategies {

--- a/driver/registry_default_recovery.go
+++ b/driver/registry_default_recovery.go
@@ -24,9 +24,7 @@ func (m *RegistryDefault) RecoveryStrategies() recovery.Strategies {
 	if len(m.recoveryStrategies) == 0 {
 		for _, strategy := range m.selfServiceStrategies() {
 			if s, ok := strategy.(recovery.Strategy); ok {
-				if m.c.SelfServiceStrategy(s.RecoveryStrategyID()).Enabled {
-					m.recoveryStrategies = append(m.recoveryStrategies, s)
-				}
+				m.recoveryStrategies = append(m.recoveryStrategies, s)
 			}
 		}
 	}

--- a/driver/registry_default_recovery.go
+++ b/driver/registry_default_recovery.go
@@ -24,9 +24,21 @@ func (m *RegistryDefault) RecoveryStrategies() recovery.Strategies {
 	if len(m.recoveryStrategies) == 0 {
 		for _, strategy := range m.selfServiceStrategies() {
 			if s, ok := strategy.(recovery.Strategy); ok {
-				m.recoveryStrategies = append(m.recoveryStrategies, s)
+				if m.c.SelfServiceStrategy(s.RecoveryStrategyID()).Enabled {
+					m.recoveryStrategies = append(m.recoveryStrategies, s)
+				}
 			}
 		}
 	}
 	return m.recoveryStrategies
+}
+
+func (m *RegistryDefault) AllRecoveryStrategies() recovery.Strategies {
+	var recoveryStrategies []recovery.Strategy
+	for _, strategy := range m.selfServiceStrategies() {
+		if s, ok := strategy.(recovery.Strategy); ok {
+			recoveryStrategies = append(recoveryStrategies, s)
+		}
+	}
+	return recoveryStrategies
 }

--- a/driver/registry_default_settings.go
+++ b/driver/registry_default_settings.go
@@ -49,9 +49,21 @@ func (m *RegistryDefault) SettingsStrategies() settings.Strategies {
 	if len(m.profileStrategies) == 0 {
 		for _, strategy := range m.selfServiceStrategies() {
 			if s, ok := strategy.(settings.Strategy); ok {
-				m.profileStrategies = append(m.profileStrategies, s)
+				if m.c.SelfServiceStrategy(s.SettingsStrategyID()).Enabled {
+					m.profileStrategies = append(m.profileStrategies, s)
+				}
 			}
 		}
 	}
 	return m.profileStrategies
+}
+
+func (m *RegistryDefault) AllSettingsStrategies() settings.Strategies {
+	var profileStrategies []settings.Strategy
+	for _, strategy := range m.selfServiceStrategies() {
+		if s, ok := strategy.(settings.Strategy); ok {
+			profileStrategies = append(profileStrategies, s)
+		}
+	}
+	return profileStrategies
 }

--- a/driver/registry_default_settings.go
+++ b/driver/registry_default_settings.go
@@ -49,9 +49,7 @@ func (m *RegistryDefault) SettingsStrategies() settings.Strategies {
 	if len(m.profileStrategies) == 0 {
 		for _, strategy := range m.selfServiceStrategies() {
 			if s, ok := strategy.(settings.Strategy); ok {
-				if m.c.SelfServiceStrategy(s.SettingsStrategyID()).Enabled {
-					m.profileStrategies = append(m.profileStrategies, s)
-				}
+				m.profileStrategies = append(m.profileStrategies, s)
 			}
 		}
 	}

--- a/driver/registry_default_test.go
+++ b/driver/registry_default_test.go
@@ -68,10 +68,10 @@ func TestDriverDefault_Strategies(t *testing.T) {
 	}{
 		{prep: func(conf *config.Config) {
 			conf.MustSet(config.ViperKeySelfServiceStrategyConfig+".password.enabled", false)
-		}},
+		}, expect: []string{"password", "oidc"}},
 		{prep: func(conf *config.Config) {
 			conf.MustSet(config.ViperKeySelfServiceStrategyConfig+".password.enabled", true)
-		}, expect: []string{"password"}},
+		}, expect: []string{"password", "oidc"}},
 		{prep: func(conf *config.Config) {
 			conf.MustSet(config.ViperKeySelfServiceStrategyConfig+".oidc.enabled", true)
 			conf.MustSet(config.ViperKeySelfServiceStrategyConfig+".password.enabled", true)
@@ -106,7 +106,7 @@ func TestDriverDefault_Strategies(t *testing.T) {
 		}{
 			{prep: func(conf *config.Config) {
 				conf.MustSet(config.ViperKeySelfServiceStrategyConfig+".link.enabled", false)
-			}},
+			}, expect: []string{"link"}},
 			{prep: func(conf *config.Config) {
 				conf.MustSet(config.ViperKeySelfServiceStrategyConfig+".link.enabled", true)
 			}, expect: []string{"link"}},
@@ -142,7 +142,8 @@ func TestDriverDefault_Strategies(t *testing.T) {
 						}),
 						configx.SkipValidation())
 					return c
-				}},
+				},
+				expect: []string{"password", "oidc", "profile"}},
 			{
 				prep: func(t *testing.T) *config.Config {
 					c := config.MustNew(l,
@@ -154,7 +155,7 @@ func TestDriverDefault_Strategies(t *testing.T) {
 						configx.SkipValidation())
 					return c
 				},
-				expect: []string{"profile"}},
+				expect: []string{"password", "oidc", "profile"}},
 			{
 				prep: func(t *testing.T) *config.Config {
 					return config.MustNew(l,
@@ -163,7 +164,7 @@ func TestDriverDefault_Strategies(t *testing.T) {
 						}),
 						configx.SkipValidation())
 				},
-				expect: []string{"password", "profile"}},
+				expect: []string{"password", "oidc", "profile"}},
 			{
 				prep: func(t *testing.T) *config.Config {
 					return config.MustNew(l,
@@ -171,7 +172,7 @@ func TestDriverDefault_Strategies(t *testing.T) {
 						configx.WithValue(config.ViperKeyDSN, config.DefaultSQLiteMemoryDSN),
 						configx.SkipValidation())
 				},
-				expect: []string{"password", "profile"}},
+				expect: []string{"password", "oidc", "profile"}},
 		} {
 			t.Run(fmt.Sprintf("run=%d", k), func(t *testing.T) {
 				conf := tc.prep(t)

--- a/driver/registry_default_test.go
+++ b/driver/registry_default_test.go
@@ -68,10 +68,10 @@ func TestDriverDefault_Strategies(t *testing.T) {
 	}{
 		{prep: func(conf *config.Config) {
 			conf.MustSet(config.ViperKeySelfServiceStrategyConfig+".password.enabled", false)
-		}, expect: []string{"password", "oidc"}},
+		}},
 		{prep: func(conf *config.Config) {
 			conf.MustSet(config.ViperKeySelfServiceStrategyConfig+".password.enabled", true)
-		}, expect: []string{"password", "oidc"}},
+		}, expect: []string{"password"}},
 		{prep: func(conf *config.Config) {
 			conf.MustSet(config.ViperKeySelfServiceStrategyConfig+".oidc.enabled", true)
 			conf.MustSet(config.ViperKeySelfServiceStrategyConfig+".password.enabled", true)
@@ -106,7 +106,7 @@ func TestDriverDefault_Strategies(t *testing.T) {
 		}{
 			{prep: func(conf *config.Config) {
 				conf.MustSet(config.ViperKeySelfServiceStrategyConfig+".link.enabled", false)
-			}, expect: []string{"link"}},
+			}},
 			{prep: func(conf *config.Config) {
 				conf.MustSet(config.ViperKeySelfServiceStrategyConfig+".link.enabled", true)
 			}, expect: []string{"link"}},
@@ -142,8 +142,7 @@ func TestDriverDefault_Strategies(t *testing.T) {
 						}),
 						configx.SkipValidation())
 					return c
-				},
-				expect: []string{"password", "oidc", "profile"}},
+				}},
 			{
 				prep: func(t *testing.T) *config.Config {
 					c := config.MustNew(l,
@@ -155,7 +154,7 @@ func TestDriverDefault_Strategies(t *testing.T) {
 						configx.SkipValidation())
 					return c
 				},
-				expect: []string{"password", "oidc", "profile"}},
+				expect: []string{"profile"}},
 			{
 				prep: func(t *testing.T) *config.Config {
 					return config.MustNew(l,
@@ -164,7 +163,7 @@ func TestDriverDefault_Strategies(t *testing.T) {
 						}),
 						configx.SkipValidation())
 				},
-				expect: []string{"password", "oidc", "profile"}},
+				expect: []string{"password", "profile"}},
 			{
 				prep: func(t *testing.T) *config.Config {
 					return config.MustNew(l,
@@ -172,7 +171,7 @@ func TestDriverDefault_Strategies(t *testing.T) {
 						configx.WithValue(config.ViperKeyDSN, config.DefaultSQLiteMemoryDSN),
 						configx.SkipValidation())
 				},
-				expect: []string{"password", "oidc", "profile"}},
+				expect: []string{"password", "profile"}},
 		} {
 			t.Run(fmt.Sprintf("run=%d", k), func(t *testing.T) {
 				conf := tc.prep(t)
@@ -187,6 +186,46 @@ func TestDriverDefault_Strategies(t *testing.T) {
 					assert.Equal(t, e, s[k].SettingsStrategyID())
 				}
 			})
+		}
+	})
+}
+
+func TestDefaultRegistry_AllStrategies(t *testing.T) {
+	_, reg := internal.NewFastRegistryWithMocks(t)
+
+	t.Run("case=all login strategies", func(t *testing.T) {
+		expects := []string{"password", "oidc"}
+		s := reg.AllLoginStrategies()
+		require.Len(t, s, len(expects))
+		for k, e := range expects {
+			assert.Equal(t, e, s[k].ID().String())
+		}
+	})
+
+	t.Run("case=all registration strategies", func(t *testing.T) {
+		expects := []string{"password", "oidc"}
+		s := reg.AllRegistrationStrategies()
+		require.Len(t, s, len(expects))
+		for k, e := range expects {
+			assert.Equal(t, e, s[k].ID().String())
+		}
+	})
+
+	t.Run("case=all settings strategies", func(t *testing.T) {
+		expects := []string{"password", "oidc", "profile"}
+		s := reg.AllSettingsStrategies()
+		require.Len(t, s, len(expects))
+		for k, e := range expects {
+			assert.Equal(t, e, s[k].SettingsStrategyID())
+		}
+	})
+
+	t.Run("case=all recovery strategies", func(t *testing.T) {
+		expects := []string{"link"}
+		s := reg.AllRecoveryStrategies()
+		require.Len(t, s, len(expects))
+		for k, e := range expects {
+			assert.Equal(t, e, s[k].RecoveryStrategyID())
 		}
 	})
 }

--- a/selfservice/strategy/handler.go
+++ b/selfservice/strategy/handler.go
@@ -17,7 +17,7 @@ func IsDisabled(c interface {
 	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 		enabled := c.Config(r.Context()).SelfServiceStrategy(strategy).Enabled
 		if !enabled {
-			c.Writer().WriteError(w, r, herodot.ErrBadRequest.WithError(EndpointDisabledMessage))
+			c.Writer().WriteError(w, r, herodot.ErrNotFound.WithReason(EndpointDisabledMessage))
 			return
 		}
 		wrap(w, r, ps)

--- a/selfservice/strategy/handler.go
+++ b/selfservice/strategy/handler.go
@@ -1,0 +1,25 @@
+package strategy
+
+import (
+	"github.com/julienschmidt/httprouter"
+	"github.com/ory/herodot"
+	"github.com/ory/kratos/driver/config"
+	"github.com/ory/kratos/x"
+	"net/http"
+)
+
+const EndpointDisabledMessage = "This endpoint was disabled by system administrator. Please check your url or contact the system administrator to enable it."
+
+func IsDisabled(c interface {
+	config.Provider
+	x.WriterProvider
+}, strategy string, wrap httprouter.Handle) httprouter.Handle {
+	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+		enabled := c.Config(r.Context()).SelfServiceStrategy(strategy).Enabled
+		if !enabled {
+			c.Writer().WriteError(w, r, herodot.ErrBadRequest.WithError(EndpointDisabledMessage))
+			return
+		}
+		wrap(w, r, ps)
+	}
+}

--- a/selfservice/strategy/link/strategy.go
+++ b/selfservice/strategy/link/strategy.go
@@ -1,10 +1,8 @@
 package link
 
 import (
-	"github.com/ory/kratos/driver/config"
-	"github.com/ory/x/decoderx"
-
 	"github.com/ory/kratos/courier"
+	"github.com/ory/kratos/driver/config"
 	"github.com/ory/kratos/identity"
 	"github.com/ory/kratos/schema"
 	"github.com/ory/kratos/selfservice/errorx"
@@ -14,6 +12,7 @@ import (
 	"github.com/ory/kratos/selfservice/form"
 	"github.com/ory/kratos/session"
 	"github.com/ory/kratos/x"
+	"github.com/ory/x/decoderx"
 )
 
 var _ recovery.Strategy = new(Strategy)

--- a/selfservice/strategy/link/strategy_recovery_test.go
+++ b/selfservice/strategy/link/strategy_recovery_test.go
@@ -363,10 +363,10 @@ func TestDisabledEndpoint(t *testing.T) {
 			rl, err := adminSDK.Admin.CreateRecoveryLink(admin.NewCreateRecoveryLinkParams().
 				WithBody(&models.CreateRecoveryLink{IdentityID: &uuid}))
 			assert.Nil(t, rl)
-			require.IsType(t, new(admin.CreateRecoveryLinkBadRequest), err, "%s", err)
+			require.IsType(t, new(admin.CreateRecoveryLinkNotFound), err, "%s", err)
 
-			br, _ := err.(*admin.CreateRecoveryLinkBadRequest)
-			assert.Contains(t, br.Payload.Error.Message, "This endpoint was disabled by system administrator")
+			br, _ := err.(*admin.CreateRecoveryLinkNotFound)
+			assert.Contains(t, br.Payload.Error.Reason, "This endpoint was disabled by system administrator")
 		})
 	})
 
@@ -376,7 +376,7 @@ func TestDisabledEndpoint(t *testing.T) {
 			u := publicTS.URL + link.RouteRecovery + "?token=endpoint-disabled"
 			res, err := c.Get(u)
 			require.NoError(t, err)
-			assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+			assert.Equal(t, http.StatusNotFound, res.StatusCode)
 
 			b := make([]byte, res.ContentLength)
 			_, _ = res.Body.Read(b)
@@ -387,7 +387,7 @@ func TestDisabledEndpoint(t *testing.T) {
 			u := publicTS.URL + link.RouteRecovery
 			res, err := c.PostForm(u, url.Values{"email": {"email@ory.sh"}})
 			require.NoError(t, err)
-			assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+			assert.Equal(t, http.StatusNotFound, res.StatusCode)
 
 			b := make([]byte, res.ContentLength)
 			_, _ = res.Body.Read(b)

--- a/selfservice/strategy/link/strategy_recovery_test.go
+++ b/selfservice/strategy/link/strategy_recovery_test.go
@@ -128,6 +128,7 @@ func TestAdminStrategy(t *testing.T) {
 		require.Len(t, sr.Payload.Messages, 1)
 		assert.Equal(t, "You successfully recovered your account. Please change your password or set up an alternative login method (e.g. social sign in) within the next 60.00 minutes.", sr.Payload.Messages[0].Text)
 	})
+
 }
 
 func TestRecovery(t *testing.T) {
@@ -340,5 +341,57 @@ func TestRecovery(t *testing.T) {
 
 		require.Len(t, sr.Payload.Messages, 1)
 		assert.Contains(t, sr.Payload.Messages[0].Text, "The recovery flow expired")
+	})
+}
+
+func TestDisabledEndpoint(t *testing.T) {
+	conf, reg := internal.NewFastRegistryWithMocks(t)
+	initViper(t, conf)
+	conf.MustSet(config.ViperKeySelfServiceStrategyConfig+"."+recovery.StrategyRecoveryLinkName+".enabled", false)
+
+	publicTS, adminTS := testhelpers.NewKratosServer(t, reg)
+	adminSDK := testhelpers.NewSDKClient(adminTS)
+
+	t.Run("role=admin", func(t *testing.T) {
+		t.Run("description=can not create recovery link when link method is disabled", func(t *testing.T) {
+			id := identity.Identity{Traits: identity.Traits(`{"email":"recovery-endpoint-disabled@ory.sh"}`)}
+
+			require.NoError(t, reg.IdentityManager().Create(context.Background(),
+				&id, identity.ManagerAllowWriteProtectedTraits))
+
+			uuid := models.UUID(id.ID.String())
+			rl, err := adminSDK.Admin.CreateRecoveryLink(admin.NewCreateRecoveryLinkParams().
+				WithBody(&models.CreateRecoveryLink{IdentityID: &uuid}))
+			assert.Nil(t, rl)
+			require.IsType(t, new(admin.CreateRecoveryLinkBadRequest), err, "%s", err)
+
+			br, _ := err.(*admin.CreateRecoveryLinkBadRequest)
+			assert.Contains(t, br.Payload.Error.Message, "This endpoint was disabled by system administrator")
+		})
+	})
+
+	t.Run("role=public", func(t *testing.T) {
+		c := testhelpers.NewClientWithCookies(t)
+		t.Run("description=can not recover an account by get request when link method is disabled", func(t *testing.T) {
+			u := publicTS.URL + link.RouteRecovery + "?token=endpoint-disabled"
+			res, err := c.Get(u)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+
+			b := make([]byte, res.ContentLength)
+			_, _ = res.Body.Read(b)
+			assert.Contains(t, string(b), "This endpoint was disabled by system administrator")
+		})
+
+		t.Run("description=can not recover an account by post request when link method is disabled", func(t *testing.T) {
+			u := publicTS.URL + link.RouteRecovery
+			res, err := c.PostForm(u, url.Values{"email": {"email@ory.sh"}})
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+
+			b := make([]byte, res.ContentLength)
+			_, _ = res.Body.Read(b)
+			assert.Contains(t, string(b), "This endpoint was disabled by system administrator")
+		})
 	})
 }

--- a/selfservice/strategy/oidc/strategy_settings.go
+++ b/selfservice/strategy/oidc/strategy_settings.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ory/kratos/selfservice/flow"
 	"github.com/ory/kratos/selfservice/flow/settings"
 	"github.com/ory/kratos/selfservice/form"
+	"github.com/ory/kratos/selfservice/strategy"
 	"github.com/ory/kratos/x"
 )
 
@@ -34,8 +35,9 @@ var ConnectionExistValidationError = &jsonschema.ValidationError{
 	Message: "can not link unknown or already existing OpenID Connect connection", InstancePtr: "#/"}
 
 func (s *Strategy) RegisterSettingsRoutes(router *x.RouterPublic) {
-	router.POST(SettingsPath, s.completeSettingsFlow)
-	router.GET(SettingsPath, s.completeSettingsFlow)
+	wrappedCompleteSettingsFlow := strategy.IsDisabled(s.d, s.SettingsStrategyID(), s.completeSettingsFlow)
+	router.POST(SettingsPath, wrappedCompleteSettingsFlow)
+	router.GET(SettingsPath, wrappedCompleteSettingsFlow)
 }
 
 func (s *Strategy) SettingsStrategyID() string {

--- a/selfservice/strategy/oidc/strategy_settings_test.go
+++ b/selfservice/strategy/oidc/strategy_settings_test.go
@@ -687,7 +687,7 @@ func TestDisabledSettingsEndpoint(t *testing.T) {
 		t.Run("method=GET", func(t *testing.T) {
 			res, err := c.Get(publicTS.URL + oidc.SettingsPath)
 			require.NoError(t, err)
-			assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+			assert.Equal(t, http.StatusNotFound, res.StatusCode)
 
 			b := make([]byte, res.ContentLength)
 			_, _ = res.Body.Read(b)
@@ -697,7 +697,7 @@ func TestDisabledSettingsEndpoint(t *testing.T) {
 		t.Run("method=POST", func(t *testing.T) {
 			res, err := c.PostForm(publicTS.URL+oidc.SettingsPath, url.Values{"link": {"xxx"}})
 			require.NoError(t, err)
-			assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+			assert.Equal(t, http.StatusNotFound, res.StatusCode)
 
 			b := make([]byte, res.ContentLength)
 			_, _ = res.Body.Read(b)

--- a/selfservice/strategy/oidc/strategy_test.go
+++ b/selfservice/strategy/oidc/strategy_test.go
@@ -592,7 +592,7 @@ func TestDisabledEndpoint(t *testing.T) {
 		c := testhelpers.NewClientWithCookies(t)
 		res, err := c.Get(publicTS.URL + oidc.RouteCallback)
 		require.NoError(t, err)
-		assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+		assert.Equal(t, http.StatusNotFound, res.StatusCode)
 
 		b := make([]byte, res.ContentLength)
 		_, _ = res.Body.Read(b)
@@ -605,7 +605,7 @@ func TestDisabledEndpoint(t *testing.T) {
 		t.Run("method=GET", func(t *testing.T) {
 			res, err := c.Get(publicTS.URL + oidc.RouteAuth)
 			require.NoError(t, err)
-			assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+			assert.Equal(t, http.StatusNotFound, res.StatusCode)
 
 			b := make([]byte, res.ContentLength)
 			_, _ = res.Body.Read(b)
@@ -615,7 +615,7 @@ func TestDisabledEndpoint(t *testing.T) {
 		t.Run("method=POST", func(t *testing.T) {
 			res, err := c.PostForm(publicTS.URL+oidc.RouteAuth, url.Values{"provider": {"github"}})
 			require.NoError(t, err)
-			assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+			assert.Equal(t, http.StatusNotFound, res.StatusCode)
 
 			b := make([]byte, res.ContentLength)
 			_, _ = res.Body.Read(b)

--- a/selfservice/strategy/oidc/strategy_test.go
+++ b/selfservice/strategy/oidc/strategy_test.go
@@ -581,3 +581,45 @@ func TestCountActiveCredentials(t *testing.T) {
 		})
 	}
 }
+
+func TestDisabledEndpoint(t *testing.T) {
+	conf, reg := internal.NewFastRegistryWithMocks(t)
+	testhelpers.StrategyEnable(t, conf, identity.CredentialsTypeOIDC.String(), false)
+
+	publicTS, _ := testhelpers.NewKratosServer(t, reg)
+
+	t.Run("case=should not callback when oidc method is disabled", func(t *testing.T) {
+		c := testhelpers.NewClientWithCookies(t)
+		res, err := c.Get(publicTS.URL + oidc.RouteCallback)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+
+		b := make([]byte, res.ContentLength)
+		_, _ = res.Body.Read(b)
+		assert.Contains(t, string(b), "This endpoint was disabled by system administrator")
+	})
+
+	t.Run("case=should not auth when oidc method is disabled", func(t *testing.T) {
+		c := testhelpers.NewClientWithCookies(t)
+
+		t.Run("method=GET", func(t *testing.T) {
+			res, err := c.Get(publicTS.URL + oidc.RouteAuth)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+
+			b := make([]byte, res.ContentLength)
+			_, _ = res.Body.Read(b)
+			assert.Contains(t, string(b), "This endpoint was disabled by system administrator")
+		})
+
+		t.Run("method=POST", func(t *testing.T) {
+			res, err := c.PostForm(publicTS.URL+oidc.RouteAuth, url.Values{"provider": {"github"}})
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+
+			b := make([]byte, res.ContentLength)
+			_, _ = res.Body.Read(b)
+			assert.Contains(t, string(b), "This endpoint was disabled by system administrator")
+		})
+	})
+}

--- a/selfservice/strategy/password/login.go
+++ b/selfservice/strategy/password/login.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ory/kratos/selfservice/flow"
 	"github.com/ory/kratos/selfservice/flow/login"
 	"github.com/ory/kratos/selfservice/form"
+	"github.com/ory/kratos/selfservice/strategy"
 	"github.com/ory/kratos/x"
 )
 
@@ -31,7 +32,8 @@ const (
 func (s *Strategy) RegisterLoginRoutes(r *x.RouterPublic) {
 	s.d.CSRFHandler().IgnorePath(RouteLogin)
 
-	r.POST(RouteLogin, s.handleLogin)
+	wrappedHandleLogin := strategy.IsDisabled(s.d, s.ID().String(), s.handleLogin)
+	r.POST(RouteLogin, wrappedHandleLogin)
 }
 
 func (s *Strategy) handleLoginError(w http.ResponseWriter, r *http.Request, rr *login.Flow, payload *CompleteSelfServiceLoginFlowWithPasswordMethod, err error) {

--- a/selfservice/strategy/password/registration.go
+++ b/selfservice/strategy/password/registration.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ory/kratos/schema"
 	"github.com/ory/kratos/selfservice/flow/registration"
 	"github.com/ory/kratos/selfservice/form"
+	"github.com/ory/kratos/selfservice/strategy"
 	"github.com/ory/kratos/x"
 )
 
@@ -43,7 +44,8 @@ type RegistrationFormPayload struct {
 func (s *Strategy) RegisterRegistrationRoutes(public *x.RouterPublic) {
 	s.d.CSRFHandler().IgnorePath(RouteRegistration)
 
-	public.POST(RouteRegistration, s.d.SessionHandler().IsNotAuthenticated(s.handleRegistration, func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	wrappedHandleRegistration := strategy.IsDisabled(s.d, s.ID().String(), s.handleRegistration)
+	public.POST(RouteRegistration, s.d.SessionHandler().IsNotAuthenticated(wrappedHandleRegistration, func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 		handler := session.RedirectOnAuthenticated(s.d)
 		if x.IsJSONRequest(r) {
 			handler = session.RespondWithJSONErrorOnAuthenticated(s.d.Writer(), registration.ErrAlreadyLoggedIn)

--- a/selfservice/strategy/password/settings.go
+++ b/selfservice/strategy/password/settings.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ory/kratos/selfservice/flow"
 	"github.com/ory/kratos/selfservice/flow/settings"
 	"github.com/ory/kratos/selfservice/form"
+	"github.com/ory/kratos/selfservice/strategy"
 	"github.com/ory/kratos/x"
 )
 
@@ -32,8 +33,9 @@ const (
 func (s *Strategy) RegisterSettingsRoutes(router *x.RouterPublic) {
 	s.d.CSRFHandler().IgnorePath(RouteSettings)
 
-	router.POST(RouteSettings, s.submitSettingsFlow)
-	router.GET(RouteSettings, s.submitSettingsFlow)
+	wrappedSubmmitSettingsFlow := strategy.IsDisabled(s.d, s.SettingsStrategyID(), s.submitSettingsFlow)
+	router.POST(RouteSettings, wrappedSubmmitSettingsFlow)
+	router.GET(RouteSettings, wrappedSubmmitSettingsFlow)
 }
 
 func (s *Strategy) SettingsStrategyID() string {

--- a/selfservice/strategy/password/strategy_test.go
+++ b/selfservice/strategy/password/strategy_test.go
@@ -3,8 +3,10 @@ package password_test
 import (
 	"context"
 	"fmt"
+	"github.com/ory/kratos/internal/testhelpers"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -104,4 +106,56 @@ func TestCountActiveCredentials(t *testing.T) {
 			assert.Equal(t, tc.expected, actual)
 		})
 	}
+}
+
+func TestDisabledEndpoint(t *testing.T) {
+	conf, reg := internal.NewFastRegistryWithMocks(t)
+	testhelpers.StrategyEnable(t, conf, identity.CredentialsTypePassword.String(), false)
+
+	publicTS, _ := testhelpers.NewKratosServer(t, reg)
+
+	c := testhelpers.NewClientWithCookies(t)
+	t.Run("case=should not login when password method is disabled", func(t *testing.T) {
+		res, err := c.PostForm(publicTS.URL+password.RouteLogin, url.Values{"identifier": []string{"identifier"}, "password": []string{"password"}})
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+
+		b := make([]byte, res.ContentLength)
+		_, _ = res.Body.Read(b)
+		assert.Contains(t, string(b), "This endpoint was disabled by system administrator")
+	})
+
+	t.Run("case=should not registration when password method is disabled", func(t *testing.T) {
+
+		res, err := c.PostForm(publicTS.URL+password.RouteRegistration, url.Values{"identifier": []string{"identifier"}, "password": []string{"password"}})
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+
+		b := make([]byte, res.ContentLength)
+		_, _ = res.Body.Read(b)
+		assert.Contains(t, string(b), "This endpoint was disabled by system administrator")
+	})
+
+	t.Run("case=should not settings when password method is disabled", func(t *testing.T) {
+
+		t.Run("method=GET", func(t *testing.T) {
+			res, err := c.Get(publicTS.URL + password.RouteSettings)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+
+			b := make([]byte, res.ContentLength)
+			_, _ = res.Body.Read(b)
+			assert.Contains(t, string(b), "This endpoint was disabled by system administrator")
+		})
+
+		t.Run("method=POST", func(t *testing.T) {
+			res, err := c.PostForm(publicTS.URL+password.RouteSettings, url.Values{"age": {"16"}})
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+
+			b := make([]byte, res.ContentLength)
+			_, _ = res.Body.Read(b)
+			assert.Contains(t, string(b), "This endpoint was disabled by system administrator")
+		})
+	})
 }

--- a/selfservice/strategy/password/strategy_test.go
+++ b/selfservice/strategy/password/strategy_test.go
@@ -118,7 +118,7 @@ func TestDisabledEndpoint(t *testing.T) {
 	t.Run("case=should not login when password method is disabled", func(t *testing.T) {
 		res, err := c.PostForm(publicTS.URL+password.RouteLogin, url.Values{"identifier": []string{"identifier"}, "password": []string{"password"}})
 		require.NoError(t, err)
-		assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+		assert.Equal(t, http.StatusNotFound, res.StatusCode)
 
 		b := make([]byte, res.ContentLength)
 		_, _ = res.Body.Read(b)
@@ -129,7 +129,7 @@ func TestDisabledEndpoint(t *testing.T) {
 
 		res, err := c.PostForm(publicTS.URL+password.RouteRegistration, url.Values{"identifier": []string{"identifier"}, "password": []string{"password"}})
 		require.NoError(t, err)
-		assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+		assert.Equal(t, http.StatusNotFound, res.StatusCode)
 
 		b := make([]byte, res.ContentLength)
 		_, _ = res.Body.Read(b)
@@ -141,7 +141,7 @@ func TestDisabledEndpoint(t *testing.T) {
 		t.Run("method=GET", func(t *testing.T) {
 			res, err := c.Get(publicTS.URL + password.RouteSettings)
 			require.NoError(t, err)
-			assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+			assert.Equal(t, http.StatusNotFound, res.StatusCode)
 
 			b := make([]byte, res.ContentLength)
 			_, _ = res.Body.Read(b)
@@ -151,7 +151,7 @@ func TestDisabledEndpoint(t *testing.T) {
 		t.Run("method=POST", func(t *testing.T) {
 			res, err := c.PostForm(publicTS.URL+password.RouteSettings, url.Values{"age": {"16"}})
 			require.NoError(t, err)
-			assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+			assert.Equal(t, http.StatusNotFound, res.StatusCode)
 
 			b := make([]byte, res.ContentLength)
 			_, _ = res.Body.Read(b)

--- a/selfservice/strategy/profile/strategy.go
+++ b/selfservice/strategy/profile/strategy.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ory/kratos/selfservice/flow"
 	"github.com/ory/kratos/selfservice/flow/settings"
 	"github.com/ory/kratos/selfservice/form"
+	"github.com/ory/kratos/selfservice/strategy"
 	"github.com/ory/kratos/session"
 	"github.com/ory/kratos/x"
 )
@@ -87,8 +88,9 @@ func (s *Strategy) SettingsStrategyID() string {
 func (s *Strategy) RegisterSettingsRoutes(public *x.RouterPublic) {
 	s.d.CSRFHandler().IgnorePath(RouteSettings)
 
-	public.POST(RouteSettings, s.d.SessionHandler().IsAuthenticated(s.handleSubmit, settings.OnUnauthenticated(s.d)))
-	public.GET(RouteSettings, s.d.SessionHandler().IsAuthenticated(s.handleSubmit, settings.OnUnauthenticated(s.d)))
+	wrappedHandleSubmit := strategy.IsDisabled(s.d, s.SettingsStrategyID(), s.handleSubmit)
+	public.POST(RouteSettings, s.d.SessionHandler().IsAuthenticated(wrappedHandleSubmit, settings.OnUnauthenticated(s.d)))
+	public.GET(RouteSettings, s.d.SessionHandler().IsAuthenticated(wrappedHandleSubmit, settings.OnUnauthenticated(s.d)))
 }
 
 func (s *Strategy) PopulateSettingsMethod(r *http.Request, id *identity.Identity, pr *settings.Flow) error {

--- a/selfservice/strategy/profile/strategy_test.go
+++ b/selfservice/strategy/profile/strategy_test.go
@@ -507,7 +507,7 @@ func TestDisabledEndpoint(t *testing.T) {
 		t.Run("method=GET", func(t *testing.T) {
 			res, err := browserUser1.Get(publicTS.URL + profile.RouteSettings)
 			require.NoError(t, err)
-			assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+			assert.Equal(t, http.StatusNotFound, res.StatusCode)
 
 			b := make([]byte, 10000)
 			_, _ = res.Body.Read(b)
@@ -517,7 +517,7 @@ func TestDisabledEndpoint(t *testing.T) {
 		t.Run("method=POST", func(t *testing.T) {
 			res, err := browserUser1.PostForm(publicTS.URL+profile.RouteSettings, url.Values{"age": {"16"}})
 			require.NoError(t, err)
-			assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+			assert.Equal(t, http.StatusNotFound, res.StatusCode)
 
 			b := make([]byte, res.ContentLength)
 			_, _ = res.Body.Read(b)

--- a/selfservice/strategy/profile/strategy_test.go
+++ b/selfservice/strategy/profile/strategy_test.go
@@ -493,3 +493,35 @@ func TestStrategyTraits(t *testing.T) {
 		})
 	})
 }
+func TestDisabledEndpoint(t *testing.T) {
+	conf, reg := internal.NewFastRegistryWithMocks(t)
+	conf.MustSet(config.ViperKeyDefaultIdentitySchemaURL, "file://./stub/identity.schema.json")
+	testhelpers.StrategyEnable(t, conf, settings.StrategyProfile, false)
+
+	publicTS, _ := testhelpers.NewKratosServer(t, reg)
+	browserIdentity1 := newIdentityWithPassword("john-browser@doe.com")
+	browserUser1 := testhelpers.NewHTTPClientWithIdentitySessionCookie(t, reg, browserIdentity1)
+
+	t.Run("case=should not submit when profile method is disabled", func(t *testing.T) {
+
+		t.Run("method=GET", func(t *testing.T) {
+			res, err := browserUser1.Get(publicTS.URL + profile.RouteSettings)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+
+			b := make([]byte, 10000)
+			_, _ = res.Body.Read(b)
+			assert.Contains(t, string(b), "This endpoint was disabled by system administrator")
+		})
+
+		t.Run("method=POST", func(t *testing.T) {
+			res, err := browserUser1.PostForm(publicTS.URL+profile.RouteSettings, url.Values{"age": {"16"}})
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+
+			b := make([]byte, res.ContentLength)
+			_, _ = res.Body.Read(b)
+			assert.Contains(t, string(b), "This endpoint was disabled by system administrator")
+		})
+	})
+}


### PR DESCRIPTION
## Related issue

#954 

## Proposed changes

Return 400 with message `This endpoint was disabled by system administrator. Please check your url or contact the system administrator to enable it.` when user requests endpoints belonging to disabled methods. 

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

