### PR TITLE
docs: fix link

### DIFF
--- a/docs/versioned_docs/version-v0.5/debug/performance-out-of-memory-password-hashing-argon2.md
+++ b/docs/versioned_docs/version-v0.5/debug/performance-out-of-memory-password-hashing-argon2.md
@@ -10,7 +10,7 @@ without trying them out, ORY Kratos comes with a
 [CLI](../cli/kratos-hashers-argon2-calibrate.md) that automatically calibrates
 the values, following best practices. You can read more about these best
 practices in our
-[blog post](https://ory.sh/argon2-parameter-choice-best-practice/).
+[blog post](https://www.ory.sh/choose-recommended-argon2-parameters-password-hashing/).
 
 ## Common Errors
 


### PR DESCRIPTION
blog post link fixed in versioned docs 0.5