### PR TITLE
chore: enable goimports linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,11 +10,16 @@ linters:
     - unused
     - gosec
     - varcheck
+    - goimports
   disable:
     - ineffassign
     - dupl
     - godox
     - bodyclose # too many false negatives
+
+linters-settings:
+  goimports:
+    local-prefixes: github.com/ory
 
 run:
   skip-dirs:


### PR DESCRIPTION
## Related issue

The linter was not enabled and thus not checking the formatting on PRs.
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

Enable goimports in golangci-lint
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->
