### PR TITLE
fix: integer parsing bit size

### DIFF
--- a/courier/courier.go
+++ b/courier/courier.go
@@ -37,7 +37,7 @@ type (
 func NewSMTP(d smtpDependencies, c *config.Config) *Courier {
 	uri := c.CourierSMTPURL()
 	password, _ := uri.User.Password()
-	port, _ := strconv.ParseInt(uri.Port(), 10, 64)
+	port, _ := strconv.ParseInt(uri.Port(), 10, 0)
 
 	var ssl bool
 	var tlsConfig *tls.Config

--- a/x/pagination.go
+++ b/x/pagination.go
@@ -16,20 +16,20 @@ func ParsePagination(r *http.Request) (page, itemsPerPage int) {
 	if offsetParam := r.URL.Query().Get("page"); offsetParam == "" {
 		page = 0
 	} else {
-		if offset64, err := strconv.ParseInt(offsetParam, 10, 64); err != nil {
+		if offset, err := strconv.ParseInt(offsetParam, 10, 0); err != nil {
 			page = 0
 		} else {
-			page = int(offset64)
+			page = int(offset)
 		}
 	}
 
 	if limitParam := r.URL.Query().Get("per_page"); limitParam == "" {
 		itemsPerPage = paginationDefaultItems
 	} else {
-		if limit64, err := strconv.ParseInt(limitParam, 10, 64); err != nil {
+		if limit, err := strconv.ParseInt(limitParam, 10, 0); err != nil {
 			itemsPerPage = paginationDefaultItems
 		} else {
-			itemsPerPage = int(limit64)
+			itemsPerPage = int(limit)
 		}
 	}
 


### PR DESCRIPTION
## Related issue

In some cases we had a wrong bitsize of `64`, while the var was later cast to `int`.
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

## Result

[3 fixed alerts :tada:](https://github.com/ory/kratos/pull/1178/checks?check_run_id=2208117918)

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

Replaced with a bitsize of `0`, which is the value to cast to `int`.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Result

[3 fixed alerts :tada:](https://github.com/ory/kratos/pull/1178/checks?check_run_id=2208117918)