### PR TITLE
feat: add vk and yandex providers to oidc providers and documentation

### DIFF
--- a/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
+++ b/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
@@ -779,11 +779,7 @@ local claims = std.extVar('claims');
 {
   identity: {
     traits: {
-      // Allowing unverified email addresses enables account
-      // enumeration attacks, especially if the value is used for
-      // e.g. verification or as a password login identifier.
-      //
-      // It is assumed that VK requires a email to be verifed before accessable via Oauth (because they don't provide an email_verified field).
+      // VK don't provide an email_verified field.
       //
       // The email might be empty if the user is not allowed to an email scope.
       [if "email" in claims then "email" else null]: claims.email,
@@ -867,11 +863,7 @@ local claims = std.extVar('claims');
 {
   identity: {
     traits: {
-      // Allowing unverified email addresses enables account
-      // enumeration attacks, especially if the value is used for
-      // e.g. verification or as a password login identifier.
-      //
-      // It is assumed that Yandex requires a email to be verifed before accessable via Oauth (because they don't provide an email_verified field).
+      // Yandex don't provide an email_verified field.
       //
       // The email might be empty if the user is not allowed to an email scope.
       [if "email" in claims then "email" else null]: claims.email,

--- a/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
+++ b/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
@@ -725,9 +725,7 @@ Please look at the Google developer documentation which can be found
 
 **Create VK Application**
 
-
-Create a
-[VK OAuth2 Application](https://vk.com/apps?act=manage).
+Create a [VK OAuth2 Application](https://vk.com/apps?act=manage).
 
 Select "Create"
 
@@ -759,15 +757,13 @@ The pattern of this URL is:
 https://<domain-of-ory-kratos>:<public-port>/self-service/methods/oidc/callback/<provider-id>
 ```
 
-
 :::note
 
 While you can use
-[VK as an OIDC identity provider](https://vk.com/dev/authcode_flow_user),
-VK only returns access_token and not id_token. Therefore, Ory Kratos makes
-a request to
-[VK's API](https://vk.com/dev/users.get) and adds
-the user info to `std.extVar('claims')`.
+[VK as an OIDC identity provider](https://vk.com/dev/authcode_flow_user), VK
+only returns access_token and not id_token. Therefore, Ory Kratos makes a
+request to [VK's API](https://vk.com/dev/users.get) and adds the user info to
+`std.extVar('claims')`.
 
 :::
 
@@ -816,13 +812,12 @@ selfservice:
               - email # required for email and email_verified claims in the near future
 ```
 
-Next, open the login endpoint of the SecureApp and you should see the VK
-Login option!
+Next, open the login endpoint of the SecureApp and you should see the VK Login
+option!
 
 ## Yandex
 
 **Create Yandex Application**
-
 
 Create a
 [Yandex OAuth2 Application](https://yandex.com/dev/oauth/doc/dg/tasks/register-client.html).
@@ -849,15 +844,14 @@ The pattern of this URL is:
 https://<domain-of-ory-kratos>:<public-port>/self-service/methods/oidc/callback/<provider-id>
 ```
 
-
 :::note
 
 While you can use
 [Yandex as an OIDC identity provider](https://yandex.com/dev/oauth/doc/dg/concepts/about.html),
-Yandex only returns access_token and not id_token. Therefore, Ory Kratos makes
-a request to
-[Yandex's API](https://yandex.com/dev/passport/doc/dg/reference/request.html) and adds
-the user info to `std.extVar('claims')`.
+Yandex only returns access_token and not id_token. Therefore, Ory Kratos makes a
+request to
+[Yandex's API](https://yandex.com/dev/passport/doc/dg/reference/request.html)
+and adds the user info to `std.extVar('claims')`.
 
 :::
 

--- a/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
+++ b/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
@@ -721,6 +721,192 @@ Please look at the Google developer documentation which can be found
 [here](https://developers.google.com/identity/protocols/oauth2/openid-connect#an-id-tokens-payload)
 .
 
+## VK
+
+**Create VK Application**
+
+
+Create a
+[VK OAuth2 Application](https://vk.com/apps?act=manage).
+
+Select "Create"
+
+Select "Platform: Website"
+
+Set the "Website address" to:
+
+```
+https://127.0.0.1:4433
+```
+
+Set the "Base domain" to:
+
+```
+127.0.0.1:4433
+```
+
+Select "Connect Website"
+
+Set the "Authorized redirect URI" to:
+
+```
+https://127.0.0.1:4433/self-service/methods/oidc/callback/vk
+```
+
+The pattern of this URL is:
+
+```
+https://<domain-of-ory-kratos>:<public-port>/self-service/methods/oidc/callback/<provider-id>
+```
+
+
+:::note
+
+While you can use
+[VK as an OIDC identity provider](https://vk.com/dev/authcode_flow_user),
+VK only returns access_token and not id_token. Therefore, Ory Kratos makes
+a request to
+[VK's API](https://vk.com/dev/users.get) and adds
+the user info to `std.extVar('claims')`.
+
+:::
+
+**Configuring Kratos**
+
+Create a Jsonnet claims mapper as described in
+[OpenID Connect and OAuth2 Credentials](../concepts/credentials/openid-connect-oidc-oauth2.mdx).
+Save the code in
+`<kratos-directory>/contrib/quickstart/kratos/email-password/oidc.vk.jsonnet`.
+
+```json title="contrib/quickstart/kratos/email-password/oidc.vk.jsonnet"
+local claims = std.extVar('claims');
+{
+  identity: {
+    traits: {
+      // Allowing unverified email addresses enables account
+      // enumeration attacks, especially if the value is used for
+      // e.g. verification or as a password login identifier.
+      //
+      // It is assumed that VK requires a email to be verifed before accessable via Oauth (because they don't provide an email_verified field).
+      //
+      // The email might be empty if the user is not allowed to an email scope.
+      [if "email" in claims then "email" else null]: claims.email,
+    },
+  },
+}
+```
+
+Now, enable the VK provider in the Ory Kratos config located at
+`<kratos-directory>/contrib/quickstart/kratos/email-password/kratos.yml`.
+
+```yaml title="contrib/quickstart/kratos/email-password/kratos.yml"
+# $ kratos -c path/to/my/kratos/config.yml serve
+selfservice:
+  methods:
+    oidc:
+      enabled: true
+      config:
+        providers:
+          - id: vk # this is `<provider-id>` in the Authorization callback URL. DO NOT CHANGE IT ONCE SET!
+            provider: vk
+            client_id: .... # Replace this with the OAuth2 Client ID provided by VK app
+            client_secret: .... # Replace this with the OAuth2 Client Secret provided by VK app
+            mapper_url: file:///etc/config/kratos/oidc.vk.jsonnet
+            scope:
+              - email # required for email and email_verified claims in the near future
+```
+
+Next, open the login endpoint of the SecureApp and you should see the VK
+Login option!
+
+## Yandex
+
+**Create Yandex Application**
+
+
+Create a
+[Yandex OAuth2 Application](https://yandex.com/dev/oauth/doc/dg/tasks/register-client.html).
+
+Select "Platforms: Web services"
+
+Set the "Website address" to:
+
+```
+https://127.0.0.1:4433
+```
+
+Select "Connect Website"
+
+Set the "Callback URI" to:
+
+```
+https://127.0.0.1:4433/self-service/methods/oidc/callback/yandex
+```
+
+The pattern of this URL is:
+
+```
+https://<domain-of-ory-kratos>:<public-port>/self-service/methods/oidc/callback/<provider-id>
+```
+
+
+:::note
+
+While you can use
+[Yandex as an OIDC identity provider](https://yandex.com/dev/oauth/doc/dg/concepts/about.html),
+Yandex only returns access_token and not id_token. Therefore, Ory Kratos makes
+a request to
+[Yandex's API](https://yandex.com/dev/passport/doc/dg/reference/request.html) and adds
+the user info to `std.extVar('claims')`.
+
+:::
+
+**Configuring Kratos**
+
+Create a Jsonnet claims mapper as described in
+[OpenID Connect and OAuth2 Credentials](../concepts/credentials/openid-connect-oidc-oauth2.mdx).
+Save the code in
+`<kratos-directory>/contrib/quickstart/kratos/email-password/oidc.yandex.jsonnet`.
+
+```json title="contrib/quickstart/kratos/email-password/oidc.yandex.jsonnet"
+local claims = std.extVar('claims');
+{
+  identity: {
+    traits: {
+      // Allowing unverified email addresses enables account
+      // enumeration attacks, especially if the value is used for
+      // e.g. verification or as a password login identifier.
+      //
+      // It is assumed that Yandex requires a email to be verifed before accessable via Oauth (because they don't provide an email_verified field).
+      //
+      // The email might be empty if the user is not allowed to an email scope.
+      [if "email" in claims then "email" else null]: claims.email,
+    },
+  },
+}
+```
+
+Now, enable the Yandex provider in the Ory Kratos config located at
+`<kratos-directory>/contrib/quickstart/kratos/email-password/kratos.yml`.
+
+```yaml title="contrib/quickstart/kratos/email-password/kratos.yml"
+# $ kratos -c path/to/my/kratos/config.yml serve
+selfservice:
+  methods:
+    oidc:
+      enabled: true
+      config:
+        providers:
+          - id: yandex # this is `<provider-id>` in the Authorization callback URL. DO NOT CHANGE IT ONCE SET!
+            provider: yandex
+            client_id: .... # Replace this with the OAuth2 Client ID provided by Yandex app
+            client_secret: .... # Replace this with the OAuth2 Client Secret provided by Yandex app
+            mapper_url: file:///etc/config/kratos/oidc.yandex.jsonnet
+```
+
+Next, open the login endpoint of the SecureApp and you should see the Yandex
+Login option!
+
 ## LinkedIn
 
 Connecting with other Social Sign In providers will be very similar to the

--- a/driver/config/.schema/config.schema.json
+++ b/driver/config/.schema/config.schema.json
@@ -258,7 +258,7 @@
         },
         "provider": {
           "title": "Provider",
-          "description": "Can be one of github, gitlab, generic, google, microsoft, discord, slack, facebook.",
+          "description": "Can be one of github, gitlab, generic, google, microsoft, discord, slack, facebook, vk, yandex.",
           "type": "string",
           "enum": [
             "github",
@@ -268,7 +268,9 @@
             "microsoft",
             "discord",
             "slack",
-            "facebook"
+            "facebook",
+            "vk",
+            "yandex"
           ],
           "examples": [
             "google"

--- a/go.mod
+++ b/go.mod
@@ -90,4 +90,5 @@ require (
 	golang.org/x/oauth2 v0.0.0-20210323180902-22b0adad7558
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	golang.org/x/tools v0.1.0
+	github.com/davecgh/go-spew v1.1.1
 )

--- a/go.mod
+++ b/go.mod
@@ -90,5 +90,4 @@ require (
 	golang.org/x/oauth2 v0.0.0-20210323180902-22b0adad7558
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	golang.org/x/tools v0.1.0
-	github.com/davecgh/go-spew v1.1.1
 )

--- a/selfservice/strategy/oidc/provider_config.go
+++ b/selfservice/strategy/oidc/provider_config.go
@@ -25,6 +25,8 @@ type Configuration struct {
 	// - discord
 	// - slack
 	// - facebook
+	// - vk
+	// - yandex
 	Provider string `json:"provider"`
 
 	// Label represents an optional label which can be used in the UI generation.
@@ -108,6 +110,10 @@ func (c ConfigurationCollection) Provider(id string, public *url.URL) (Provider,
 				return NewProviderSlack(&p, public), nil
 			case addProviderName("facebook"):
 				return NewProviderFacebook(&p, public), nil
+			case addProviderName("vk"):
+				return NewProviderVK(&p, public), nil
+			case addProviderName("yandex"):
+				return NewProviderYandex(&p, public), nil
 			}
 			return nil, errors.Errorf("provider type %s is not supported, supported are: %v", p.Provider, providerNames)
 		}

--- a/selfservice/strategy/oidc/provider_vk.go
+++ b/selfservice/strategy/oidc/provider_vk.go
@@ -1,0 +1,128 @@
+package oidc
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/pkg/errors"
+	"golang.org/x/oauth2"
+
+	"github.com/ory/herodot"
+)
+
+type ProviderVK struct {
+	config *Configuration
+	public *url.URL
+}
+
+func NewProviderVK(
+	config *Configuration,
+	public *url.URL,
+) *ProviderVK {
+	return &ProviderVK{
+		config: config,
+		public: public,
+	}
+}
+
+func (g *ProviderVK) Config() *Configuration {
+	return g.config
+}
+
+func (g *ProviderVK) oauth2() *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:     g.config.ClientID,
+		ClientSecret: g.config.ClientSecret,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  "https://oauth.vk.com/authorize",
+			TokenURL: "https://oauth.vk.com/access_token",
+		},
+		Scopes:      g.config.Scope,
+		RedirectURL: g.config.Redir(g.public),
+	}
+}
+
+func (g *ProviderVK) AuthCodeURLOptions(r ider) []oauth2.AuthCodeOption {
+	return []oauth2.AuthCodeOption{}
+}
+
+func (g *ProviderVK) OAuth2(ctx context.Context) (*oauth2.Config, error) {
+	return g.oauth2(), nil
+}
+
+func (g *ProviderVK) Claims(ctx context.Context, exchange *oauth2.Token) (*Claims, error) {
+
+	o, err := g.OAuth2(ctx)
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+
+	client := o.Client(ctx, exchange)
+
+	u, err := url.Parse("https://api.vk.com/method/users.get?fields=photo_200,nickname,bdate,sex&access_token=" + exchange.AccessToken + "&v=5.103")
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+	defer resp.Body.Close()
+
+	type User struct {
+		Id            int    `json:"id,omitempty"`
+		FirstName     string `json:"first_name,omitempty"`
+		LastName      string `json:"last_name,omitempty"`
+		Nickname      string `json:"nickname,omitempty"`
+		Picture       string `json:"photo_200,omitempty"`
+		Email         string
+		EmailVerified bool
+		Gender        int    `json:"sex,omitempty"`
+		BirthDay      string `json:"bdate,omitempty"`
+	}
+
+	var response struct {
+		Result []User `json:"response,omitempty"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+
+	user := response.Result[0]
+
+	if email := exchange.Extra("email"); email != nil {
+		user.Email = email.(string)
+		user.EmailVerified = true
+	}
+
+	gender := ""
+	switch user.Gender {
+	case 1:
+		gender = "female"
+	case 2:
+		gender = "male"
+	}
+
+	return &Claims{
+		Issuer:        u.String(),
+		Subject:       strconv.Itoa(user.Id),
+		GivenName:     user.FirstName,
+		FamilyName:    user.LastName,
+		Nickname:      user.Nickname,
+		Picture:       user.Picture,
+		Email:         user.Email,
+		EmailVerified: user.EmailVerified,
+		Gender:        gender,
+		Birthdate:     user.BirthDay,
+	}, nil
+}

--- a/selfservice/strategy/oidc/provider_vk.go
+++ b/selfservice/strategy/oidc/provider_vk.go
@@ -79,15 +79,14 @@ func (g *ProviderVK) Claims(ctx context.Context, exchange *oauth2.Token) (*Claim
 	defer resp.Body.Close()
 
 	type User struct {
-		Id            int    `json:"id,omitempty"`
-		FirstName     string `json:"first_name,omitempty"`
-		LastName      string `json:"last_name,omitempty"`
-		Nickname      string `json:"nickname,omitempty"`
-		Picture       string `json:"photo_200,omitempty"`
-		Email         string
-		EmailVerified bool
-		Gender        int    `json:"sex,omitempty"`
-		BirthDay      string `json:"bdate,omitempty"`
+		Id        int    `json:"id,omitempty"`
+		FirstName string `json:"first_name,omitempty"`
+		LastName  string `json:"last_name,omitempty"`
+		Nickname  string `json:"nickname,omitempty"`
+		Picture   string `json:"photo_200,omitempty"`
+		Email     string
+		Gender    int    `json:"sex,omitempty"`
+		BirthDay  string `json:"bdate,omitempty"`
 	}
 
 	var response struct {
@@ -102,7 +101,6 @@ func (g *ProviderVK) Claims(ctx context.Context, exchange *oauth2.Token) (*Claim
 
 	if email := exchange.Extra("email"); email != nil {
 		user.Email = email.(string)
-		user.EmailVerified = true
 	}
 
 	gender := ""
@@ -114,15 +112,14 @@ func (g *ProviderVK) Claims(ctx context.Context, exchange *oauth2.Token) (*Claim
 	}
 
 	return &Claims{
-		Issuer:        u.String(),
-		Subject:       strconv.Itoa(user.Id),
-		GivenName:     user.FirstName,
-		FamilyName:    user.LastName,
-		Nickname:      user.Nickname,
-		Picture:       user.Picture,
-		Email:         user.Email,
-		EmailVerified: user.EmailVerified,
-		Gender:        gender,
-		Birthdate:     user.BirthDay,
+		Issuer:     u.String(),
+		Subject:    strconv.Itoa(user.Id),
+		GivenName:  user.FirstName,
+		FamilyName: user.LastName,
+		Nickname:   user.Nickname,
+		Picture:    user.Picture,
+		Email:      user.Email,
+		Gender:     gender,
+		Birthdate:  user.BirthDay,
 	}, nil
 }

--- a/selfservice/strategy/oidc/provider_yandex.go
+++ b/selfservice/strategy/oidc/provider_yandex.go
@@ -1,0 +1,115 @@
+package oidc
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+
+	"github.com/pkg/errors"
+	"golang.org/x/oauth2"
+
+	"github.com/ory/herodot"
+)
+
+type ProviderYandex struct {
+	config *Configuration
+	public *url.URL
+}
+
+func NewProviderYandex(
+	config *Configuration,
+	public *url.URL,
+) *ProviderYandex {
+	return &ProviderYandex{
+		config: config,
+		public: public,
+	}
+}
+
+func (g *ProviderYandex) Config() *Configuration {
+	return g.config
+}
+
+func (g *ProviderYandex) oauth2() *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:     g.config.ClientID,
+		ClientSecret: g.config.ClientSecret,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  "https://oauth.yandex.com/authorize",
+			TokenURL: "https://oauth.yandex.com/token",
+		},
+		Scopes:      g.config.Scope,
+		RedirectURL: g.config.Redir(g.public),
+	}
+}
+
+func (g *ProviderYandex) AuthCodeURLOptions(r ider) []oauth2.AuthCodeOption {
+	return []oauth2.AuthCodeOption{}
+}
+
+func (g *ProviderYandex) OAuth2(ctx context.Context) (*oauth2.Config, error) {
+	return g.oauth2(), nil
+}
+
+func (g *ProviderYandex) Claims(ctx context.Context, exchange *oauth2.Token) (*Claims, error) {
+	o, err := g.OAuth2(ctx)
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+
+	client := o.Client(ctx, exchange)
+
+	u, err := url.Parse("https://login.yandex.ru/info?format=json&oauth_token=" + exchange.AccessToken)
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+	defer resp.Body.Close()
+
+	var user struct {
+		Id            string `json:"id,omitempty"`
+		FirstName     string `json:"first_name,omitempty"`
+		LastName      string `json:"last_name,omitempty"`
+		Email         string `json:"default_email,omitempty"`
+		EmailVerified bool
+		Picture       string `json:"default_avatar_id,omitempty"`
+		PictureEmpty  bool   `json:"is_avatar_empty,omitempty"`
+		Gender        string `json:"sex,omitempty"`
+		BirthDay      string `json:"birthday,omitempty"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&user); err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+
+	if !user.PictureEmpty {
+		user.Picture = "https://avatars.yandex.net/get-yapic/" + user.Picture + "/islands-200"
+	} else {
+		user.Picture = ""
+	}
+
+	if user.Email != "" {
+		user.EmailVerified = true
+	}
+
+	return &Claims{
+		Issuer:        u.String(),
+		Subject:       user.Id,
+		GivenName:     user.FirstName,
+		FamilyName:    user.LastName,
+		Picture:       user.Picture,
+		Email:         user.Email,
+		EmailVerified: user.EmailVerified,
+		Gender:        user.Gender,
+		Birthdate:     user.BirthDay,
+	}, nil
+}

--- a/selfservice/strategy/oidc/provider_yandex.go
+++ b/selfservice/strategy/oidc/provider_yandex.go
@@ -76,15 +76,14 @@ func (g *ProviderYandex) Claims(ctx context.Context, exchange *oauth2.Token) (*C
 	defer resp.Body.Close()
 
 	var user struct {
-		Id            string `json:"id,omitempty"`
-		FirstName     string `json:"first_name,omitempty"`
-		LastName      string `json:"last_name,omitempty"`
-		Email         string `json:"default_email,omitempty"`
-		EmailVerified bool
-		Picture       string `json:"default_avatar_id,omitempty"`
-		PictureEmpty  bool   `json:"is_avatar_empty,omitempty"`
-		Gender        string `json:"sex,omitempty"`
-		BirthDay      string `json:"birthday,omitempty"`
+		Id           string `json:"id,omitempty"`
+		FirstName    string `json:"first_name,omitempty"`
+		LastName     string `json:"last_name,omitempty"`
+		Email        string `json:"default_email,omitempty"`
+		Picture      string `json:"default_avatar_id,omitempty"`
+		PictureEmpty bool   `json:"is_avatar_empty,omitempty"`
+		Gender       string `json:"sex,omitempty"`
+		BirthDay     string `json:"birthday,omitempty"`
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(&user); err != nil {
@@ -97,19 +96,14 @@ func (g *ProviderYandex) Claims(ctx context.Context, exchange *oauth2.Token) (*C
 		user.Picture = ""
 	}
 
-	if user.Email != "" {
-		user.EmailVerified = true
-	}
-
 	return &Claims{
-		Issuer:        u.String(),
-		Subject:       user.Id,
-		GivenName:     user.FirstName,
-		FamilyName:    user.LastName,
-		Picture:       user.Picture,
-		Email:         user.Email,
-		EmailVerified: user.EmailVerified,
-		Gender:        user.Gender,
-		Birthdate:     user.BirthDay,
+		Issuer:     u.String(),
+		Subject:    user.Id,
+		GivenName:  user.FirstName,
+		FamilyName: user.LastName,
+		Picture:    user.Picture,
+		Email:      user.Email,
+		Gender:     user.Gender,
+		Birthdate:  user.BirthDay,
 	}, nil
 }


### PR DESCRIPTION
## Related issue

#1234

## Proposed changes

- Adds provider_vk.go and updates the configuration schema to allow for vk as an OIDC provider
- Adds provider_yandex.go and updates the configuration schema to allow for yandex as an OIDC provider
- Adds description to documentation

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
