### PR TITLE
docs: Fix incorrect command

### DIFF
--- a/docs/versioned_docs/version-v0.6/guides/docker.md
+++ b/docs/versioned_docs/version-v0.6/guides/docker.md
@@ -82,7 +82,7 @@ below:
 
 ```dockerfile
 FROM oryd/kratos:latest
-COPY contrib/quickstart/kratos/email-password/kratos.yml /ory/home
+COPY contrib/quickstart/kratos/email-password/kratos.yml /home/ory
 ```
 
 ### Examples


### PR DESCRIPTION
Fixes doc typo in which files are suggested to be copied to `/ory/home` instead of `/home/ory`.