### PR TITLE
docs: Fixes typo in "Sign in/up with ID & assword"

### DIFF
--- a/docs/docs/concepts/ui-user-interface.md
+++ b/docs/docs/concepts/ui-user-interface.md
@@ -70,7 +70,7 @@ forms that need to be shown during e.g. login, registration:
 
 Nodes are grouped (using the `group` key) based on the source that generated the
 node. Sources are the different methods such as "password" ("Sign in/up with ID
-& assword"), "oidc" (Social Sign In), "link" (Password reset and email
+& password"), "oidc" (Social Sign In), "link" (Password reset and email
 verification), "profile" ("Update your profile") and the "default" group which
 typically contains the CSRF token.
 

--- a/docs/versioned_docs/version-v0.6/concepts/ui-user-interface.md
+++ b/docs/versioned_docs/version-v0.6/concepts/ui-user-interface.md
@@ -70,7 +70,7 @@ forms that need to be shown during e.g. login, registration:
 
 Nodes are grouped (using the `group` key) based on the source that generated the
 node. Sources are the different methods such as "password" ("Sign in/up with ID
-& assword"), "oidc" (Social Sign In), "link" (Password reset and email
+& password"), "oidc" (Social Sign In), "link" (Password reset and email
 verification), "profile" ("Update your profile") and the "default" group which
 typically contains the CSRF token.
 


### PR DESCRIPTION
## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Proposed changes

I think it should mean 'password' instead of 'assword', shouldn't it?
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
