### PR TITLE
docs: Docker file links

### DIFF
--- a/docs/docs/concepts/docker.md
+++ b/docs/docs/concepts/docker.md
@@ -82,7 +82,7 @@ below:
 
 ```dockerfile
 FROM oryd/kratos:latest
-COPY contrib/quickstart/kratos/email-password/.kratos.yml /home/ory
+COPY contrib/quickstart/kratos/email-password/kratos.yml /home/ory
 ```
 
 ### Examples

--- a/docs/docs/guides/docker.md
+++ b/docs/docs/guides/docker.md
@@ -82,7 +82,7 @@ below:
 
 ```dockerfile
 FROM oryd/kratos:latest
-COPY contrib/quickstart/kratos/email-password/.kratos.yml /ory/home
+COPY contrib/quickstart/kratos/email-password/kratos.yml /ory/home
 ```
 
 ### Examples

--- a/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
+++ b/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
@@ -107,9 +107,9 @@ local claims = {
 ```
 
 Now, enable the Discord provider in the ORY Kratos config located at
-`<kratos-directory>/contrib/quickstart/kratos/email-password/.kratos.yml`.
+`<kratos-directory>/contrib/quickstart/kratos/email-password/kratos.yml`.
 
-```yaml title="contrib/quickstart/kratos/email-password/.kratos.yml"
+```yaml title="contrib/quickstart/kratos/email-password/kratos.yml"
 # $ kratos -c path/to/my/kratos/config.yml serve
 selfservice:
   methods:
@@ -203,9 +203,9 @@ local claims = {
 ```
 
 Now, enable the Slack provider in the ORY Kratos config located at
-`<kratos-directory>/contrib/quickstart/kratos/email-password/.kratos.yml`.
+`<kratos-directory>/contrib/quickstart/kratos/email-password/kratos.yml`.
 
-```yaml title="contrib/quickstart/kratos/email-password/.kratos.yml"
+```yaml title="contrib/quickstart/kratos/email-password/kratos.yml"
 # $ kratos -c path/to/my/kratos/config.yml serve
 selfservice:
   methods:
@@ -294,9 +294,9 @@ local claims = {
 ```
 
 Now, enable the GitHub provider in the ORY Kratos config located at
-`<kratos-directory>/contrib/quickstart/kratos/email-password/.kratos.yml`.
+`<kratos-directory>/contrib/quickstart/kratos/email-password/kratos.yml`.
 
-```yaml title="contrib/quickstart/kratos/email-password/.kratos.yml"
+```yaml title="contrib/quickstart/kratos/email-password/kratos.yml"
 # $ kratos -c path/to/my/kratos/config.yml serve
 selfservice:
   methods:
@@ -365,9 +365,9 @@ local claims = {
 ```
 
 Now, enable the GitLab provider in the ORY Kratos config located at
-`<kratos-directory>/contrib/quickstart/kratos/email-password/.kratos.yml`.
+`<kratos-directory>/contrib/quickstart/kratos/email-password/kratos.yml`.
 
-```yaml title="contrib/quickstart/kratos/email-password/.kratos.yml"
+```yaml title="contrib/quickstart/kratos/email-password/kratos.yml"
 # $ kratos -c path/to/my/kratos/config.yml serve
 selfservice:
   methods:
@@ -438,9 +438,9 @@ local claims = std.extVar('claims');
 ```
 
 Enable the Microsoft provider in the ORY Kratos config located at
-`<kratos-directory>/contrib/quickstart/kratos/email-password/.kratos.yml`.
+`<kratos-directory>/contrib/quickstart/kratos/email-password/kratos.yml`.
 
-```yaml title="contrib/quickstart/kratos/email-password/.kratos.yml"
+```yaml title="contrib/quickstart/kratos/email-password/kratos.yml"
 selfservice:
   methods:
     oidc:
@@ -522,9 +522,9 @@ local claims = {
 ```
 
 Now, enable the Twitch provider in the ORY Kratos config located at
-`<kratos-directory>/contrib/quickstart/kratos/email-password/.kratos.yml`.
+`<kratos-directory>/contrib/quickstart/kratos/email-password/kratos.yml`.
 
-```yaml title="contrib/quickstart/kratos/email-password/.kratos.yml"
+```yaml title="contrib/quickstart/kratos/email-password/kratos.yml"
 # $ kratos -c path/to/my/kratos/config.yml serve
 selfservice:
   methods:
@@ -679,7 +679,7 @@ local claims = {
 ```
 
 Now, enable the Google provider in the ORY Kratos config located at
-`<kratos-directory>/contrib/quickstart/kratos/email-password/.kratos.yml`.
+`<kratos-directory>/contrib/quickstart/kratos/email-password/kratos.yml`.
 
 ```yaml title="contrib/quickstart/kratos/email-password/kratos.yml"
 # $ kratos -c path/to/my/kratos/config.yml serve

--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -461,11 +461,11 @@ chapters of this documentation.
 
 To get a minimal version of ORY Kratos running, you need to set configuration
 values for
-[`identity.default_schema_url`](https://github.com/ory/kratos/blob/v0.5.5-alpha.1/contrib/quickstart/kratos/email-password/.kratos.yml#L67)
+[`identity.default_schema_url`](https://github.com/ory/kratos/blob/v0.5.5-alpha.1/contrib/quickstart/kratos/email-password/kratos.yml#L75)
 and
 [`DSN`](https://github.com/ory/kratos/blob/v0.5.5-alpha.1/quickstart.yml#L42).
 You should also configure
-[`selfservice.flows.*.ui_url`](https://github.com/ory/kratos/blob/v0.5.5-alpha.1/contrib/quickstart/kratos/email-password/.kratos.yml#L40)
+[`selfservice.flows.*.ui_url`](https://github.com/ory/kratos/blob/v0.5.5-alpha.1/contrib/quickstart/kratos/email-password/kratos.yml#L24)
 or else Kratos will use fallback URLs.
 
 :::
@@ -506,7 +506,7 @@ If you want to run the quickstart with MySQL, run the following docker-compose:
 
 If you want to change ports for the SelfService-UI, you need to change them in
 `quickstart.yml` as well as in the
-`contrib/quickstart/kratos/email-password/.kratos.yml` accordingly.
+`contrib/quickstart/kratos/email-password/kratos.yml` accordingly.
 
 Note that you also need to change the ports for flows (error, settings,
 recovery, verification, logout, login, registration).

--- a/docs/versioned_docs/version-v0.3/guides/sign-in-with-github-google-facebook-linkedin.mdx
+++ b/docs/versioned_docs/version-v0.3/guides/sign-in-with-github-google-facebook-linkedin.mdx
@@ -77,9 +77,9 @@ local claims = {
 ```
 
 Now, enable the GitHub provider in the ORY Kratos config located at
-`<kratos-directory>/contrib/quickstart/kratos/email-password/.kratos.yml`.
+`<kratos-directory>/contrib/quickstart/kratos/email-password/kratos.yml`.
 
-```yaml title="contrib/quickstart/kratos/email-password/.kratos.yml"
+```yaml title="contrib/quickstart/kratos/email-password/kratos.yml"
 # $ kratos -c path/to/my/kratos/config.yml serve
 selfservice:
   strategies:
@@ -141,9 +141,9 @@ local claims = std.extVar('claims');
 See https://docs.microsoft.com/en-us/azure/active-directory-b2c/user-flow-disable-email-verification for warnings.
 
 Enable the Microsoft Azure provider in the ORY Kratos config located at
-`<kratos-directory>/contrib/quickstart/kratos/email-password/.kratos.yml`.
+`<kratos-directory>/contrib/quickstart/kratos/email-password/kratos.yml`.
 
-```yaml title="contrib/quickstart/kratos/email-password/.kratos.yml"
+```yaml title="contrib/quickstart/kratos/email-password/kratos.yml"
 selfservice:
   strategies:
     oidc:

--- a/docs/versioned_docs/version-v0.4/guides/sign-in-with-github-google-facebook-linkedin.mdx
+++ b/docs/versioned_docs/version-v0.4/guides/sign-in-with-github-google-facebook-linkedin.mdx
@@ -79,9 +79,9 @@ local claims = {
 ```
 
 Now, enable the GitHub provider in the ORY Kratos config located at
-`<kratos-directory>/contrib/quickstart/kratos/email-password/.kratos.yml`.
+`<kratos-directory>/contrib/quickstart/kratos/email-password/kratos.yml`.
 
-```yaml title="contrib/quickstart/kratos/email-password/.kratos.yml"
+```yaml title="contrib/quickstart/kratos/email-password/kratos.yml"
 # $ kratos -c path/to/my/kratos/config.yml serve
 selfservice:
   strategies:
@@ -150,9 +150,9 @@ local claims = std.extVar('claims');
 ```
 
 Enable the Microsoft provider in the ORY Kratos config located at
-`<kratos-directory>/contrib/quickstart/kratos/email-password/.kratos.yml`.
+`<kratos-directory>/contrib/quickstart/kratos/email-password/kratos.yml`.
 
-```yaml title="contrib/quickstart/kratos/email-password/.kratos.yml"
+```yaml title="contrib/quickstart/kratos/email-password/kratos.yml"
 selfservice:
   strategies:
     oidc:

--- a/docs/versioned_docs/version-v0.4/quickstart.mdx
+++ b/docs/versioned_docs/version-v0.4/quickstart.mdx
@@ -591,11 +591,11 @@ chapters of this documentation.
 
 To get a minimal version of ORY Kratos running, you need to set configuration
 values for
-[`identity.default_schema_url`](https://github.com/ory/kratos/blob/v0.4.6-alpha.1/contrib/quickstart/kratos/email-password/.kratos.yml#L67)
+[`identity.default_schema_url`](https://github.com/ory/kratos/blob/v0.4.6-alpha.1/contrib/quickstart/kratos/email-password/kratos.yml#L67)
 and
 [`DSN`](https://github.com/ory/kratos/blob/v0.4.6-alpha.1/quickstart.yml#L42).
 You should also configure
-[`selfservice.flows.*.ui_url`](https://github.com/ory/kratos/blob/v0.4.6-alpha.1/contrib/quickstart/kratos/email-password/.kratos.yml#L40)
+[`selfservice.flows.*.ui_url`](https://github.com/ory/kratos/blob/v0.4.6-alpha.1/contrib/quickstart/kratos/email-password/kratos.yml#L40)
 or else Kratos will use fallback URLs.
 
 :::

--- a/docs/versioned_docs/version-v0.5/guides/docker.md
+++ b/docs/versioned_docs/version-v0.5/guides/docker.md
@@ -82,7 +82,7 @@ below:
 
 ```dockerfile
 FROM oryd/kratos:latest
-COPY contrib/quickstart/kratos/email-password/.kratos.yml /home/ory
+COPY contrib/quickstart/kratos/email-password/kratos.yml /home/ory
 ```
 
 ### Examples

--- a/docs/versioned_docs/version-v0.5/guides/sign-in-with-github-google-facebook-linkedin.mdx
+++ b/docs/versioned_docs/version-v0.5/guides/sign-in-with-github-google-facebook-linkedin.mdx
@@ -107,9 +107,9 @@ local claims = {
 ```
 
 Now, enable the Discord provider in the ORY Kratos config located at
-`<kratos-directory>/contrib/quickstart/kratos/email-password/.kratos.yml`.
+`<kratos-directory>/contrib/quickstart/kratos/email-password/kratos.yml`.
 
-```yaml title="contrib/quickstart/kratos/email-password/.kratos.yml"
+```yaml title="contrib/quickstart/kratos/email-password/kratos.yml"
 # $ kratos -c path/to/my/kratos/config.yml serve
 selfservice:
   methods:
@@ -198,9 +198,9 @@ local claims = {
 ```
 
 Now, enable the GitHub provider in the ORY Kratos config located at
-`<kratos-directory>/contrib/quickstart/kratos/email-password/.kratos.yml`.
+`<kratos-directory>/contrib/quickstart/kratos/email-password/kratos.yml`.
 
-```yaml title="contrib/quickstart/kratos/email-password/.kratos.yml"
+```yaml title="contrib/quickstart/kratos/email-password/kratos.yml"
 # $ kratos -c path/to/my/kratos/config.yml serve
 selfservice:
   methods:
@@ -269,9 +269,9 @@ local claims = {
 ```
 
 Now, enable the GitLab provider in the ORY Kratos config located at
-`<kratos-directory>/contrib/quickstart/kratos/email-password/.kratos.yml`.
+`<kratos-directory>/contrib/quickstart/kratos/email-password/kratos.yml`.
 
-```yaml title="contrib/quickstart/kratos/email-password/.kratos.yml"
+```yaml title="contrib/quickstart/kratos/email-password/kratos.yml"
 # $ kratos -c path/to/my/kratos/config.yml serve
 selfservice:
   methods:
@@ -342,9 +342,9 @@ local claims = std.extVar('claims');
 ```
 
 Enable the Microsoft provider in the ORY Kratos config located at
-`<kratos-directory>/contrib/quickstart/kratos/email-password/.kratos.yml`.
+`<kratos-directory>/contrib/quickstart/kratos/email-password/kratos.yml`.
 
-```yaml title="contrib/quickstart/kratos/email-password/.kratos.yml"
+```yaml title="contrib/quickstart/kratos/email-password/kratos.yml"
 selfservice:
   methods:
     oidc:
@@ -425,9 +425,9 @@ local claims = {
 ```
 
 Now, enable the Twitch provider in the ORY Kratos config located at
-`<kratos-directory>/contrib/quickstart/kratos/email-password/.kratos.yml`.
+`<kratos-directory>/contrib/quickstart/kratos/email-password/kratos.yml`.
 
-```yaml title="contrib/quickstart/kratos/email-password/.kratos.yml"
+```yaml title="contrib/quickstart/kratos/email-password/kratos.yml"
 # $ kratos -c path/to/my/kratos/config.yml serve
 selfservice:
   methods:

--- a/docs/versioned_docs/version-v0.5/quickstart.mdx
+++ b/docs/versioned_docs/version-v0.5/quickstart.mdx
@@ -458,11 +458,11 @@ chapters of this documentation.
 
 To get a minimal version of ORY Kratos running, you need to set configuration
 values for
-[`identity.default_schema_url`](https://github.com/ory/kratos/blob/v0.5.5-alpha.1/contrib/quickstart/kratos/email-password/.kratos.yml#L67)
+[`identity.default_schema_url`](https://github.com/ory/kratos/blob/v0.5.5-alpha.1/contrib/quickstart/kratos/email-password/kratos.yml#L75)
 and
 [`DSN`](https://github.com/ory/kratos/blob/v0.5.5-alpha.1/quickstart.yml#L42).
 You should also configure
-[`selfservice.flows.*.ui_url`](https://github.com/ory/kratos/blob/v0.5.5-alpha.1/contrib/quickstart/kratos/email-password/.kratos.yml#L40)
+[`selfservice.flows.*.ui_url`](https://github.com/ory/kratos/blob/v0.5.5-alpha.1/contrib/quickstart/kratos/email-password/kratos.yml#L24)
 or else Kratos will use fallback URLs.
 
 :::
@@ -503,7 +503,7 @@ If you want to run the quickstart with MySQL, run the following docker-compose:
 
 If you want to change ports for the SelfService-UI, you need to change them in
 `quickstart.yml` as well as in the
-`contrib/quickstart/kratos/email-password/.kratos.yml` accordingly.
+`contrib/quickstart/kratos/email-password/kratos.yml` accordingly.
 
 Note that you also need to change the ports for flows (error, settings,
 recovery, verification, logout, login, registration).


### PR DESCRIPTION


## Proposed changes
The Quickstart documentation have broken links in then, this fixes them.

The file `.kratos.yml` have changed name to `kratos.yml` and the lines references have changed. 

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. [...]
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).
