### PR TITLE
fix: remove absolete 'make pack' from Dockerfile

### DIFF
--- a/.docker/Dockerfile-build
+++ b/.docker/Dockerfile-build
@@ -16,7 +16,7 @@ RUN go mod download
 
 ADD . .
 
-RUN make pack && go build -tags sqlite -o /usr/bin/kratos
+RUN go build -tags sqlite -o /usr/bin/kratos
 
 FROM alpine:3.12
 


### PR DESCRIPTION

## Proposed changes

Remove call to `make pack` in Dockerfile after it was removed from the Makefile.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).
