### PR TITLE
fix: version schema

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,6 +209,7 @@ workflows:
             tags:
               only: /.*/
       - goreleaser/render-version-schema:
+          schema-path: driver/config/.schema/config.schema.json
           requires:
             - goreleaser/release
           filters:

--- a/.schema/version.schema.json
+++ b/.schema/version.schema.json
@@ -126,7 +126,7 @@
                     }
                 },
                 {
-                    "$ref": "https://raw.githubusercontent.com/ory/kratos/v0.6.0-alpha.1/.schema/config.schema.json"
+                    "$ref": "https://raw.githubusercontent.com/ory/kratos/v0.6.0-alpha.1/driver/config/.schema/config.schema.json"
                 }
             ]
         },
@@ -140,7 +140,7 @@
                     }
                 },
                 {
-                    "$ref": "https://raw.githubusercontent.com/ory/kratos/v0.6.0-alpha.2/.schema/config.schema.json"
+                    "$ref": "https://raw.githubusercontent.com/ory/kratos/v0.6.0-alpha.2/driver/config/.schema/config.schema.json"
                 }
             ]
         },
@@ -154,7 +154,7 @@
                     }
                 },
                 {
-                    "$ref": "https://raw.githubusercontent.com/ory/kratos/v0.6.1-alpha.1/.schema/config.schema.json"
+                    "$ref": "https://raw.githubusercontent.com/ory/kratos/v0.6.1-alpha.1/driver/config/.schema/config.schema.json"
                 }
             ]
         },
@@ -168,7 +168,7 @@
                     }
                 },
                 {
-                    "$ref": "https://raw.githubusercontent.com/ory/kratos/v0.6.2-alpha.1/.schema/config.schema.json"
+                    "$ref": "https://raw.githubusercontent.com/ory/kratos/v0.6.2-alpha.1/driver/config/.schema/config.schema.json"
                 }
             ]
         },
@@ -182,7 +182,7 @@
                     }
                 },
                 {
-                    "$ref": "https://raw.githubusercontent.com/ory/kratos/v0.6.3-alpha.1/.schema/config.schema.json"
+                    "$ref": "https://raw.githubusercontent.com/ory/kratos/v0.6.3-alpha.1/driver/config/.schema/config.schema.json"
                 }
             ]
         }


### PR DESCRIPTION
## Related issue

Closes #1331 
Closes #1101 
This fixes the config schema paths in the version.schema.json to reflect the new path since we use go embed.
See also https://github.com/ory/hydra/pull/2427
The CI was also updated to include the new schema path.

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->
