### PR TITLE
feat: strip base url path prefix while routing

### DIFF
--- a/cmd/daemon/middleware.go
+++ b/cmd/daemon/middleware.go
@@ -2,15 +2,18 @@ package daemon
 
 import (
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/negroni"
 
-	"github.com/ory/x/logrusx"
-
 	"github.com/ory/x/healthx"
+	"github.com/ory/x/logrusx"
 	"github.com/ory/x/reqlog"
+
+	"github.com/ory/kratos/driver/config"
 )
 
 func NewNegroniLoggerMiddleware(l *logrusx.Logger, name string) *reqlog.Middleware {
@@ -33,4 +36,34 @@ func NewNegroniLoggerMiddleware(l *logrusx.Logger, name string) *reqlog.Middlewa
 		})
 	}
 	return n
+}
+
+func NewStripPrefixMiddleware(prefixLoader func(r *http.Request) string) negroni.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+		prefix := strings.TrimRight(prefixLoader(r), "/")
+		if len(prefix) == 0 {
+			next.ServeHTTP(w, r)
+			return
+		}
+		http.StripPrefix(prefix, next).ServeHTTP(w, r)
+	}
+}
+
+func extractPrefixFromBaseURL(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+	return strings.TrimSuffix(u.Path, "/")
+}
+
+func publicURLPrefixExtractor(provider config.Provider) func(r *http.Request) string {
+	return func(r *http.Request) string {
+		return extractPrefixFromBaseURL(provider.Config(r.Context()).SelfPublicURL(r))
+	}
+}
+
+func adminURLPrefixExtractor(provider config.Provider) func(r *http.Request) string {
+	return func(r *http.Request) string {
+		return extractPrefixFromBaseURL(provider.Config(r.Context()).SelfAdminURL())
+	}
 }

