### PR TITLE
fix: change SMTP config validation from URI to a Regex pattern

### DIFF
--- a/driver/config/.schema/config.schema.json
+++ b/driver/config/.schema/config.schema.json
@@ -933,7 +933,7 @@
                 "smtps://foo:bar@my-mailserver:1234/?skip_ssl_verify=false"
               ],
               "type": "string",
-              "format": "uri"
+              "pattern": "^smtps?:\\/\\/.*"
             },
             "from_address": {
               "title": "SMTP Sender Address",


### PR DESCRIPTION
## Related issue

#1435

## Proposed changes

SMTP validation requires the connection string to be a valid URI, however, AWS SES adds invalid characters to the password, failing validation

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

We match against `SMTP://` or `SMTPS://` plus a valid string after. 