### PR TITLE
WIP: Login method api

### DIFF
--- a/driver/registry_default.go
+++ b/driver/registry_default.go
@@ -137,6 +137,7 @@ func (m *RegistryDefault) RegisterPublicRoutes(ctx context.Context, router *x.Ro
 	m.RegistrationHandler().RegisterPublicRoutes(router)
 	m.LogoutHandler().RegisterPublicRoutes(router)
 	m.SettingsHandler().RegisterPublicRoutes(router)
+	m.IdentityHandler().RegisterPublicRoutes(router)
 	m.AllLoginStrategies().RegisterPublicRoutes(router)
 	m.AllSettingsStrategies().RegisterPublicRoutes(router)
 	m.AllRegistrationStrategies().RegisterPublicRoutes(router)

--- a/driver/registry_default.go
+++ b/driver/registry_default.go
@@ -137,7 +137,6 @@ func (m *RegistryDefault) RegisterPublicRoutes(ctx context.Context, router *x.Ro
 	m.RegistrationHandler().RegisterPublicRoutes(router)
 	m.LogoutHandler().RegisterPublicRoutes(router)
 	m.SettingsHandler().RegisterPublicRoutes(router)
-	m.IdentityHandler().RegisterPublicRoutes(router)
 	m.AllLoginStrategies().RegisterPublicRoutes(router)
 	m.AllSettingsStrategies().RegisterPublicRoutes(router)
 	m.AllRegistrationStrategies().RegisterPublicRoutes(router)

--- a/identity/handler.go
+++ b/identity/handler.go
@@ -1,12 +1,13 @@
 package identity
 
 import (
-	"bytes"
+	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
-	"strings"
 
-	"github.com/ory/herodot"
+	"github.com/tidwall/gjson"
+
 	"github.com/ory/kratos/driver/config"
 
 	"github.com/julienschmidt/httprouter"
@@ -16,10 +17,11 @@ import (
 	"github.com/ory/x/urlx"
 
 	"github.com/ory/kratos/x"
+	"github.com/ory/x/sqlcon"
 )
 
 const RouteBase = "/identities"
-const RouteMethod = "/method/:id"
+const RouteKnownCredentials = "/credentials/known"
 
 type (
 	handlerDependencies interface {
@@ -49,17 +51,62 @@ func (h *Handler) RegisterAdminRoutes(admin *x.RouterAdmin) {
 	admin.POST(RouteBase, h.create)
 	admin.PUT(RouteBase+"/:id", h.update)
 
-	admin.GET(RouteMethod, h.method)
+	admin.POST(RouteKnownCredentials, h.knownCredentials)
 }
 
-type methodResponse struct {
+// A single login method and provider.
+type knownCredentialsMethod struct {
 	Method   string `json:"method"`
 	Provider string `json:"provider,omitempty"`
 }
 
-// swagger:route GET /method admin getMethod
+// Response object for knownCredentials
+type knownCredentialsResponse struct {
+	Found   bool                     `json:"found"`
+	Methods []knownCredentialsMethod `json:"methods,omitempty"`
+}
+
+// Request object for knownCredentials
+type knownCredentialsRequest struct {
+	Identifier string `json:"identifier"`
+	Method     string `json:"method"`
+}
+
+func (h *Handler) knownCredentialsOIDC(ctx context.Context, id string) (bool, []string, error) {
+	address, err := h.r.PrivilegedIdentityPool().FindVerifiableAddressByValue(ctx, VerifiableAddressTypeEmail, id)
+	if err != nil {
+		if errors.Is(err, sqlcon.ErrNoRows) {
+			return false, nil, nil
+		}
+		return false, nil, err
+	}
+
+	identity, err := h.r.PrivilegedIdentityPool().GetIdentityConfidential(ctx, address.IdentityID)
+	if err != nil {
+		if errors.Is(err, sqlcon.ErrNoRows) {
+			return false, nil, nil
+		}
+		return false, nil, err
+	}
+
+	creds, ok := identity.GetCredentials(CredentialsTypeOIDC)
+	if !ok {
+		return false, []string{}, nil
+	}
+
+	providers := gjson.Get(string(creds.Config), "providers")
+	result := []string{}
+	for _, provider := range providers.Array() {
+		result = append(result, provider.Get("provider").String())
+	}
+
+	return true, result, nil
+}
+
+// swagger:route GET /credentials/known admin knownCredentialsRequest
 //
-// Get login method for a previously registered email address or username
+// Check if a specified identifier has been previously registered with the specified method, or optionally search
+// for the method and provider if a method is not specified.
 //
 //     Produces:
 //     - application/json
@@ -67,71 +114,52 @@ type methodResponse struct {
 //     Schemes: http, https
 //
 //     Responses:
-//       200: loginMethod
+//       200: knownCredentialsResponse
 //       500: genericError
-func (h *Handler) method(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+func (h *Handler) knownCredentials(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 
-	// if the credentials can be looked up directly by email address then they're type password
-	_, _, err := h.r.PrivilegedIdentityPool().FindByCredentialsIdentifier(r.Context(), CredentialsTypePassword, ps.ByName("id"))
-	if err != nil {
-		// otherwise if they're OIDC credentials we have to find them by the verifiable address and then see if they are indeed OIDC
-		address, err := h.r.PrivilegedIdentityPool().FindVerifiableAddressByValue(r.Context(), VerifiableAddressTypeEmail, ps.ByName("id"))
-
-		if err != nil {
-			h.r.Writer().WriteError(w, r, err)
-			return
-		}
-
-		id, err := h.r.PrivilegedIdentityPool().GetIdentityConfidential(r.Context(), address.IdentityID)
-		if err != nil {
-			h.r.Writer().WriteError(w, r, err)
-			return
-		}
-
-		creds, ok := id.GetCredentials(CredentialsTypeOIDC)
-
-		var cfg map[string]interface{}
-		if err := json.NewDecoder(bytes.NewBuffer(creds.Config)).Decode(&cfg); err != nil {
-			h.r.Writer().WriteError(w, r, errors.WithStack(herodot.ErrInternalServerError.WithReason("The oidc credentials could not be decoded properly").WithDebug(err.Error())))
-			return
-		}
-
-		if ok == false {
-			h.r.Writer().WriteError(w, r, errors.WithStack(herodot.ErrInternalServerError.WithReason("The oidc credentials could not be decoded")))
-			return
-		}
-
-		providers, ok := cfg["providers"].([]interface{})
-		if ok == false {
-			h.r.Writer().WriteError(w, r, errors.WithStack(herodot.ErrInternalServerError.WithReason("No providers found in oidc config").WithDebug(err.Error())))
-			return
-		}
-
-		provider, ok := providers[0].(map[string]interface{})
-
-		if ok == false {
-			h.r.Writer().WriteError(w, r, errors.WithStack(herodot.ErrInternalServerError.WithReason("No provider found in array in oidc config").WithDebug(err.Error())))
-			return
-		}
-
-		ps, ok := provider["provider"].(string)
-
-		if ok == false {
-			h.r.Writer().WriteError(w, r, errors.WithStack(herodot.ErrInternalServerError.WithReason("Provider in oidc config is not a string").WithDebug(err.Error())))
-			return
-		}
-
-		h.r.Writer().Write(w, r, &methodResponse{Method: CredentialsTypeOIDC.String(), Provider: ps})
+	kcr := knownCredentialsRequest{}
+	if err := jsonx.NewStrictDecoder(r.Body).Decode(&kcr); err != nil {
+		h.r.Writer().WriteErrorCode(w, r, http.StatusBadRequest, errors.WithStack(err))
 		return
-
 	}
 
-	if strings.Contains(ps.ByName("id"), "@") {
-		h.r.Writer().Write(w, r, &methodResponse{Method: "need-username"})
-	} else {
-		h.r.Writer().Write(w, r, &methodResponse{Method: CredentialsTypePassword.String()})
+	if kcr.Identifier == "" {
+		h.r.Writer().WriteErrorCode(w, r, http.StatusBadRequest, errors.WithStack(errors.New("must specify identifier")))
+		return
 	}
 
+	if kcr.Method != "" && kcr.Method != CredentialsTypeOIDC.String() && kcr.Method != CredentialsTypePassword.String() {
+		h.r.Writer().WriteErrorCode(w, r, http.StatusBadRequest, errors.WithStack(fmt.Errorf("if method is specified, must be either '%s' or '%s'", CredentialsTypePassword, CredentialsTypeOIDC)))
+		return
+	}
+
+	result := knownCredentialsResponse{false, []knownCredentialsMethod{}}
+	if kcr.Method == CredentialsTypePassword.String() || kcr.Method == "" {
+		// if the credentials can be looked up directly by identifier then they're type password
+		_, _, err := h.r.PrivilegedIdentityPool().FindByCredentialsIdentifier(r.Context(), CredentialsTypePassword, kcr.Identifier)
+		if err == nil {
+			result.Found = true
+			result.Methods = append(result.Methods, knownCredentialsMethod{CredentialsTypePassword.String(), ""})
+		}
+	}
+
+	if kcr.Method == CredentialsTypeOIDC.String() || kcr.Method == "" {
+		found, providers, err := h.knownCredentialsOIDC(r.Context(), kcr.Identifier)
+		if err != nil {
+			h.r.Writer().WriteError(w, r, err)
+			return
+		}
+
+		if found {
+			result.Found = true
+			for _, provider := range providers {
+				result.Methods = append(result.Methods, knownCredentialsMethod{CredentialsTypeOIDC.String(), provider})
+			}
+		}
+	}
+
+	h.r.Writer().Write(w, r, &result)
 }
 
 // A single identity.

--- a/identity/handler.go
+++ b/identity/handler.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/ory/herodot"
 	"github.com/ory/kratos/driver/config"
@@ -118,7 +119,11 @@ func (h *Handler) method(w http.ResponseWriter, r *http.Request, ps httprouter.P
 
 	}
 
-	h.r.Writer().Write(w, r, &methodResponse{Method: CredentialsTypePassword.String()})
+	if strings.Contains(ps.ByName("id"), "@") {
+		h.r.Writer().Write(w, r, &methodResponse{Method: "need-username"})
+	} else {
+		h.r.Writer().Write(w, r, &methodResponse{Method: CredentialsTypePassword.String()})
+	}
 
 }
 

--- a/identity/handler.go
+++ b/identity/handler.go
@@ -1,9 +1,11 @@
 package identity
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 
+	"github.com/ory/herodot"
 	"github.com/ory/kratos/driver/config"
 
 	"github.com/julienschmidt/httprouter"
@@ -55,18 +57,65 @@ func (h *Handler) RegisterAdminRoutes(admin *x.RouterAdmin) {
 }
 
 type methodResponse struct {
-	Method string `json:"method"`
+	Method   string `json:"method"`
+	Provider string `json:"provider,omitempty"`
 }
 
 func (h *Handler) method(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+
+	// if the credentials can be looked up directly by email address then they're type password
 	_, _, err := h.r.PrivilegedIdentityPool().FindByCredentialsIdentifier(r.Context(), CredentialsTypePassword, ps.ByName("id"))
 	if err != nil {
-		_, _, err := h.r.PrivilegedIdentityPool().FindByCredentialsIdentifier(r.Context(), CredentialsTypeOIDC, ps.ByName("id"))
+		// otherwise if they're OIDC credentials we have to find them by the verifiable address and then see if they are indeed OIDC
+		address, err := h.r.PrivilegedIdentityPool().FindVerifiableAddressByValue(r.Context(), VerifiableAddressTypeEmail, ps.ByName("id"))
+
 		if err != nil {
 			h.r.Writer().WriteError(w, r, err)
 			return
 		}
-		h.r.Writer().Write(w, r, &methodResponse{Method: CredentialsTypeOIDC.String()})
+
+		id, err := h.r.PrivilegedIdentityPool().GetIdentityConfidential(r.Context(), address.IdentityID)
+		if err != nil {
+			h.r.Writer().WriteError(w, r, err)
+			return
+		}
+
+		creds, ok := id.GetCredentials(CredentialsTypeOIDC)
+
+		var cfg map[string]interface{}
+		if err := json.NewDecoder(bytes.NewBuffer(creds.Config)).Decode(&cfg); err != nil {
+			h.r.Writer().WriteError(w, r, errors.WithStack(herodot.ErrInternalServerError.WithReason("The oidc credentials could not be decoded properly").WithDebug(err.Error())))
+			return
+		}
+
+		if ok == false {
+			h.r.Writer().WriteError(w, r, errors.WithStack(herodot.ErrInternalServerError.WithReason("The oidc credentials could not be decoded")))
+			return
+		}
+
+		providers, ok := cfg["providers"].([]interface{})
+		if ok == false {
+			h.r.Writer().WriteError(w, r, errors.WithStack(herodot.ErrInternalServerError.WithReason("No providers found in oidc config").WithDebug(err.Error())))
+			return
+		}
+
+		provider, ok := providers[0].(map[string]interface{})
+
+		if ok == false {
+			h.r.Writer().WriteError(w, r, errors.WithStack(herodot.ErrInternalServerError.WithReason("No provider found in array in oidc config").WithDebug(err.Error())))
+			return
+		}
+
+		ps, ok := provider["provider"].(string)
+
+		if ok == false {
+			h.r.Writer().WriteError(w, r, errors.WithStack(herodot.ErrInternalServerError.WithReason("Provider in oidc config is not a string").WithDebug(err.Error())))
+			return
+		}
+
+		h.r.Writer().Write(w, r, &methodResponse{Method: CredentialsTypeOIDC.String(), Provider: ps})
+		return
+
 	}
 
 	h.r.Writer().Write(w, r, &methodResponse{Method: CredentialsTypePassword.String()})

--- a/identity/handler.go
+++ b/identity/handler.go
@@ -41,13 +41,6 @@ func NewHandler(r handlerDependencies) *Handler {
 	return &Handler{r: r}
 }
 
-func (h *Handler) RegisterPublicRoutes(public *x.RouterPublic) {
-	for _, m := range []string{http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut, http.MethodPatch,
-		http.MethodDelete, http.MethodConnect, http.MethodOptions, http.MethodTrace} {
-		public.Handle(m, RouteMethod, h.method)
-	}
-}
-
 func (h *Handler) RegisterAdminRoutes(admin *x.RouterAdmin) {
 	admin.GET(RouteBase, h.list)
 	admin.GET(RouteBase+"/:id", h.get)
@@ -55,6 +48,8 @@ func (h *Handler) RegisterAdminRoutes(admin *x.RouterAdmin) {
 
 	admin.POST(RouteBase, h.create)
 	admin.PUT(RouteBase+"/:id", h.update)
+
+	admin.GET(RouteMethod, h.method)
 }
 
 type methodResponse struct {
@@ -62,6 +57,18 @@ type methodResponse struct {
 	Provider string `json:"provider,omitempty"`
 }
 
+// swagger:route GET /method admin getMethod
+//
+// Get login method for a previously registered email address or username
+//
+//     Produces:
+//     - application/json
+//
+//     Schemes: http, https
+//
+//     Responses:
+//       200: loginMethod
+//       500: genericError
 func (h *Handler) method(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 
 	// if the credentials can be looked up directly by email address then they're type password

--- a/identity/handler.go
+++ b/identity/handler.go
@@ -16,6 +16,7 @@ import (
 )
 
 const RouteBase = "/identities"
+const RouteMethod = "/method/:id"
 
 type (
 	handlerDependencies interface {
@@ -37,6 +38,13 @@ func NewHandler(r handlerDependencies) *Handler {
 	return &Handler{r: r}
 }
 
+func (h *Handler) RegisterPublicRoutes(public *x.RouterPublic) {
+	for _, m := range []string{http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut, http.MethodPatch,
+		http.MethodDelete, http.MethodConnect, http.MethodOptions, http.MethodTrace} {
+		public.Handle(m, RouteMethod, h.method)
+	}
+}
+
 func (h *Handler) RegisterAdminRoutes(admin *x.RouterAdmin) {
 	admin.GET(RouteBase, h.list)
 	admin.GET(RouteBase+"/:id", h.get)
@@ -44,6 +52,25 @@ func (h *Handler) RegisterAdminRoutes(admin *x.RouterAdmin) {
 
 	admin.POST(RouteBase, h.create)
 	admin.PUT(RouteBase+"/:id", h.update)
+}
+
+type methodResponse struct {
+	Method string `json:"method"`
+}
+
+func (h *Handler) method(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	_, _, err := h.r.PrivilegedIdentityPool().FindByCredentialsIdentifier(r.Context(), CredentialsTypePassword, ps.ByName("id"))
+	if err != nil {
+		_, _, err := h.r.PrivilegedIdentityPool().FindByCredentialsIdentifier(r.Context(), CredentialsTypeOIDC, ps.ByName("id"))
+		if err != nil {
+			h.r.Writer().WriteError(w, r, err)
+			return
+		}
+		h.r.Writer().Write(w, r, &methodResponse{Method: CredentialsTypeOIDC.String()})
+	}
+
+	h.r.Writer().Write(w, r, &methodResponse{Method: CredentialsTypePassword.String()})
+
 }
 
 // A single identity.


### PR DESCRIPTION
## Related issue

There is no related issue.

## Proposed changes

In my app I want to allow users to register via one of several methods: two OIDC providers or a password.  When they return after sign-up, I want to provide a login experience that doesn't require them to remember how they registered. I want them to enter their username or email address and for the UI to start the correct OIDC provider flow or prompt for their password using the same method they registered with.

To make this possible, I've put together this login method API. It looks up the given email address and returns either the ID of the OIDC provider that should be used, the "password" method.  My app UI is able to interpret the result and either launch the correct OIDC flow or prompt for a password.

I also have a requirement that users who login via password need to have a username rather just than an email address.  Login via email address is fine for users who login via OIDC.

I understand this is a potential account enumeration attack vector, so maybe it should be turned on with a configuration option and left off for most users.

I'm open to different/better approaches to accomplish this. I'm marking it WIP because I implemented what seemed to me to be the most straightforward way, but maybe there is a different approach that would work better.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments
