### PR TITLE
fix: marking whoami auhorization parameter as 'in header'

### DIFF
--- a/session/handler.go
+++ b/session/handler.go
@@ -125,7 +125,7 @@ type whoamiParameters struct {
 	// in: header
 	Cookie string `json:"Cookie"`
 
-	// in: authorization
+	// in: header
 	Authorization string `json:"Authorization"`
 }
 

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -1557,9 +1557,8 @@
           },
           {
             "type": "string",
-            "description": "in: authorization",
             "name": "Authorization",
-            "in": "query"
+            "in": "header"
           }
         ],
         "responses": {


### PR DESCRIPTION
## Related issue

I believe this resolves #1215; for the `whoami` endpoint, the Authorization string was included as 'query' parameter in the OpenAPI spec as the used 'in' location was not valid. As a result, generated API clients pass the authorization to Kratos via a query param, which is not supported.

## Proposed changes

PR includes a small patch to change the location from 'query' to 'header', which should let users generate a working API client from the spec.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

Regenerating the specification via `make` resulted in a number of unrelated changes for me, which I've not included in this PR for brevity.