### PR TITLE
feat: Allow specifying Sender Name in smtp.from_address

### DIFF
--- a/courier/courier.go
+++ b/courier/courier.go
@@ -140,13 +140,13 @@ func (m *Courier) DispatchQueue(ctx context.Context) error {
 		switch msg.Type {
 		case MessageTypeEmail:
 			from := m.d.Config(ctx).CourierSMTPFrom()
-      fromName := m.d.Config(ctx).CourierSMTPFromName()
+			fromName := m.d.Config(ctx).CourierSMTPFromName()
 			gm := gomail.NewMessage()
-      if fromName == "" {
-        gm.SetHeader("From", from)
-      } else {
-        gm.SetAddressHeader("From", from, fromName)
-      }
+			if fromName == "" {
+				gm.SetHeader("From", from)
+			} else {
+				gm.SetAddressHeader("From", from, fromName)
+			}
 			gm.SetHeader("To", msg.Recipient)
 			gm.SetHeader("Subject", msg.Subject)
 			gm.SetBody("text/plain", msg.Body)

--- a/courier/courier.go
+++ b/courier/courier.go
@@ -140,8 +140,13 @@ func (m *Courier) DispatchQueue(ctx context.Context) error {
 		switch msg.Type {
 		case MessageTypeEmail:
 			from := m.d.Config(ctx).CourierSMTPFrom()
+      fromName := m.d.Config(ctx).CourierSMTPFromName()
 			gm := gomail.NewMessage()
-			gm.SetHeader("From", from)
+      if fromName == "" {
+        gm.SetHeader("From", from)
+      } else {
+        gm.SetAddressHeader("From", from, fromName)
+      }
 			gm.SetHeader("To", msg.Recipient)
 			gm.SetHeader("Subject", msg.Subject)
 			gm.SetBody("text/plain", msg.Body)

--- a/courier/courier_test.go
+++ b/courier/courier_test.go
@@ -73,8 +73,8 @@ func TestSMTP(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEqual(t, uuid.Nil, id)
 
-    // The third email contains a sender name
-    conf.MustSet(config.ViperKeyCourierSMTPFromName, "Bob")
+		// The third email contains a sender name
+		conf.MustSet(config.ViperKeyCourierSMTPFromName, "Bob")
 		id, err = c.QueueEmail(context.Background(), templates.NewTestStub(conf, &templates.TestStubModel{
 			To:      "test-recipient-3@example.org",
 			Subject: "test-subject-3",
@@ -124,7 +124,7 @@ func TestSMTP(t *testing.T) {
 			assert.Contains(t, string(body), "test-stub@ory.sh")
 		}
 
-    // Assertion for the third email with sender name
-    assert.Contains(t, string(body), "Bob")
+		// Assertion for the third email with sender name
+		assert.Contains(t, string(body), "Bob")
 	})
 }

--- a/driver/config/.schema/config.schema.json
+++ b/driver/config/.schema/config.schema.json
@@ -752,8 +752,14 @@
               "title": "SMTP Sender Address",
               "description": "The recipient of an email will see this as the sender address.",
               "type": "string",
-              "format": "idn-email",
-              "default": "Kratos <no-reply@ory.kratos.sh>"
+              "format": "email",
+              "default": "no-reply@ory.kratos.sh"
+            },
+            "from_name": {
+              "title": "SMTP Sender Name",
+              "description": "The recipient of an email will see this as the sender name.",
+              "type": "string",
+              "examples": ["Bob"]
             }
           },
           "required": [

--- a/driver/config/.schema/config.schema.json
+++ b/driver/config/.schema/config.schema.json
@@ -752,8 +752,8 @@
               "title": "SMTP Sender Address",
               "description": "The recipient of an email will see this as the sender address.",
               "type": "string",
-              "format": "email",
-              "default": "no-reply@ory.kratos.sh"
+              "format": "idn-email",
+              "default": "Kratos <no-reply@ory.kratos.sh>"
             }
           },
           "required": [

--- a/driver/config/config.go
+++ b/driver/config/config.go
@@ -39,6 +39,7 @@ const (
 	ViperKeyCourierSMTPURL                                          = "courier.smtp.connection_uri"
 	ViperKeyCourierTemplatesPath                                    = "courier.template_override_path"
 	ViperKeyCourierSMTPFrom                                         = "courier.smtp.from_address"
+	ViperKeyCourierSMTPFromName                                     = "courier.smtp.from_name"
 	ViperKeySecretsDefault                                          = "secrets.default"
 	ViperKeySecretsCookie                                           = "secrets.cookie"
 	ViperKeyPublicBaseURL                                           = "serve.public.base_url"
@@ -594,6 +595,10 @@ func (p *Config) SelfServiceFlowLogoutRedirectURL() *url.URL {
 
 func (p *Config) CourierSMTPFrom() string {
 	return p.p.StringF(ViperKeyCourierSMTPFrom, "noreply@kratos.ory.sh")
+}
+
+func (p *Config) CourierSMTPFromName() string {
+	return p.p.StringF(ViperKeyCourierSMTPFromName, "")
 }
 
 func (p *Config) CourierTemplatesRoot() string {


### PR DESCRIPTION
## Proposed changes

Currently, there is no way to configure Email `from` name for Kratos. 

By checking  [ory/mail's source code](https://github.com/ory/mail/blob/e6b733ef914946a8c48b5c81a451c5277d0da0bc/message.go#L133), I am convinced that Kratos is equipped with the ability to handle [RFC-5322](https://tools.ietf.org/html/rfc5322#section-3.4) `mailbox` format. 

This PR introduces a new optional `from_name` properties under `smtp.from_name`.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

If this looks alright, I am happy to raise another PR to update doc or just do it as part of this change too.
