### PR TITLE
docs: fix self-service code flows labels

### DIFF
--- a/docs/docs/self-service/flows/code/login/index.js
+++ b/docs/docs/self-service/flows/code/login/index.js
@@ -15,12 +15,12 @@ export const initBrowserFlow = {
     code: require('raw-loader!./samples/browser/init.jsx.txt').default
   },
   node: {
-    label: 'Angular',
+    label: 'ExpressJS',
     language: 'html',
     code: require('raw-loader!./samples/browser/init.js.txt').default
   },
   angular: {
-    label: 'ExpressJS',
+    label: 'Angular',
     language: 'js',
     code: require('raw-loader!./samples/browser/init.ng.html.txt').default
   }

--- a/docs/docs/self-service/flows/code/recovery/index.js
+++ b/docs/docs/self-service/flows/code/recovery/index.js
@@ -33,12 +33,12 @@ export const initBrowserFlow = {
     code: require('raw-loader!./samples/browser/init.jsx.txt').default
   },
   node: {
-    label: 'Angular',
+    label: 'ExpressJS',
     language: 'html',
     code: require('raw-loader!./samples/browser/init.js.txt').default
   },
   angular: {
-    label: 'ExpressJS',
+    label: 'Angular',
     language: 'js',
     code: require('raw-loader!./samples/browser/init.ng.html.txt').default
   }

--- a/docs/docs/self-service/flows/code/registration/index.js
+++ b/docs/docs/self-service/flows/code/registration/index.js
@@ -33,12 +33,12 @@ export const initBrowserFlow = {
     code: require('raw-loader!./samples/browser/init.jsx.txt').default
   },
   node: {
-    label: 'Angular',
+    label: 'ExpressJS',
     language: 'html',
     code: require('raw-loader!./samples/browser/init.js.txt').default
   },
   angular: {
-    label: 'ExpressJS',
+    label: 'Angular',
     language: 'js',
     code: require('raw-loader!./samples/browser/init.ng.html.txt').default
   }

--- a/docs/docs/self-service/flows/code/settings/index.js
+++ b/docs/docs/self-service/flows/code/settings/index.js
@@ -36,12 +36,12 @@ export const initBrowserFlow = {
     code: require('raw-loader!./samples/browser/init.jsx.txt').default
   },
   node: {
-    label: 'Angular',
+    label: 'ExpressJS',
     language: 'html',
     code: require('raw-loader!./samples/browser/init.js.txt').default
   },
   angular: {
-    label: 'ExpressJS',
+    label: 'Angular',
     language: 'js',
     code: require('raw-loader!./samples/browser/init.ng.html.txt').default
   }

--- a/docs/docs/self-service/flows/code/verification/index.js
+++ b/docs/docs/self-service/flows/code/verification/index.js
@@ -33,12 +33,12 @@ export const initBrowserFlow = {
     code: require('raw-loader!./samples/browser/init.jsx.txt').default
   },
   node: {
-    label: 'Angular',
+    label: 'ExpressJS',
     language: 'html',
     code: require('raw-loader!./samples/browser/init.js.txt').default
   },
   angular: {
-    label: 'ExpressJS',
+    label: 'Angular',
     language: 'js',
     code: require('raw-loader!./samples/browser/init.ng.html.txt').default
   }

--- a/docs/versioned_docs/version-v0.5/self-service/flows/code/login/index.js
+++ b/docs/versioned_docs/version-v0.5/self-service/flows/code/login/index.js
@@ -15,12 +15,12 @@ export const initBrowserFlow = {
     code: require('raw-loader!./samples/browser/init.jsx.txt').default
   },
   node: {
-    label: 'Angular',
+    label: 'ExpressJS',
     language: 'html',
     code: require('raw-loader!./samples/browser/init.js.txt').default
   },
   angular: {
-    label: 'ExpressJS',
+    label: 'Angular',
     language: 'js',
     code: require('raw-loader!./samples/browser/init.ng.html.txt').default
   }

--- a/docs/versioned_docs/version-v0.5/self-service/flows/code/recovery/index.js
+++ b/docs/versioned_docs/version-v0.5/self-service/flows/code/recovery/index.js
@@ -33,12 +33,12 @@ export const initBrowserFlow = {
     code: require('raw-loader!./samples/browser/init.jsx.txt').default
   },
   node: {
-    label: 'Angular',
+    label: 'ExpressJS',
     language: 'html',
     code: require('raw-loader!./samples/browser/init.js.txt').default
   },
   angular: {
-    label: 'ExpressJS',
+    label: 'Angular',
     language: 'js',
     code: require('raw-loader!./samples/browser/init.ng.html.txt').default
   }

--- a/docs/versioned_docs/version-v0.5/self-service/flows/code/registration/index.js
+++ b/docs/versioned_docs/version-v0.5/self-service/flows/code/registration/index.js
@@ -33,12 +33,12 @@ export const initBrowserFlow = {
     code: require('raw-loader!./samples/browser/init.jsx.txt').default
   },
   node: {
-    label: 'Angular',
+    label: 'ExpressJS',
     language: 'html',
     code: require('raw-loader!./samples/browser/init.js.txt').default
   },
   angular: {
-    label: 'ExpressJS',
+    label: 'Angular',
     language: 'js',
     code: require('raw-loader!./samples/browser/init.ng.html.txt').default
   }

--- a/docs/versioned_docs/version-v0.5/self-service/flows/code/settings/index.js
+++ b/docs/versioned_docs/version-v0.5/self-service/flows/code/settings/index.js
@@ -36,12 +36,12 @@ export const initBrowserFlow = {
     code: require('raw-loader!./samples/browser/init.jsx.txt').default
   },
   node: {
-    label: 'Angular',
+    label: 'ExpressJS',
     language: 'html',
     code: require('raw-loader!./samples/browser/init.js.txt').default
   },
   angular: {
-    label: 'ExpressJS',
+    label: 'Angular',
     language: 'js',
     code: require('raw-loader!./samples/browser/init.ng.html.txt').default
   }

--- a/docs/versioned_docs/version-v0.5/self-service/flows/code/verification/index.js
+++ b/docs/versioned_docs/version-v0.5/self-service/flows/code/verification/index.js
@@ -33,12 +33,12 @@ export const initBrowserFlow = {
     code: require('raw-loader!./samples/browser/init.jsx.txt').default
   },
   node: {
-    label: 'Angular',
+    label: 'ExpressJS',
     language: 'html',
     code: require('raw-loader!./samples/browser/init.js.txt').default
   },
   angular: {
-    label: 'ExpressJS',
+    label: 'Angular',
     language: 'js',
     code: require('raw-loader!./samples/browser/init.ng.html.txt').default
   }


### PR DESCRIPTION
Fix tab labels in self-service code flows documentation.

The labels `Angular` and `ExpressJS` are interchanged: [Example in docs](https://www.ory.sh/kratos/docs/self-service/#initialization-and-redirect-to-ui)

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
