### PR TITLE
chore: update repository template to bc8c693e

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ that your company deserves a spot here, reach out to
 
 We also want to thank all individual contributors
 
-<img src="https://opencollective.com/ory/contributors.svg?width=890&button=false" /></a>
+<a href="https://opencollective.com/ory" target="_blank"><img src="https://opencollective.com/ory/contributors.svg?width=890&button=false" /></a>
 
 as well as all of our backers
 


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/bc8c693e32223db9960c0a8084cf0b2e8255193b.