### PR TITLE
Make explicit the ID of the default schema

### DIFF
--- a/docs/versioned_docs/version-v0.5/reference/configuration.md
+++ b/docs/versioned_docs/version-v0.5/reference/configuration.md
@@ -40,6 +40,8 @@ identity:
   #
   # Path to the JSON Schema which describes a default identity's traits.
   #
+  # Default schema has an id of: "default"
+  #
   # Examples:
   # - file://path/to/identity.traits.schema.json
   # - https://foo.bar.com/path/to/identity.traits.schema.json

--- a/docs/versioned_docs/version-v0.5/reference/configuration.md
+++ b/docs/versioned_docs/version-v0.5/reference/configuration.md
@@ -40,8 +40,6 @@ identity:
   #
   # Path to the JSON Schema which describes a default identity's traits.
   #
-  # Default schema has an id of: "default"
-  #
   # Examples:
   # - file://path/to/identity.traits.schema.json
   # - https://foo.bar.com/path/to/identity.traits.schema.json

--- a/driver/config/.schema/config.schema.json
+++ b/driver/config/.schema/config.schema.json
@@ -1193,7 +1193,7 @@
       "properties": {
         "default_schema_url": {
           "title": "JSON Schema URL for default identity traits",
-          "description": "URL for JSON Schema which describes a default identity's traits. Can be a file path, a https URL, or a base64 encoded string.",
+          "description": "URL for JSON Schema which describes a default identity's traits. Can be a file path, a https URL, or a base64 encoded string. Will have ID: \"default\"",
           "type": "string",
           "format": "uri",
           "examples": [


### PR DESCRIPTION
## Proposed changes

Add one line to the config docs to mention the ID of the default schema. This is useful for using the schema/{id} API. It is not mentioned anywhere else in the docs.

## Checklist

- [ x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x ] I have read the [security policy](../security/policy).
- [x ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x ] I have added tests that prove my fix is effective or that my feature
      works.
- [x ] I have added or changed [the documentation](docs/docs).

