### PR TITLE
refactor: introduce DefaultContextualizer in corp package

### DIFF
--- a/corp/context.go
+++ b/corp/context.go
@@ -9,20 +9,29 @@ import (
 	"github.com/ory/kratos/driver/config"
 )
 
-func ContextualizeTableName(_ context.Context, name string) string {
-	return name
+type Contextualizer interface {
+	ContextualizeTableName(ctx context.Context, name string) string
+	ContextualizeMiddleware(ctx context.Context) func(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc)
+	ContextualizeConfig(ctx context.Context, fb *config.Config) *config.Config
+	ContextualizeNID(ctx context.Context, fallback uuid.UUID) uuid.UUID
 }
 
-func ContextualizeMiddleware(_ context.Context) func(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
-	return func(w http.ResponseWriter, r *http.Request, n http.HandlerFunc) {
-		n(w, r)
-	}
+var DefaultContextualizer Contextualizer = noopContextualizer{}
+
+// These global functions call the respective method on DefaultContextualizer
+
+func ContextualizeTableName(ctx context.Context, name string) string {
+	return DefaultContextualizer.ContextualizeTableName(ctx, name)
+}
+
+func ContextualizeMiddleware(ctx context.Context) func(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	return DefaultContextualizer.ContextualizeMiddleware(ctx)
 }
 
 func ContextualizeConfig(ctx context.Context, fb *config.Config) *config.Config {
-	return fb
+	return DefaultContextualizer.ContextualizeConfig(ctx, fb)
 }
 
-func ContextualizeNID(_ context.Context, fallback uuid.UUID) uuid.UUID {
-	return fallback
+func ContextualizeNID(ctx context.Context, fallback uuid.UUID) uuid.UUID {
+	return DefaultContextualizer.ContextualizeNID(ctx, fallback)
 }

--- a/corp/noop.go
+++ b/corp/noop.go
@@ -1,0 +1,29 @@
+package corp
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gofrs/uuid"
+	"github.com/ory/kratos/driver/config"
+)
+
+type noopContextualizer struct{}
+
+func (noopContextualizer) ContextualizeTableName(_ context.Context, name string) string {
+	return name
+}
+
+func (noopContextualizer) ContextualizeMiddleware(_ context.Context) func(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	return func(w http.ResponseWriter, r *http.Request, n http.HandlerFunc) {
+		n(w, r)
+	}
+}
+
+func (noopContextualizer) ContextualizeConfig(ctx context.Context, fb *config.Config) *config.Config {
+	return fb
+}
+
+func (noopContextualizer) ContextualizeNID(_ context.Context, fallback uuid.UUID) uuid.UUID {
+	return fallback
+}


### PR DESCRIPTION
## Related issue

First part of #1363 

## Proposed changes

Refactor the `corp` package/module to allow an easier override of the `Contextualize*` functions.

Once this is merged, you can update your own build pipeline to overwrite `corp.DefaultContextualizer` in some `init` function.

After that the `corp/go.{mod,sum}` files can be removed, as well as the `replace` directive in `go.mod`.

This will then ease building kratos from other packages (see #1363 for details).

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added or changed [the documentation](docs/docs).
