### PR TITLE
fix: Hashtag in url converts to %23

### DIFF
--- a/driver/config/config.go
+++ b/driver/config/config.go
@@ -577,7 +577,7 @@ func (p *Config) parseURIOrFail(key string) *url.URL {
 		p.l.WithError(errors.WithStack(err)).
 			Fatalf("Configuration value from key %s is not a valid URL: %s", key, p.p.String(key))
 	}
-	if url.Host == "" || (url.Scheme != "http" && url.Scheme != "https") {
+	if url.Host == "" || (url.Scheme != "") {
 		p.l.Fatalf("Configuration value from key %s is not a valid URL: %s", key, p.p.String(key))
 	}
 

--- a/driver/config/config.go
+++ b/driver/config/config.go
@@ -562,7 +562,7 @@ func (p *Config) CourierTemplatesRoot() string {
 }
 
 func (p *Config) parseURIOrFail(key string) *url.URL {
-	u, err := url.ParseRequestURI(p.p.String(key))
+	u, err := url.Parse(p.p.String(key))
 	if err != nil {
 		p.l.WithError(errors.WithStack(err)).
 			Fatalf("Configuration value from key %s is not a valid URL: %s", key, p.p.String(key))

--- a/driver/config/config.go
+++ b/driver/config/config.go
@@ -577,7 +577,7 @@ func (p *Config) parseURIOrFail(key string) *url.URL {
 		p.l.WithError(errors.WithStack(err)).
 			Fatalf("Configuration value from key %s is not a valid URL: %s", key, p.p.String(key))
 	}
-	if url.Host == "" || (url.Scheme != "") {
+	if url.Host == "" || url.Scheme != "" {
 		p.l.Fatalf("Configuration value from key %s is not a valid URL: %s", key, p.p.String(key))
 	}
 

--- a/driver/config/config.go
+++ b/driver/config/config.go
@@ -577,7 +577,7 @@ func (p *Config) parseURIOrFail(key string) *url.URL {
 		p.l.WithError(errors.WithStack(err)).
 			Fatalf("Configuration value from key %s is not a valid URL: %s", key, p.p.String(key))
 	}
-	if url.Host == "" || url.Scheme != "" {
+	if url.Host == "" || url.Scheme == "" {
 		p.l.Fatalf("Configuration value from key %s is not a valid URL: %s", key, p.p.String(key))
 	}
 

--- a/driver/config/config_test.go
+++ b/driver/config/config_test.go
@@ -65,7 +65,7 @@ func TestViperProvider(t *testing.T) {
 				"#/login",
 				"/login",
 				"/",
-				"smtp://test.kratos.ory.sh/login",
+				"test.kratos.ory.sh/login",
 			} {
 
 				logger := logrusx.New("", "")

--- a/driver/config/config_test.go
+++ b/driver/config/config_test.go
@@ -44,6 +44,21 @@ func TestViperProvider(t *testing.T) {
 				"http://return-to-1-test.ory.sh/",
 				"http://return-to-2-test.ory.sh/",
 			}, ds)
+
+			pWithFragments := config.MustNew(logrusx.New("", ""),
+				configx.WithValues(map[string]interface{}{
+					config.ViperKeySelfServiceLoginUI:        "http://test.kratos.ory.sh/#/login",
+					config.ViperKeySelfServiceSettingsURL:    "http://test.kratos.ory.sh/#/settings",
+					config.ViperKeySelfServiceRegistrationUI: "http://test.kratos.ory.sh/#/register",
+					config.ViperKeySelfServiceErrorUI:        "http://test.kratos.ory.sh/#/error",
+				}),
+				configx.SkipValidation(),
+			)
+
+			assert.Equal(t, "http://test.kratos.ory.sh/#/login", pWithFragments.SelfServiceFlowLoginUI().String())
+			assert.Equal(t, "http://test.kratos.ory.sh/#/settings", pWithFragments.SelfServiceFlowSettingsUI().String())
+			assert.Equal(t, "http://test.kratos.ory.sh/#/register", pWithFragments.SelfServiceFlowRegistrationUI().String())
+			assert.Equal(t, "http://test.kratos.ory.sh/#/error", pWithFragments.SelfServiceFlowErrorURL().String())
 		})
 
 		t.Run("group=default_return_to", func(t *testing.T) {


### PR DESCRIPTION
## Related issue
#1032 @aeneasr 

## Proposed changes

Lots of hybrid applications that are built with [electron](https://nklayman.github.io/vue-cli-plugin-electron-builder/guide/commonIssues.html#blank-screen-on-builds-but-works-fine-on-serve), cordova, capacitor, etc. use hash-based routing. When we use URLs with a hash mark ([fragment](https://en.wikipedia.org/wiki/URI_fragment)), Kratos replaced it with `%23` because [ParseRequestURI](https://golang.org/pkg/net/url/#ParseRequestURI) assumed that URL dows not to have a #fragment suffix (see docs). [Parse](https://golang.org/pkg/net/url/#Parse) function parse URL correctly with #fragment.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x ] I have read the [security policy](../security/policy).
- [x ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x ] I have added tests that prove my fix is effective or that my feature
      works.
- [x ] I have added or changed [the documentation](docs/docs).
