### PR TITLE
feat: Courier foreground worker with "kratos courier watch"

### DIFF
--- a/cmd/courier/watch_test.go
+++ b/cmd/courier/watch_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ory/kratos/internal"
+	"github.com/phayes/freeport"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,7 +23,9 @@ func TestStartCourier(t *testing.T) {
 	t.Run("case=with metrics", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		_, r := internal.NewFastRegistryWithMocks(t)
-		r.Config(ctx).Set("expose-metrics-port", 8080)
+		port, err := freeport.GetFreePort()
+		require.NoError(t, err)
+		r.Config(ctx).Set("expose-metrics-port", port)
 		go StartCourier(ctx, r)
 		time.Sleep(time.Second)
 		res, err := http.Get("http://" + r.Config(ctx).MetricsListenOn() + "/metrics/prometheus")


### PR DESCRIPTION
## Related issue
#652 #732
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->
Following the discussion in #1024, this PR defines a new `kratos courier watch` command which runs the message courier in the foreground, as well as disabling the background courier by default when `kratos serve` is executed. 
The `--watch-courier` flag can be passed to the `serve` command to execute the courier in the background as is the current behavior.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
