### PR TITLE
feat: add facebook provider to oidc providers and documentation

### DIFF
--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -137,7 +137,7 @@
         },
         "provider": {
           "title": "Provider",
-          "description": "Can be one of github, gitlab, generic, google, microsoft, discord, slack.",
+          "description": "Can be one of github, gitlab, generic, google, microsoft, discord, slack, facebook.",
           "type": "string",
           "enum": [
             "github",
@@ -146,7 +146,8 @@
             "google",
             "microsoft",
             "discord",
-            "slack"
+            "slack",
+            "facebook"
           ],
           "examples": [
             "google"

--- a/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
+++ b/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
@@ -551,7 +551,90 @@ selfservice:
 Next, open the login endpoint of the SecureApp and you should see the Twitch
 Login option!
 
-## Google, LinkedIn, Facebook
+## Facebook
+
+**Create Facebook Application**
+
+To set up "Sign in with Facebook" you must create a
+[Facebook OAuth2 Application](https://developers.facebook.com/apps/).
+
+Then add a "Facebook Login" product to this application.
+
+Set the "Valid OAuth Redirect URIs" to:
+
+```
+https://127.0.0.1:4433/self-service/methods/oidc/callback/facebook
+```
+
+The pattern of this URL is:
+
+```
+https://<domain-of-ory-kratos>:<public-port>/self-service/methods/oidc/callback/<provider-id>
+```
+
+Facebook requires https the redirect URIs!
+
+:::note
+
+While you can use
+[Facebook as an OIDC identity provider](https://developers.facebook.com/docs/facebook-login/),
+Facebook only returns access_token and not id_token. Therefore,
+ORY Kratos makes a request to
+[Facebook's graph.facebook.com/me API](https://graph.facebook.com/me) and adds the
+user info to `std.extVar('claims')`.
+
+:::
+
+**Configuring Kratos**
+
+Create a Jsonnet claims mapper as described in
+[OpenID Connect and OAuth2 Credentials](../concepts/credentials/openid-connect-oidc-oauth2.mdx).
+Save the code in
+`<kratos-directory>/contrib/quickstart/kratos/email-password/oidc.facebook.jsonnet`.
+
+```json title="contrib/quickstart/kratos/email-password/oidc.facebook.jsonnet"
+local claims = std.extVar('claims');
+{
+  identity: {
+    traits: {
+      // Allowing unverified email addresses enables account
+      // enumeration attacks, especially if the value is used for
+      // e.g. verification or as a password login identifier.
+      //
+      // It is assumed that Facebook requires a email to be verifed before accessable via Oauth (because they don't provide an email_verified field).
+      //
+      // The email might be empty if the user is not allowed to an email scope.
+      [if "email" in claims then "email" else null]: claims.email,
+    },
+  },
+}
+```
+
+Now, enable the Facebook provider in the ORY Kratos config located at
+`<kratos-directory>/contrib/quickstart/kratos/email-password/kratos.yml`.
+
+```yaml title="contrib/quickstart/kratos/email-password/kratos.yml"
+# $ kratos -c path/to/my/kratos/config.yml serve
+selfservice:
+  methods:
+    oidc:
+      enabled: true
+      config:
+        providers:
+          - id: facebook # this is `<provider-id>` in the Authorization callback URL. DO NOT CHANGE IT ONCE SET!
+            provider: facebook
+            client_id: .... # Replace this with the OAuth2 Client ID provided by Facebook app
+            client_secret: .... # Replace this with the OAuth2 Client Secret provided by Facebook app
+            mapper_url: file:///etc/config/kratos/oidc.facebook.jsonnet
+            scope:
+              - email # required for email and email_verified claims in the near future
+                      # other supported scopes: user_gender, user_birthday
+```
+
+Next, open the login endpoint of the SecureApp and you should see the Facebook
+Login option!
+
+## Google, LinkedIn
 
 Connecting with other Social Sign In providers will be very similar to the
 GitHub flow. If you've managed to do it, add to this document by writing it down

--- a/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
+++ b/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
@@ -465,14 +465,15 @@ Azure AD is now an option to log in to kratos.
 There are two ways to use the `microsoft` provider for authentication:
 
 1. For authenticating users in a single Azure AD Directory (organisation), set
-   the `tenant` value to either the `Directory ID` from the "App Registration"
-   page, or the organisation domain. E.g. `8eaef023-2b34-4da1-9baa-8bc8c9d6a490`
-   or `contoso.onmicrosoft.com`.
+the `tenant` value to either the `Directory ID` from the "App Registration"
+page, or the organisation domain. E.g. `8eaef023-2b34-4da1-9baa-8bc8c9d6a490`
+or `contoso.onmicrosoft.com`.
 2. For authenticating any user in the Microsoft identity platform, set the
-   `tenant` value to either:
-   - `organizations` to allow users with work or school accounts, or
-   - `consumers` to allow users with personal accounts, or
-   - `common` to allow both kind of accounts.
+`tenant` value to either:
+
+- `organizations` to allow users with work or school accounts, or
+- `consumers` to allow users with personal accounts, or
+- `common` to allow both kind of accounts.
 
 ## Twitch
 
@@ -578,10 +579,10 @@ Facebook requires https the redirect URIs!
 
 While you can use
 [Facebook as an OIDC identity provider](https://developers.facebook.com/docs/facebook-login/),
-Facebook only returns access_token and not id_token. Therefore,
-ORY Kratos makes a request to
-[Facebook's graph.facebook.com/me API](https://graph.facebook.com/me) and adds the
-user info to `std.extVar('claims')`.
+Facebook only returns access_token and not id_token. Therefore, ORY Kratos makes
+a request to
+[Facebook's graph.facebook.com/me API](https://graph.facebook.com/me) and adds
+the user info to `std.extVar('claims')`.
 
 :::
 
@@ -628,7 +629,7 @@ selfservice:
             mapper_url: file:///etc/config/kratos/oidc.facebook.jsonnet
             scope:
               - email # required for email and email_verified claims in the near future
-                      # other supported scopes: user_gender, user_birthday
+                # other supported scopes: user_gender, user_birthday
 ```
 
 Next, open the login endpoint of the SecureApp and you should see the Facebook

--- a/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
+++ b/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
@@ -556,10 +556,15 @@ Login option!
 
 ### Create Facebook Application
 
-To set up "Sign in with Facebook" you must create a
-[Facebook OAuth2 Application](https://developers.facebook.com/apps/).
+To set up "Sign in with Facebook" you first need a
+[Facebook Developer Account](https://developers.facebook.com/docs/development/register).
 
-Then add a "Facebook Login" product to this application.
+Create a
+[Facebook OAuth2 Application](https://developers.facebook.com/docs/development/create-an-app).
+
+Add a "Facebook Login" product to this application.
+
+Select "Settings" in the Products menu.
 
 Set the "Valid OAuth Redirect URIs" to:
 

--- a/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
+++ b/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
@@ -465,11 +465,11 @@ Azure AD is now an option to log in to kratos.
 There are two ways to use the `microsoft` provider for authentication:
 
 1. For authenticating users in a single Azure AD Directory (organisation), set
-the `tenant` value to either the `Directory ID` from the "App Registration"
-page, or the organisation domain. E.g. `8eaef023-2b34-4da1-9baa-8bc8c9d6a490`
-or `contoso.onmicrosoft.com`.
+   the `tenant` value to either the `Directory ID` from the "App Registration"
+   page, or the organisation domain. E.g. `8eaef023-2b34-4da1-9baa-8bc8c9d6a490`
+   or `contoso.onmicrosoft.com`.
 2. For authenticating any user in the Microsoft identity platform, set the
-`tenant` value to either:
+   `tenant` value to either:
 
 - `organizations` to allow users with work or school accounts, or
 - `consumers` to allow users with personal accounts, or

--- a/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
+++ b/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
@@ -553,7 +553,7 @@ Login option!
 
 ## Facebook
 
-**Create Facebook Application**
+### Create Facebook Application
 
 To set up "Sign in with Facebook" you must create a
 [Facebook OAuth2 Application](https://developers.facebook.com/apps/).
@@ -585,7 +585,7 @@ user info to `std.extVar('claims')`.
 
 :::
 
-**Configuring Kratos**
+### Configuring Kratos
 
 Create a Jsonnet claims mapper as described in
 [OpenID Connect and OAuth2 Credentials](../concepts/credentials/openid-connect-oidc-oauth2.mdx).

--- a/selfservice/strategy/oidc/provider_config.go
+++ b/selfservice/strategy/oidc/provider_config.go
@@ -24,6 +24,7 @@ type Configuration struct {
 	// - microsoft
 	// - discord
 	// - slack
+	// - facebook
 	Provider string `json:"provider"`
 
 	// ClientID is the application's Client ID.
@@ -102,6 +103,8 @@ func (c ConfigurationCollection) Provider(id string, public *url.URL) (Provider,
 				return NewProviderDiscord(&p, public), nil
 			case addProviderName("slack"):
 				return NewProviderSlack(&p, public), nil
+			case addProviderName("facebook"):
+				return NewProviderFacebook(&p, public), nil
 			}
 			return nil, errors.Errorf("provider type %s is not supported, supported are: %v", p.Provider, providerNames)
 		}

--- a/selfservice/strategy/oidc/provider_facebook.go
+++ b/selfservice/strategy/oidc/provider_facebook.go
@@ -1,0 +1,110 @@
+package oidc
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/ory/herodot"
+	"github.com/pkg/errors"
+	"golang.org/x/oauth2"
+	"net/http"
+	"net/url"
+)
+
+type ProviderFacebook struct {
+	*ProviderGenericOIDC
+}
+
+func NewProviderFacebook(
+	config *Configuration,
+	public *url.URL,
+) *ProviderFacebook {
+	config.IssuerURL = "https://facebook.com"
+	return &ProviderFacebook{
+		ProviderGenericOIDC: &ProviderGenericOIDC{
+			config: config,
+			public: public,
+		},
+	}
+}
+
+func (g *ProviderFacebook) OAuth2(ctx context.Context) (*oauth2.Config, error) {
+	p, err := g.provider(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint := p.Endpoint()
+
+	if endpoint.AuthURL == "" {
+		endpoint.AuthURL = "https://facebook.com/dialog/oauth"
+	}
+	if endpoint.TokenURL == "" {
+		endpoint.TokenURL = "https://graph.facebook.com/oauth/access_token"
+	}
+
+	return g.oauth2ConfigFromEndpoint(endpoint), nil
+}
+
+func (g *ProviderFacebook) Claims(ctx context.Context, exchange *oauth2.Token) (*Claims, error) {
+	o, err := g.OAuth2(ctx)
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+
+	client := o.Client(ctx, exchange)
+
+	u, err := url.Parse("https://graph.facebook.com/me?fields=id,name,first_name,last_name,middle_name,email,picture,birthday,gender")
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+	defer resp.Body.Close()
+
+	var user struct {
+		Id            string `json:"id,omitempty"`
+		Name          string `json:"name,omitempty"`
+		FirstName     string `json:"first_name,omitempty"`
+		LastName      string `json:"last_name,omitempty"`
+		MiddleName    string `json:"middle_name,omitempty"`
+		Email         string `json:"email,omitempty"`
+		EmailVerified bool
+		Picture       struct {
+			Data struct {
+				Url string `json:"url,omitempty"`
+			} `json:"data,omitempty"`
+		} `json:"picture,omitempty"`
+		BirthDay string `json:"birthday,omitempty"`
+		Gender   string `json:"gender,omitempty"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&user); err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+
+	if user.Email != "" {
+		user.EmailVerified = true
+	}
+
+	return &Claims{
+		Issuer:            u.String(),
+		Subject:           user.Id,
+		Name:              user.Name,
+		GivenName:         user.FirstName,
+		FamilyName:        user.LastName,
+		MiddleName:        user.MiddleName,
+		Nickname:          user.Name,
+		PreferredUsername: user.Name,
+		Picture:           user.Picture.Data.Url,
+		Email:             user.Email,
+		EmailVerified:     user.EmailVerified,
+		Gender:            user.Gender,
+		Birthdate:         user.BirthDay,
+	}, nil
+}


### PR DESCRIPTION
## Related issue

https://github.com/ory/kratos/issues/1034

## Proposed changes

- Adds provider_facebook.go and updates the configuration schema to allow for facebook as an OIDC provider
- Adds description to documentation

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
