### PR TITLE
docs: Remove unnecessary and wrong docker pull commands

### DIFF
--- a/docs/docs/guides/zero-trust-iap-proxy-identity-access-proxy.mdx
+++ b/docs/docs/guides/zero-trust-iap-proxy-identity-access-proxy.mdx
@@ -36,8 +36,6 @@ git clone https://github.com/ory/kratos.git
 cd kratos
 git checkout v0.5.5-alpha.1
 
-docker pull oryd/kratos:latest-sqlite
-docker pull oryd/kratos-selfservice-ui-node:latest
 ```
 
 Next, run the quickstart and add the ORY Oathkeeper config:

--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -129,8 +129,6 @@ git clone https://github.com/ory/kratos.git
 cd kratos
 git checkout v0.5.5-alpha.1
 
-docker pull oryd/kratos:latest-sqlite
-docker pull oryd/kratos-selfservice-ui-node:latest
 docker-compose -f quickstart.yml -f quickstart-standalone.yml up --build --force-recreate
 # If you have SELinux, run:
 docker-compose -f quickstart.yml -f quickstart-selinux.yml -f quickstart-standalone.yml up --build --force-recreate

--- a/docs/versioned_docs/version-v0.1/quickstart.mdx
+++ b/docs/versioned_docs/version-v0.1/quickstart.mdx
@@ -87,8 +87,6 @@ git checkout v0.1.1-alpha.1
 make quickstart
 
 # or if you don't have make installed:
-docker pull oryd/kratos:latest-sqlite
-docker pull oryd/kratos-selfservice-ui-node:latest
 docker-compose -f quickstart.yml up --build --force-recreate
 ```
 

--- a/docs/versioned_docs/version-v0.2/guides/zero-trust-iap-proxy-identity-access-proxy.md
+++ b/docs/versioned_docs/version-v0.2/guides/zero-trust-iap-proxy-identity-access-proxy.md
@@ -38,8 +38,6 @@ git clone https://github.com/ory/kratos.git
 cd kratos
 git checkout v0.2.1-alpha.1
 
-docker pull oryd/kratos:latest-sqlite
-docker pull oryd/kratos-selfservice-ui-node:latest
 ```
 
 Next, run the quickstart and add the ORY Oathkeeper config:

--- a/docs/versioned_docs/version-v0.2/quickstart.mdx
+++ b/docs/versioned_docs/version-v0.2/quickstart.mdx
@@ -161,8 +161,6 @@ git checkout v0.2.1-alpha.1
 make quickstart
 
 # or if you don't have make installed:
-docker pull oryd/kratos:latest-sqlite
-docker pull oryd/kratos-selfservice-ui-node:latest
 docker-compose -f quickstart.yml -f quickstart-standalone.yml up --build --force-recreate
 ```
 

--- a/docs/versioned_docs/version-v0.3/guides/zero-trust-iap-proxy-identity-access-proxy.md
+++ b/docs/versioned_docs/version-v0.3/guides/zero-trust-iap-proxy-identity-access-proxy.md
@@ -38,8 +38,6 @@ git clone https://github.com/ory/kratos.git
 cd kratos
 git checkout v0.3.0-alpha.1
 
-docker pull oryd/kratos:latest-sqlite
-docker pull oryd/kratos-selfservice-ui-node:latest
 ```
 
 Next, run the quickstart and add the ORY Oathkeeper config:

--- a/docs/versioned_docs/version-v0.3/quickstart.mdx
+++ b/docs/versioned_docs/version-v0.3/quickstart.mdx
@@ -161,8 +161,6 @@ git checkout v0.3.0-alpha.1
 make quickstart
 
 # or if you don't have make installed:
-docker pull oryd/kratos:latest-sqlite
-docker pull oryd/kratos-selfservice-ui-node:latest
 docker-compose -f quickstart.yml -f quickstart-standalone.yml up --build --force-recreate
 ```
 

--- a/docs/versioned_docs/version-v0.4/guides/zero-trust-iap-proxy-identity-access-proxy.mdx
+++ b/docs/versioned_docs/version-v0.4/guides/zero-trust-iap-proxy-identity-access-proxy.mdx
@@ -36,8 +36,6 @@ git clone https://github.com/ory/kratos.git
 cd kratos
 git checkout v0.4.6-alpha.1
 
-docker pull oryd/kratos:latest-sqlite
-docker pull oryd/kratos-selfservice-ui-node:latest
 ```
 
 Next, run the quickstart and add the ORY Oathkeeper config:

--- a/docs/versioned_docs/version-v0.4/quickstart.mdx
+++ b/docs/versioned_docs/version-v0.4/quickstart.mdx
@@ -177,8 +177,6 @@ git clone https://github.com/ory/kratos.git
 cd kratos
 git checkout v0.4.6-alpha.1
 
-docker pull oryd/kratos:latest-sqlite
-docker pull oryd/kratos-selfservice-ui-node:latest
 docker-compose -f quickstart.yml -f quickstart-standalone.yml up --build --force-recreate
 ```
 

--- a/docs/versioned_docs/version-v0.5/guides/zero-trust-iap-proxy-identity-access-proxy.mdx
+++ b/docs/versioned_docs/version-v0.5/guides/zero-trust-iap-proxy-identity-access-proxy.mdx
@@ -36,8 +36,6 @@ git clone https://github.com/ory/kratos.git
 cd kratos
 git checkout v0.5.5-alpha.1
 
-docker pull oryd/kratos:latest-sqlite
-docker pull oryd/kratos-selfservice-ui-node:latest
 ```
 
 Next, run the quickstart and add the ORY Oathkeeper config:

--- a/docs/versioned_docs/version-v0.5/quickstart.mdx
+++ b/docs/versioned_docs/version-v0.5/quickstart.mdx
@@ -129,8 +129,6 @@ git clone https://github.com/ory/kratos.git
 cd kratos
 git checkout v0.5.5-alpha.1
 
-docker pull oryd/kratos:latest-sqlite
-docker pull oryd/kratos-selfservice-ui-node:latest
 docker-compose -f quickstart.yml -f quickstart-standalone.yml up --build --force-recreate
 # If you have SELinux, run:
 docker-compose -f quickstart.yml -f quickstart-selinux.yml -f quickstart-standalone.yml up --build --force-recreate


### PR DESCRIPTION
The `docker pull` command pulls the wrong images as they are not used in the quickstart (uses e.g. oryd/kratos:v0.5.5-alpha.1.pre.1-sqlite tag). The quickstart still works, even though pulling the wrong images, as the docker-compose command itself automatically pulls the images from docker. Therefore the `docker pull` command can be omitted.