### PR TITLE
fix: replace broken dependency in test

### DIFF
--- a/courier/template/load_template_test.go
+++ b/courier/template/load_template_test.go
@@ -1,12 +1,10 @@
 package template
 
 import (
-	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/shurcooL/go/ioutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -27,7 +25,8 @@ func TestLoadTextTemplate(t *testing.T) {
 
 	t.Run("method=cache works", func(t *testing.T) {
 		fp := filepath.Join(os.TempDir(), x.NewUUID().String()) + ".body.gotmpl"
-		require.NoError(t, ioutil.WriteFile(fp, bytes.NewBufferString("cached stub body")))
+
+		require.NoError(t, os.WriteFile(fp, []byte("cached stub body"), 0666))
 		assert.Contains(t, executeTemplate(t, fp), "cached stub body")
 
 		require.NoError(t, os.RemoveAll(fp))


### PR DESCRIPTION
## Proposed changes

Dependency "github.com/shurcooL/go/ioutil" no longer exists. It's replaced with "os", in this case.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).
