### PR TITLE
fix: check filesystem before fallback to bundled templates

### DIFF
--- a/courier/template/load_template_test.go
+++ b/courier/template/load_template_test.go
@@ -12,24 +12,31 @@ import (
 )
 
 func TestLoadTextTemplate(t *testing.T) {
-	var executeTemplate = func(t *testing.T, path string) string {
-		tp, err := loadTextTemplate(path, nil)
+	var executeTemplate = func(t *testing.T, dir, name string) string {
+		tp, err := loadTextTemplate(dir, name, nil)
 		require.NoError(t, err)
 		return tp
 	}
 
 	t.Run("method=from bundled", func(t *testing.T) {
-		actual := executeTemplate(t, "courier/builtin/templates/test_stub/email.body.gotmpl")
+		actual := executeTemplate(t, "courier/builtin/templates", "test_stub/email.body.gotmpl")
+		assert.Contains(t, actual, "stub email")
+	})
+
+	t.Run("method=fallback to bundled", func(t *testing.T) {
+		actual := executeTemplate(t, "some/inexistent/dir", "test_stub/email.body.gotmpl")
 		assert.Contains(t, actual, "stub email")
 	})
 
 	t.Run("method=cache works", func(t *testing.T) {
-		fp := filepath.Join(os.TempDir(), x.NewUUID().String()) + ".body.gotmpl"
+		dir := os.TempDir()
+		name := x.NewUUID().String() + ".body.gotmpl"
+		fp := filepath.Join(dir, name)
 
 		require.NoError(t, os.WriteFile(fp, []byte("cached stub body"), 0666))
-		assert.Contains(t, executeTemplate(t, fp), "cached stub body")
+		assert.Contains(t, executeTemplate(t, dir, name), "cached stub body")
 
 		require.NoError(t, os.RemoveAll(fp))
-		assert.Contains(t, executeTemplate(t, fp), "cached stub body")
+		assert.Contains(t, executeTemplate(t, dir, name), "cached stub body")
 	})
 }

--- a/courier/template/recovery_invalid.go
+++ b/courier/template/recovery_invalid.go
@@ -2,7 +2,6 @@ package template
 
 import (
 	"encoding/json"
-	"path/filepath"
 
 	"github.com/ory/kratos/driver/config"
 )
@@ -26,15 +25,15 @@ func (t *RecoveryInvalid) EmailRecipient() (string, error) {
 }
 
 func (t *RecoveryInvalid) EmailSubject() (string, error) {
-	return loadTextTemplate(filepath.Join(t.c.CourierTemplatesRoot(), "recovery/invalid/email.subject.gotmpl"), t.m)
+	return loadTextTemplate(t.c.CourierTemplatesRoot(), "recovery/invalid/email.subject.gotmpl", t.m)
 }
 
 func (t *RecoveryInvalid) EmailBody() (string, error) {
-	return loadTextTemplate(filepath.Join(t.c.CourierTemplatesRoot(), "recovery/invalid/email.body.gotmpl"), t.m)
+	return loadTextTemplate(t.c.CourierTemplatesRoot(), "recovery/invalid/email.body.gotmpl", t.m)
 }
 
 func (t *RecoveryInvalid) EmailBodyPlaintext() (string, error) {
-	return loadTextTemplate(filepath.Join(t.c.CourierTemplatesRoot(), "recovery/invalid/email.body.plaintext.gotmpl"), t.m)
+	return loadTextTemplate(t.c.CourierTemplatesRoot(), "recovery/invalid/email.body.plaintext.gotmpl", t.m)
 }
 
 func (t *RecoveryInvalid) MarshalJSON() ([]byte, error) {

--- a/courier/template/recovery_valid.go
+++ b/courier/template/recovery_valid.go
@@ -2,7 +2,6 @@ package template
 
 import (
 	"encoding/json"
-	"path/filepath"
 
 	"github.com/ory/kratos/driver/config"
 )
@@ -27,15 +26,15 @@ func (t *RecoveryValid) EmailRecipient() (string, error) {
 }
 
 func (t *RecoveryValid) EmailSubject() (string, error) {
-	return loadTextTemplate(filepath.Join(t.c.CourierTemplatesRoot(), "recovery/valid/email.subject.gotmpl"), t.m)
+	return loadTextTemplate(t.c.CourierTemplatesRoot(), "recovery/valid/email.subject.gotmpl", t.m)
 }
 
 func (t *RecoveryValid) EmailBody() (string, error) {
-	return loadTextTemplate(filepath.Join(t.c.CourierTemplatesRoot(), "recovery/valid/email.body.gotmpl"), t.m)
+	return loadTextTemplate(t.c.CourierTemplatesRoot(), "recovery/valid/email.body.gotmpl", t.m)
 }
 
 func (t *RecoveryValid) EmailBodyPlaintext() (string, error) {
-	return loadTextTemplate(filepath.Join(t.c.CourierTemplatesRoot(), "recovery/valid/email.body.plaintext.gotmpl"), t.m)
+	return loadTextTemplate(t.c.CourierTemplatesRoot(), "recovery/valid/email.body.plaintext.gotmpl", t.m)
 }
 
 func (t *RecoveryValid) MarshalJSON() ([]byte, error) {

--- a/courier/template/stub.go
+++ b/courier/template/stub.go
@@ -2,7 +2,6 @@ package template
 
 import (
 	"encoding/json"
-	"path/filepath"
 
 	"github.com/ory/kratos/driver/config"
 )
@@ -27,15 +26,15 @@ func (t *TestStub) EmailRecipient() (string, error) {
 }
 
 func (t *TestStub) EmailSubject() (string, error) {
-	return loadTextTemplate(filepath.Join(t.c.CourierTemplatesRoot(), "test_stub/email.subject.gotmpl"), t.m)
+	return loadTextTemplate(t.c.CourierTemplatesRoot(), "test_stub/email.subject.gotmpl", t.m)
 }
 
 func (t *TestStub) EmailBody() (string, error) {
-	return loadTextTemplate(filepath.Join(t.c.CourierTemplatesRoot(), "test_stub/email.body.gotmpl"), t.m)
+	return loadTextTemplate(t.c.CourierTemplatesRoot(), "test_stub/email.body.gotmpl", t.m)
 }
 
 func (t *TestStub) EmailBodyPlaintext() (string, error) {
-	return loadTextTemplate(filepath.Join(t.c.CourierTemplatesRoot(), "test_stub/email.body.plaintext.gotmpl"), t.m)
+	return loadTextTemplate(t.c.CourierTemplatesRoot(), "test_stub/email.body.plaintext.gotmpl", t.m)
 }
 
 func (t *TestStub) MarshalJSON() ([]byte, error) {

--- a/courier/template/verification_invalid.go
+++ b/courier/template/verification_invalid.go
@@ -2,7 +2,6 @@ package template
 
 import (
 	"encoding/json"
-	"path/filepath"
 
 	"github.com/ory/kratos/driver/config"
 )
@@ -26,15 +25,15 @@ func (t *VerificationInvalid) EmailRecipient() (string, error) {
 }
 
 func (t *VerificationInvalid) EmailSubject() (string, error) {
-	return loadTextTemplate(filepath.Join(t.c.CourierTemplatesRoot(), "verification/invalid/email.subject.gotmpl"), t.m)
+	return loadTextTemplate(t.c.CourierTemplatesRoot(), "verification/invalid/email.subject.gotmpl", t.m)
 }
 
 func (t *VerificationInvalid) EmailBody() (string, error) {
-	return loadTextTemplate(filepath.Join(t.c.CourierTemplatesRoot(), "verification/invalid/email.body.gotmpl"), t.m)
+	return loadTextTemplate(t.c.CourierTemplatesRoot(), "verification/invalid/email.body.gotmpl", t.m)
 }
 
 func (t *VerificationInvalid) EmailBodyPlaintext() (string, error) {
-	return loadTextTemplate(filepath.Join(t.c.CourierTemplatesRoot(), "verification/invalid/email.body.plaintext.gotmpl"), t.m)
+	return loadTextTemplate(t.c.CourierTemplatesRoot(), "verification/invalid/email.body.plaintext.gotmpl", t.m)
 }
 
 func (t *VerificationInvalid) MarshalJSON() ([]byte, error) {

--- a/courier/template/verification_valid.go
+++ b/courier/template/verification_valid.go
@@ -2,7 +2,6 @@ package template
 
 import (
 	"encoding/json"
-	"path/filepath"
 
 	"github.com/ory/kratos/driver/config"
 )
@@ -27,15 +26,15 @@ func (t *VerificationValid) EmailRecipient() (string, error) {
 }
 
 func (t *VerificationValid) EmailSubject() (string, error) {
-	return loadTextTemplate(filepath.Join(t.c.CourierTemplatesRoot(), "verification/valid/email.subject.gotmpl"), t.m)
+	return loadTextTemplate(t.c.CourierTemplatesRoot(), "verification/valid/email.subject.gotmpl", t.m)
 }
 
 func (t *VerificationValid) EmailBody() (string, error) {
-	return loadTextTemplate(filepath.Join(t.c.CourierTemplatesRoot(), "verification/valid/email.body.gotmpl"), t.m)
+	return loadTextTemplate(t.c.CourierTemplatesRoot(), "verification/valid/email.body.gotmpl", t.m)
 }
 
 func (t *VerificationValid) EmailBodyPlaintext() (string, error) {
-	return loadTextTemplate(filepath.Join(t.c.CourierTemplatesRoot(), "verification/valid/email.body.plaintext.gotmpl"), t.m)
+	return loadTextTemplate(t.c.CourierTemplatesRoot(), "verification/valid/email.body.plaintext.gotmpl", t.m)
 }
 
 func (t *VerificationValid) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
## Proposed changes

I am interested in implementing #595 and I took a look at the email management. The way `filepath.Join` is used there does not seem cross-platform (`filepath.Join(..., "recovery/invalid/email.subject.gotmpl")` will not be converted to backward slashes).

This PR fixes that by refactoring CourierTemplatesRoot into CourierTemplatePath

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).