--- a/cmd/daemon/middleware_test.go
+++ b/cmd/daemon/middleware_test.go
@@ -1,0 +1,212 @@
+package daemon
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ory/x/configx"
+	"github.com/ory/x/logrusx"
+
+	"github.com/ory/kratos/driver/config"
+)
+
+func TestNewStripPrefixMiddleware(t *testing.T) {
+	tests := []struct {
+		name         string
+		target       string
+		prefixLoader func(r *http.Request) string
+		wantNext     bool
+		wantPath     string
+		wantStatus   int
+	}{
+		{
+			name:         "empty prefix 1",
+			target:       "http://127.0.0.1:1234",
+			prefixLoader: func(r *http.Request) string { return "" },
+			wantNext:     true,
+			wantPath:     "",
+		},
+		{
+			name:         "empty prefix 2",
+			target:       "http://127.0.0.1:1234/foo",
+			prefixLoader: func(r *http.Request) string { return "" },
+			wantNext:     true,
+			wantPath:     "/foo",
+		},
+		{
+			name:         "slash prefix 1",
+			target:       "http://127.0.0.1:1234",
+			prefixLoader: func(r *http.Request) string { return "/" },
+			wantNext:     true,
+			wantPath:     "",
+		},
+		{
+			name:         "slash prefix 2",
+			target:       "http://127.0.0.1:1234/foo",
+			prefixLoader: func(r *http.Request) string { return "/" },
+			wantNext:     true,
+			wantPath:     "/foo",
+		},
+		{
+			name:         "slash prefix 3",
+			target:       "http://127.0.0.1:1234/",
+			prefixLoader: func(r *http.Request) string { return "/" },
+			wantNext:     true,
+			wantPath:     "/",
+		},
+		{
+			name:         "not matching prefix 1",
+			target:       "http://127.0.0.1:1234",
+			prefixLoader: func(r *http.Request) string { return "/kratos" },
+			wantStatus:   http.StatusNotFound,
+			wantPath:     "",
+		},
+		{
+			name:         "not matching prefix 2",
+			target:       "http://127.0.0.1:1234/foo",
+			prefixLoader: func(r *http.Request) string { return "/kratos" },
+			wantStatus:   http.StatusNotFound,
+			wantPath:     "/foo",
+		},
+		{
+			name:         "matching prefix 1",
+			target:       "http://127.0.0.1:1234/kratos/foo",
+			prefixLoader: func(r *http.Request) string { return "/kratos" },
+			wantNext:     true,
+			wantPath:     "/foo",
+		},
+		{
+			name:         "matching prefix 2",
+			target:       "http://127.0.0.1:1234/kratos/foo?query=value",
+			prefixLoader: func(r *http.Request) string { return "/kratos" },
+			wantNext:     true,
+			wantPath:     "/foo",
+		},
+		{
+			name:         "matching prefix 3",
+			target:       "http://127.0.0.1:1234/kratos/nested/foo",
+			prefixLoader: func(r *http.Request) string { return "/kratos" },
+			wantNext:     true,
+			wantPath:     "/nested/foo",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodGet, tt.target, nil)
+			mw := NewStripPrefixMiddleware(tt.prefixLoader)
+			nextRequest := request
+			gotNext := false
+			mw(recorder, request, func(w http.ResponseWriter, r *http.Request) {
+				gotNext = true
+				nextRequest = r
+			})
+			if tt.wantNext != gotNext {
+				t.Errorf("NewStripPrefixMiddleware() executed next %v, want %v", gotNext, tt.wantNext)
+			}
+			if tt.wantPath != nextRequest.URL.Path {
+				t.Errorf("NewStripPrefixMiddleware() got path %s, want %s", nextRequest.URL.Path, tt.wantPath)
+			}
+
+			if tt.wantStatus > 0 && recorder.Code != tt.wantStatus {
+				t.Errorf("NewStripPrefixMiddleware() got status %d, want %d", recorder.Code, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func MustURL(s string) *url.URL {
+	u, err := url.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+func Test_extractPrefixFromBaseURL(t *testing.T) {
+	tests := []struct {
+		name string
+		u    *url.URL
+		want string
+	}{
+		{"nil url", nil, ""},
+		{"no prefix 1", MustURL("https://127.0.0.1:4433"), ""},
+		{"no prefix 2", MustURL("https://127.0.0.1:4433/"), ""},
+		{"no prefix 3", MustURL("https://example.com"), ""},
+		{"prefix 1", MustURL("https://127.0.0.1:4433/kratos"), "/kratos"},
+		{"prefix 2", MustURL("https://example.com/kratos"), "/kratos"},
+		{"prefix 3", MustURL("https://example.com/my/kratos"), "/my/kratos"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractPrefixFromBaseURL(tt.u); got != tt.want {
+				t.Errorf("extractPrefixFromBaseURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type MockConfigProvider struct {
+	Conf *config.Config
+}
+
+func (p *MockConfigProvider) Config(ctx context.Context) *config.Config {
+	return p.Conf
+}
+
+// Ensure that the prefix can be extracted from the configured base url.
+func Test_StripPathPrefix(t *testing.T) {
+	t.Run("group=public", func(t *testing.T) {
+		get := func(cfg *config.Config, target string) string {
+			req := httptest.NewRequest(http.MethodGet, target, http.NoBody)
+			p := &MockConfigProvider{Conf: cfg}
+			return publicURLPrefixExtractor(p)(req)
+		}
+		c := config.MustNew(logrusx.New("", ""),
+			configx.WithConfigFiles("../../internal/.kratos.yaml"))
+		c.MustSet(config.ViperKeyPublicBaseURL, "http://public.kratos.ory.sh:1234")
+		c.MustSet(config.ViperKeyPublicHost, "public.kratos.ory.sh")
+		c.MustSet(config.ViperKeyPublicPort, 1234)
+		assert.Equal(t, get(c, "http://public.kratos.ory.sh:1234"), "")
+
+		// no path on base url
+		c.MustSet(config.ViperKeyPublicBaseURL, "http://public.kratos.ory.sh:1234")
+		assert.Equal(t, get(c, "http://public.kratos.ory.sh:1234"), "")
+
+		// trailing slash on base url
+		c.MustSet(config.ViperKeyPublicBaseURL, "http://public.kratos.ory.sh:1234/")
+		assert.Equal(t, get(c, "http://public.kratos.ory.sh:1234"), "")
+
+		// base path on base url
+		c.MustSet(config.ViperKeyPublicBaseURL, "http://public.kratos.ory.sh:1234/kratos")
+		assert.Equal(t, get(c, "http://public.kratos.ory.sh:1234"), "/kratos")
+
+	})
+
+	t.Run("group=admin", func(t *testing.T) {
+		get := func(cfg *config.Config, target string) string {
+			req := httptest.NewRequest(http.MethodGet, target, http.NoBody)
+			p := &MockConfigProvider{Conf: cfg}
+			return adminURLPrefixExtractor(p)(req)
+		}
+		c := config.MustNew(logrusx.New("", ""),
+			configx.WithConfigFiles("../../internal/.kratos.yaml"))
+
+		// no base path on url
+		c.MustSet(config.ViperKeyAdminBaseURL, "http://admin.kratos.ory.sh:1234")
+		assert.Equal(t, get(c, "http://admin.kratos.ory.sh:1234"), "")
+
+		// trailing slash on url
+		c.MustSet(config.ViperKeyAdminBaseURL, "http://admin.kratos.ory.sh:1234/")
+		assert.Equal(t, get(c, "http://admin.kratos.ory.sh:1234"), "")
+
+		// base path on base url
+		c.MustSet(config.ViperKeyAdminBaseURL, "http://admin.kratos.ory.sh:1234/kratos")
+		assert.Equal(t, get(c, "http://admin.kratos.ory.sh:1234"), "/kratos")
+	})
+}

--- a/cmd/daemon/serve.go
+++ b/cmd/daemon/serve.go
@@ -70,10 +70,10 @@ func ServePublic(r driver.Registry, wg *sync.WaitGroup, cmd *cobra.Command, args
 	c := r.Config(cmd.Context())
 	l := r.Logger()
 	n := negroni.New()
+	n.UseFunc(NewStripPrefixMiddleware(publicURLPrefixExtractor(r)))
 	for _, mw := range modifiers.mwf {
 		n.UseFunc(mw)
 	}
-
 	router := x.NewRouterPublic()
 	csrf := x.NewCSRFHandler(router, r)
 
@@ -116,6 +116,7 @@ func ServeAdmin(r driver.Registry, wg *sync.WaitGroup, cmd *cobra.Command, args 
 	c := r.Config(cmd.Context())
 	l := r.Logger()
 	n := negroni.New()
+	n.UseFunc(NewStripPrefixMiddleware(adminURLPrefixExtractor(r)))
 	for _, mw := range modifiers.mwf {
 		n.UseFunc(mw)
 	}

--- a/contrib/quickstart/kratos/email-password/kratos.yml
+++ b/contrib/quickstart/kratos/email-password/kratos.yml
@@ -7,6 +7,7 @@ serve:
     base_url: http://127.0.0.1:4433/
     cors:
       enabled: true
+    domain_aliases: []
   admin:
     base_url: http://kratos:4434/
 

--- a/internal/.kratos.yaml
+++ b/internal/.kratos.yaml
@@ -8,6 +8,7 @@ serve:
     base_url: http://public.kratos.ory.sh
     port: 1235
     host: public.kratos.ory.sh
+    domain_aliases: []
 
 dsn: sqlite://foo.db?mode=memory&_fk=true
 


### PR DESCRIPTION
Hello! This is my first kratos PR and I'm still relatively unfamiliar with the code base, so I'm happy to take suggestions about other ways to do this that might be more in line with existing ORY practices as well as feedback about style or code conventions.

## Related issue

#1152 

## Proposed changes

This change is aimed at supporting serving Kratos on a shared hostname behind a path prefix. If a `base_url` config value for the `public` or `admin` server contains a path, Kratos will assume that the entire server is running behind that path and strip the prefix from incoming requests. Requests that do not match the leading prefix will receive a 404 response.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

Design assumptions:
* If the base url is specified as `https://my.domain.com/kratos`, Kratos can assume that requests **must** have a leading `/kratos` prefix.
* It is not desirable to interpret trailing slashes on a base url as a prefix to strip. (`https://my.domain.com/` does not result in `/` being stripped from incoming requests)
* It's acceptable to add a global middleware for this rather than changing the root `http.Handler` at launch.
    * It appeared as if a middleware was necessary because the config field was dynamic, but it looks like `base_url` is marked as immutable so `kratos` doesn't actually support changing this on the fly.

Open Questions

* I could use some guidance on if there are better places to set up tests for this behavior. I only added unit tests for the added middleware functions, but nothing that actually tests the full configuration. I only validated this by running the quickstart with a path prefix.
* There seems to be a mix of test styles/structures? Is there a preferred way to structure unit tests for this project?
* Would it be preferred to just read the base path prefix at startup and add a static middleware?
* Should this address the `domain_aliases` config in some way? I wasn't exactly sure how to interact with those properties.