### PR TITLE
feat: Include Credentials Metadata in admin api.

### DIFF
--- a/identity/credentials.go
+++ b/identity/credentials.go
@@ -42,7 +42,7 @@ type Credentials struct {
 
 	// Config contains the concrete credential payload. This might contain the bcrypt-hashed password, or the email
 	// for passwordless authentication.
-	Config sqlxx.JSONRawMessage `json:"config" db:"config"`
+	Config sqlxx.JSONRawMessage `json:"config,omitempty" db:"config"`
 
 	IdentityID uuid.UUID `json:"-" faker:"-" db:"identity_id"`
 

--- a/identity/identity_test.go
+++ b/identity/identity_test.go
@@ -1,6 +1,9 @@
 package identity
 
 import (
+	"encoding/json"
+	"github.com/gofrs/uuid"
+	"github.com/ory/x/sqlxx"
 	"testing"
 
 	"github.com/ory/kratos/driver/config"
@@ -14,4 +17,80 @@ func TestNewIdentity(t *testing.T) {
 	// assert.NotEmpty(t, i.Metadata)
 	assert.NotEmpty(t, i.Traits)
 	assert.NotNil(t, i.Credentials)
+}
+
+func TestMarshalExcludesCredentials(t *testing.T) {
+	i := NewIdentity(config.DefaultIdentityTraitsSchemaID)
+	credentials := map[CredentialsType]Credentials{
+		CredentialsTypePassword: Credentials{
+			ID: uuid.UUID{},
+		},
+	}
+
+	i.Credentials = credentials
+	jsonBytes, err := json.Marshal(i)
+	assert.Nil(t, err)
+	var jsonMap = map[string]json.RawMessage{}
+	err = json.Unmarshal(jsonBytes, &jsonMap)
+	assert.Nil(t, err)
+	assert.Nil(t, jsonMap["credentials"])
+	assert.Equal(t, credentials, i.Credentials, "Original credentials should not be touched by marshalling")
+}
+
+func TestMarshalExcludesCredentialsByReference(t *testing.T) {
+	i := NewIdentity(config.DefaultIdentityTraitsSchemaID)
+	credentials := map[CredentialsType]Credentials{
+		CredentialsTypePassword: Credentials{
+			Type: CredentialsTypePassword,
+		},
+	}
+	i.Credentials = credentials
+	jsonBytes, err := json.Marshal(&i)
+	assert.Nil(t, err)
+	var jsonMap = map[string]json.RawMessage{}
+	err = json.Unmarshal(jsonBytes, &jsonMap)
+	assert.Nil(t, err)
+	assert.Nil(t, jsonMap["credentials"])
+	assert.Equal(t, credentials, i.Credentials, "Original credentials should not be touched by marshalling")
+}
+
+func TestUnMarshallIgnoresCredentials(t *testing.T) {
+	jsonText := "{\"id\":\"3234ad11-49c6-49e2-bfac-537f3e06cd85\",\"schema_id\":\"default\",\"schema_url\":\"\",\"traits\":{}, \"credentials\" : {\"password\":{\"type\":\"\",\"identifiers\":null,\"config\":null,\"updatedAt\":\"0001-01-01T00:00:00Z\"}}}"
+	var i Identity
+	err := json.Unmarshal([]byte(jsonText), &i)
+	assert.Nil(t, err)
+
+	assert.Nil(t, i.Credentials)
+	assert.Equal(t, "3234ad11-49c6-49e2-bfac-537f3e06cd85", i.ID.String())
+}
+
+func TestMarshalIdentityWithCredentialsWhenCredentialsNil(t *testing.T) {
+	i := NewIdentity(config.DefaultIdentityTraitsSchemaID)
+	i.Credentials = nil
+	jsonBytes, err := json.Marshal(IdentityWithCredentialsMetadataInJSON(*i))
+	assert.Nil(t, err)
+	var jsonMap = map[string]json.RawMessage{}
+	err = json.Unmarshal(jsonBytes, &jsonMap)
+	assert.Nil(t, err)
+	assert.Nil(t, jsonMap["credentials"])
+}
+
+func TestMarshalIdentityWithCredentials(t *testing.T) {
+	i := NewIdentity(config.DefaultIdentityTraitsSchemaID)
+	credentials := map[CredentialsType]Credentials{
+		CredentialsTypePassword: Credentials{
+			Type:   CredentialsTypePassword,
+			Config: sqlxx.JSONRawMessage("{\"some\" : \"secet\"}"),
+		},
+	}
+	i.Credentials = credentials
+
+	jsonBytes, err := json.Marshal(IdentityWithCredentialsMetadataInJSON(*i))
+	assert.Nil(t, err)
+	var jsonMap = map[string]json.RawMessage{}
+	err = json.Unmarshal(jsonBytes, &jsonMap)
+	assert.Nil(t, err)
+	assert.NotNil(t, jsonMap["credentials"])
+	assert.JSONEq(t, "{\"password\":{\"type\":\"password\",\"identifiers\":null,\"updatedAt\":\"0001-01-01T00:00:00Z\"}}", string(jsonMap["credentials"]))
+	assert.Equal(t, credentials, i.Credentials, "Original credentials should not be touched by marshalling")
 }

--- a/identity/identity_test.go
+++ b/identity/identity_test.go
@@ -2,9 +2,11 @@ package identity
 
 import (
 	"encoding/json"
-	"github.com/gofrs/uuid"
-	"github.com/ory/x/sqlxx"
 	"testing"
+
+	"github.com/gofrs/uuid"
+
+	"github.com/ory/x/sqlxx"
 
 	"github.com/ory/kratos/driver/config"
 
@@ -80,7 +82,7 @@ func TestMarshalIdentityWithCredentials(t *testing.T) {
 	credentials := map[CredentialsType]Credentials{
 		CredentialsTypePassword: Credentials{
 			Type:   CredentialsTypePassword,
-			Config: sqlxx.JSONRawMessage("{\"some\" : \"secet\"}"),
+			Config: sqlxx.JSONRawMessage("{\"some\" : \"secret\"}"),
 		},
 	}
 	i.Credentials = credentials
@@ -91,6 +93,6 @@ func TestMarshalIdentityWithCredentials(t *testing.T) {
 	err = json.Unmarshal(jsonBytes, &jsonMap)
 	assert.Nil(t, err)
 	assert.NotNil(t, jsonMap["credentials"])
-	assert.JSONEq(t, "{\"password\":{\"type\":\"password\",\"identifiers\":null,\"updatedAt\":\"0001-01-01T00:00:00Z\"}}", string(jsonMap["credentials"]))
+	assert.JSONEq(t, "{\"password\":{\"type\":\"password\",\"identifiers\":null,\"updated_at\":\"0001-01-01T00:00:00Z\",\"created_at\":\"0001-01-01T00:00:00Z\"}}", string(jsonMap["credentials"]))
 	assert.Equal(t, credentials, i.Credentials, "Original credentials should not be touched by marshalling")
 }

--- a/internal/httpclient/api/openapi.yaml
+++ b/internal/httpclient/api/openapi.yaml
@@ -2465,6 +2465,15 @@ components:
           via: via
         traits: ""
         updated_at: 2000-01-23T04:56:07.000+00:00
+        credentials:
+          key:
+            updated_at: 2000-01-23T04:56:07.000+00:00
+            identifiers:
+            - identifiers
+            - identifiers
+            created_at: 2000-01-23T04:56:07.000+00:00
+            type: type
+            config: '{}'
         verifiable_addresses:
         - updated_at: 2014-01-01T23:28:56.782Z
           verified_at: 2000-01-23T04:56:07.000+00:00
@@ -2491,6 +2500,12 @@ components:
           description: CreatedAt is a helper struct field for gobuffalo.pop.
           format: date-time
           type: string
+        credentials:
+          additionalProperties:
+            $ref: '#/components/schemas/identityCredentials'
+          description: Credentials represents all credentials that can be used for
+            authenticating this identity.
+          type: object
         id:
           format: uuid4
           type: string
@@ -2536,6 +2551,14 @@ components:
       type: object
     identityCredentials:
       description: Credentials represents a specific credential type
+      example:
+        updated_at: 2000-01-23T04:56:07.000+00:00
+        identifiers:
+        - identifiers
+        - identifiers
+        created_at: 2000-01-23T04:56:07.000+00:00
+        type: type
+        config: '{}'
       properties:
         config:
           title: JSONRawMessage represents a json.RawMessage that works well with
@@ -2719,6 +2742,15 @@ components:
               via: via
             traits: ""
             updated_at: 2000-01-23T04:56:07.000+00:00
+            credentials:
+              key:
+                updated_at: 2000-01-23T04:56:07.000+00:00
+                identifiers:
+                - identifiers
+                - identifiers
+                created_at: 2000-01-23T04:56:07.000+00:00
+                type: type
+                config: '{}'
             verifiable_addresses:
             - updated_at: 2014-01-01T23:28:56.782Z
               verified_at: 2000-01-23T04:56:07.000+00:00
@@ -2994,6 +3026,15 @@ components:
             via: via
           traits: ""
           updated_at: 2000-01-23T04:56:07.000+00:00
+          credentials:
+            key:
+              updated_at: 2000-01-23T04:56:07.000+00:00
+              identifiers:
+              - identifiers
+              - identifiers
+              created_at: 2000-01-23T04:56:07.000+00:00
+              type: type
+              config: '{}'
           verifiable_addresses:
           - updated_at: 2014-01-01T23:28:56.782Z
             verified_at: 2000-01-23T04:56:07.000+00:00
@@ -3031,6 +3072,15 @@ components:
               via: via
             traits: ""
             updated_at: 2000-01-23T04:56:07.000+00:00
+            credentials:
+              key:
+                updated_at: 2000-01-23T04:56:07.000+00:00
+                identifiers:
+                - identifiers
+                - identifiers
+                created_at: 2000-01-23T04:56:07.000+00:00
+                type: type
+                config: '{}'
             verifiable_addresses:
             - updated_at: 2014-01-01T23:28:56.782Z
               verified_at: 2000-01-23T04:56:07.000+00:00
@@ -3135,6 +3185,15 @@ components:
             via: via
           traits: ""
           updated_at: 2000-01-23T04:56:07.000+00:00
+          credentials:
+            key:
+              updated_at: 2000-01-23T04:56:07.000+00:00
+              identifiers:
+              - identifiers
+              - identifiers
+              created_at: 2000-01-23T04:56:07.000+00:00
+              type: type
+              config: '{}'
           verifiable_addresses:
           - updated_at: 2014-01-01T23:28:56.782Z
             verified_at: 2000-01-23T04:56:07.000+00:00
@@ -3253,6 +3312,15 @@ components:
             via: via
           traits: ""
           updated_at: 2000-01-23T04:56:07.000+00:00
+          credentials:
+            key:
+              updated_at: 2000-01-23T04:56:07.000+00:00
+              identifiers:
+              - identifiers
+              - identifiers
+              created_at: 2000-01-23T04:56:07.000+00:00
+              type: type
+              config: '{}'
           verifiable_addresses:
           - updated_at: 2014-01-01T23:28:56.782Z
             verified_at: 2000-01-23T04:56:07.000+00:00
@@ -3363,6 +3431,15 @@ components:
             via: via
           traits: ""
           updated_at: 2000-01-23T04:56:07.000+00:00
+          credentials:
+            key:
+              updated_at: 2000-01-23T04:56:07.000+00:00
+              identifiers:
+              - identifiers
+              - identifiers
+              created_at: 2000-01-23T04:56:07.000+00:00
+              type: type
+              config: '{}'
           verifiable_addresses:
           - updated_at: 2014-01-01T23:28:56.782Z
             verified_at: 2000-01-23T04:56:07.000+00:00
@@ -3447,6 +3524,15 @@ components:
               via: via
             traits: ""
             updated_at: 2000-01-23T04:56:07.000+00:00
+            credentials:
+              key:
+                updated_at: 2000-01-23T04:56:07.000+00:00
+                identifiers:
+                - identifiers
+                - identifiers
+                created_at: 2000-01-23T04:56:07.000+00:00
+                type: type
+                config: '{}'
             verifiable_addresses:
             - updated_at: 2014-01-01T23:28:56.782Z
               verified_at: 2000-01-23T04:56:07.000+00:00

--- a/internal/httpclient/docs/Identity.md
+++ b/internal/httpclient/docs/Identity.md
@@ -5,6 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **CreatedAt** | Pointer to **time.Time** | CreatedAt is a helper struct field for gobuffalo.pop. | [optional] 
+**Credentials** | Pointer to [**map[string]IdentityCredentials**](IdentityCredentials.md) | Credentials represents all credentials that can be used for authenticating this identity. | [optional] 
 **Id** | **string** |  | 
 **RecoveryAddresses** | Pointer to [**[]RecoveryAddress**](RecoveryAddress.md) | RecoveryAddresses contains all the addresses that can be used to recover an identity. | [optional] 
 **SchemaId** | **string** | SchemaID is the ID of the JSON Schema to be used for validating the identity&#39;s traits. | 
@@ -56,6 +57,31 @@ SetCreatedAt sets CreatedAt field to given value.
 `func (o *Identity) HasCreatedAt() bool`
 
 HasCreatedAt returns a boolean if a field has been set.
+
+### GetCredentials
+
+`func (o *Identity) GetCredentials() map[string]IdentityCredentials`
+
+GetCredentials returns the Credentials field if non-nil, zero value otherwise.
+
+### GetCredentialsOk
+
+`func (o *Identity) GetCredentialsOk() (*map[string]IdentityCredentials, bool)`
+
+GetCredentialsOk returns a tuple with the Credentials field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetCredentials
+
+`func (o *Identity) SetCredentials(v map[string]IdentityCredentials)`
+
+SetCredentials sets Credentials field to given value.
+
+### HasCredentials
+
+`func (o *Identity) HasCredentials() bool`
+
+HasCredentials returns a boolean if a field has been set.
 
 ### GetId
 

--- a/internal/httpclient/model_identity.go
+++ b/internal/httpclient/model_identity.go
@@ -20,7 +20,9 @@ import (
 type Identity struct {
 	// CreatedAt is a helper struct field for gobuffalo.pop.
 	CreatedAt *time.Time `json:"created_at,omitempty"`
-	Id        string     `json:"id"`
+	// Credentials represents all credentials that can be used for authenticating this identity.
+	Credentials *map[string]IdentityCredentials `json:"credentials,omitempty"`
+	Id          string                          `json:"id"`
 	// RecoveryAddresses contains all the addresses that can be used to recover an identity.
 	RecoveryAddresses []RecoveryAddress `json:"recovery_addresses,omitempty"`
 	// SchemaID is the ID of the JSON Schema to be used for validating the identity's traits.
@@ -86,6 +88,38 @@ func (o *Identity) HasCreatedAt() bool {
 // SetCreatedAt gets a reference to the given time.Time and assigns it to the CreatedAt field.
 func (o *Identity) SetCreatedAt(v time.Time) {
 	o.CreatedAt = &v
+}
+
+// GetCredentials returns the Credentials field value if set, zero value otherwise.
+func (o *Identity) GetCredentials() map[string]IdentityCredentials {
+	if o == nil || o.Credentials == nil {
+		var ret map[string]IdentityCredentials
+		return ret
+	}
+	return *o.Credentials
+}
+
+// GetCredentialsOk returns a tuple with the Credentials field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Identity) GetCredentialsOk() (*map[string]IdentityCredentials, bool) {
+	if o == nil || o.Credentials == nil {
+		return nil, false
+	}
+	return o.Credentials, true
+}
+
+// HasCredentials returns a boolean if a field has been set.
+func (o *Identity) HasCredentials() bool {
+	if o != nil && o.Credentials != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetCredentials gets a reference to the given map[string]IdentityCredentials and assigns it to the Credentials field.
+func (o *Identity) SetCredentials(v map[string]IdentityCredentials) {
+	o.Credentials = &v
 }
 
 // GetId returns the Id field value
@@ -286,6 +320,9 @@ func (o Identity) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if o.CreatedAt != nil {
 		toSerialize["created_at"] = o.CreatedAt
+	}
+	if o.Credentials != nil {
+		toSerialize["credentials"] = o.Credentials
 	}
 	if true {
 		toSerialize["id"] = o.Id

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -1022,6 +1022,13 @@
             "format": "date-time",
             "type": "string"
           },
+          "credentials": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/identityCredentials"
+            },
+            "description": "Credentials represents all credentials that can be used for authenticating this identity.",
+            "type": "object"
+          },
           "id": {
             "$ref": "#/components/schemas/UUID"
           },

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -2623,6 +2623,13 @@
           "type": "string",
           "format": "date-time"
         },
+        "credentials": {
+          "description": "Credentials represents all credentials that can be used for authenticating this identity.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/identityCredentials"
+          }
+        },
         "id": {
           "$ref": "#/definitions/UUID"
         },


### PR DESCRIPTION
## Related issue
#820


## Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

This is a simple attempt to add the information of the last changed date to the admin api for "get identity".
I'd like to see what you think about it.