### PR TITLE
feat: Team id in slack oidc

### DIFF
--- a/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
+++ b/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
@@ -166,6 +166,7 @@ sub                 # alphanumeric slack user id
 name                # username
 nickname            # username
 preferred_username  # username
+team                # team id slack user belongs to
 ```
 
 Additionally, the `identity.email` scope will add:

--- a/docs/versioned_docs/version-v0.6/guides/sign-in-with-github-google-facebook-linkedin.mdx
+++ b/docs/versioned_docs/version-v0.6/guides/sign-in-with-github-google-facebook-linkedin.mdx
@@ -166,6 +166,7 @@ sub                 # alphanumeric slack user id
 name                # username
 nickname            # username
 preferred_username  # username
+team                # team id slack user belongs to
 ```
 
 Additionally, the `identity.email` scope will add:

--- a/selfservice/strategy/oidc/provider.go
+++ b/selfservice/strategy/oidc/provider.go
@@ -36,4 +36,5 @@ type Claims struct {
 	PhoneNumberVerified bool   `json:"phone_number_verified,omitempty"`
 	UpdatedAt           int64  `json:"updated_at,omitempty"`
 	HD                  string `json:"hd,omitempty"`
+	Team                string `json:"team,omitempty"`
 }

--- a/selfservice/strategy/oidc/provider_slack.go
+++ b/selfservice/strategy/oidc/provider_slack.go
@@ -81,6 +81,7 @@ func (d *ProviderSlack) Claims(ctx context.Context, exchange *oauth2.Token) (*Cl
 		Email:             identity.User.Email,
 		EmailVerified:     true,
 		Picture:           identity.User.Image512,
+		Team:              identity.Team.ID,
 	}
 
 	return claims, nil


### PR DESCRIPTION
I did name the property in the Claims struct Team, although I can see it being called something more generic like OrganizationId since Team may be a specific Slack term, but some generic organization seems like something that will be present in many other OAuth providers.

Closes #1408

## Related issue

#1408
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

Reasoning behind this change described in the related issue. Basically it's a small change to include the team ID user belongs to in the Slack OIDC provider response so it's usable information in the hooks
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
