### PR TITLE
Disable pwnedpasswords breaches check

### DIFF
--- a/driver/config/config.go
+++ b/driver/config/config.go
@@ -89,6 +89,7 @@ const (
 	ViperKeyHasherArgon2ConfigKeyLength                             = "hashers.argon2.key_length"
 	ViperKeyPasswordMaxBreaches                                     = "selfservice.methods.password.config.max_breaches"
 	ViperKeyIgnoreNetworkErrors                                     = "selfservice.methods.password.config.ignore_network_errors"
+	ViperKeyDisableBreachesCheck                                    = "selfservice.methods.password.config.disable_breaches_check"
 	ViperKeyVersion                                                 = "version"
 	Argon2DefaultMemory                                      uint32 = 4 * 1024 * 1024
 	Argon2DefaultIterations                                  uint32 = 4
@@ -120,8 +121,9 @@ type (
 		URL string `json:"url"`
 	}
 	PasswordPolicy struct {
-		MaxBreaches         uint `json:"max_breaches"`
-		IgnoreNetworkErrors bool `json:"ignore_network_errors"`
+		MaxBreaches          uint `json:"max_breaches"`
+		IgnoreNetworkErrors  bool `json:"ignore_network_errors"`
+		DisableBreachesCheck bool `json:"disable_breaches_check"`
 	}
 	Schemas []Schema
 	Config  struct {
@@ -719,7 +721,8 @@ func (p *Config) ConfigVersion() string {
 
 func (p *Config) PasswordPolicyConfig() *PasswordPolicy {
 	return &PasswordPolicy{
-		MaxBreaches:         uint(p.p.Int(ViperKeyPasswordMaxBreaches)),
-		IgnoreNetworkErrors: p.p.BoolF(ViperKeyIgnoreNetworkErrors, true),
+		MaxBreaches:          uint(p.p.Int(ViperKeyPasswordMaxBreaches)),
+		IgnoreNetworkErrors:  p.p.BoolF(ViperKeyIgnoreNetworkErrors, true),
+		DisableBreachesCheck: p.p.BoolF(ViperKeyDisableBreachesCheck, false),
 	}
 }

--- a/selfservice/strategy/password/validator.go
+++ b/selfservice/strategy/password/validator.go
@@ -153,6 +153,10 @@ func (s *DefaultPasswordValidator) Validate(ctx context.Context, identifier, pas
 		return errors.Errorf("the password is too similar to the user identifier")
 	}
 
+	if s.reg.Config(ctx).PasswordPolicyConfig().DisableBreachesCheck {
+		return nil
+	}
+
 	/* #nosec G401 sha1 is used for k-anonymity */
 	h := sha1.New()
 	if _, err := h.Write([]byte(password)); err != nil {

--- a/selfservice/strategy/password/validator_test.go
+++ b/selfservice/strategy/password/validator_test.go
@@ -69,18 +69,17 @@ func TestDefaultPasswordValidationStrategy(t *testing.T) {
 	fakeClient := NewFakeHTTPClient()
 	s.Client = &fakeClient.Client
 
+	t.Run("case=should not send request to pwnedpasswords.com when breaches check is disabled", func(t *testing.T) {
+		conf.MustSet(config.ViperKeyDisableBreachesCheck, true)
+		require.NoError(t, s.Validate(context.Background(), "mohutdesub", "damrumukuh"))
+		require.NotContains(t, fakeClient.RequestedURLs(), "https://api.pwnedpasswords.com/range/BCBA9")
+		conf.MustSet(config.ViperKeyDisableBreachesCheck, false)
+	})
+
 	t.Run("case=should send request to pwnedpasswords.com", func(t *testing.T) {
 		conf.MustSet(config.ViperKeyIgnoreNetworkErrors, false)
 		require.Error(t, s.Validate(context.Background(), "mohutdesub", "damrumukuh"))
 		require.Contains(t, fakeClient.RequestedURLs(), "https://api.pwnedpasswords.com/range/BCBA9")
-	})
-
-	t.Run("case=should not send request to pwnedpasswords.com when breaches check is disabled", func(t *testing.T) {
-		conf.Set("disable_breaches_check", true)
-		conf.MustSet(config.ViperKeyIgnoreNetworkErrors, false)
-		require.NoError(t, s.Validate(context.Background(), "mohutdesub", "damrumukuh"))
-		require.NotContains(t, fakeClient.RequestedURLs(), "https://api.pwnedpasswords.com/range/BCBA9")
-		conf.Set("disable_breaches_check", false)
 	})
 
 	t.Run("case=should fail if request fails and ignoreNetworkErrors is not set", func(t *testing.T) {

--- a/selfservice/strategy/password/validator_test.go
+++ b/selfservice/strategy/password/validator_test.go
@@ -75,6 +75,14 @@ func TestDefaultPasswordValidationStrategy(t *testing.T) {
 		require.Contains(t, fakeClient.RequestedURLs(), "https://api.pwnedpasswords.com/range/BCBA9")
 	})
 
+	t.Run("case=should not send request to pwnedpasswords.com when breaches check is disabled", func(t *testing.T) {
+		conf.Set("disable_breaches_check", true)
+		conf.MustSet(config.ViperKeyIgnoreNetworkErrors, false)
+		require.NoError(t, s.Validate(context.Background(), "mohutdesub", "damrumukuh"))
+		require.NotContains(t, fakeClient.RequestedURLs(), "https://api.pwnedpasswords.com/range/BCBA9")
+		conf.Set("disable_breaches_check", false)
+	})
+
 	t.Run("case=should fail if request fails and ignoreNetworkErrors is not set", func(t *testing.T) {
 		conf.MustSet(config.ViperKeyIgnoreNetworkErrors, false)
 		fakeClient.RespondWithError("Network request failed")


### PR DESCRIPTION
## Proposed changes

This PR allows Kratos to be configured to not check passwords against the database of pwnedpasswords.com.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

I understand that this check is helpful because it prevents users from using passwords which are vulnerable to dictionary attacks by people who have the list of compromised passwords held by pwnedpasswords. Nevertheless, in some use cases it is acceptable to let users be responsible for their own security and allow them to use any password they like. While this should certainly not be the default, it should be a configurable option. This is what this PR makes possible.
