### PR TITLE
feat(selfservice/strategy/oidc): support custom claims

### DIFF
--- a/selfservice/strategy/oidc/provider.go
+++ b/selfservice/strategy/oidc/provider.go
@@ -1,7 +1,9 @@
 package oidc
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 
 	"golang.org/x/oauth2"
 )
@@ -13,7 +15,31 @@ type Provider interface {
 	AuthCodeURLOptions(r ider) []oauth2.AuthCodeOption
 }
 
+func toClaims(basicClaims BasicClaims) Claims {
+	var buffer []byte
+	bb := bytes.NewBuffer(buffer)
+	enc := json.NewEncoder(bb)
+	err := enc.Encode(basicClaims)
+	if err != nil {
+		return Claims{}
+	}
+
+	dec := json.NewDecoder(bb)
+	var claims Claims
+	err = dec.Decode(&claims)
+	if err != nil {
+		return Claims{}
+	}
+
+	return claims
+}
+
 type Claims struct {
+	BasicClaims
+	AdditionalClaims map[string]interface{} `json:"additional_claims"`
+}
+
+type BasicClaims struct {
 	Issuer              string `json:"iss,omitempty"`
 	Subject             string `json:"sub,omitempty"`
 	Name                string `json:"name,omitempty"`

--- a/selfservice/strategy/oidc/provider_discord.go
+++ b/selfservice/strategy/oidc/provider_discord.go
@@ -77,7 +77,7 @@ func (d *ProviderDiscord) Claims(ctx context.Context, exchange *oauth2.Token) (*
 		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
 	}
 
-	claims := &Claims{
+	basicClaims := BasicClaims{
 		Issuer:            discordgo.EndpointOauth2,
 		Subject:           user.ID,
 		Name:              fmt.Sprintf("%s#%s", user.Username, user.Discriminator),
@@ -89,5 +89,6 @@ func (d *ProviderDiscord) Claims(ctx context.Context, exchange *oauth2.Token) (*
 		Locale:            user.Locale,
 	}
 
-	return claims, nil
+	claims := toClaims(basicClaims)
+	return &claims, nil
 }

--- a/selfservice/strategy/oidc/provider_facebook.go
+++ b/selfservice/strategy/oidc/provider_facebook.go
@@ -94,7 +94,7 @@ func (g *ProviderFacebook) Claims(ctx context.Context, exchange *oauth2.Token) (
 		user.EmailVerified = true
 	}
 
-	return &Claims{
+	basicClaims := BasicClaims{
 		Issuer:            u.String(),
 		Subject:           user.Id,
 		Name:              user.Name,
@@ -108,5 +108,8 @@ func (g *ProviderFacebook) Claims(ctx context.Context, exchange *oauth2.Token) (
 		EmailVerified:     user.EmailVerified,
 		Gender:            user.Gender,
 		Birthdate:         user.BirthDay,
-	}, nil
+	}
+
+	claims := toClaims(basicClaims)
+	return &claims, nil
 }

--- a/selfservice/strategy/oidc/provider_generic_oidc.go
+++ b/selfservice/strategy/oidc/provider_generic_oidc.go
@@ -100,6 +100,12 @@ func (g *ProviderGenericOIDC) verifyAndDecodeClaimsWithProvider(ctx context.Cont
 		return nil, errors.WithStack(herodot.ErrBadRequest.WithReasonf("%s", err))
 	}
 
+	var additionalClaims map[string]interface{}
+	if err = token.Claims(&additionalClaims); err != nil {
+		return nil, errors.WithStack(herodot.ErrBadRequest.WithReasonf("%s", err))
+	}
+
+	claims.AdditionalClaims = additionalClaims
 	return &claims, nil
 }
 

--- a/selfservice/strategy/oidc/provider_github.go
+++ b/selfservice/strategy/oidc/provider_github.go
@@ -69,7 +69,7 @@ func (g *ProviderGitHub) Claims(ctx context.Context, exchange *oauth2.Token) (*C
 		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
 	}
 
-	claims := &Claims{
+	basicClaims := BasicClaims{
 		Subject:   fmt.Sprintf("%d", user.GetID()),
 		Issuer:    github.Endpoint.TokenURL,
 		Name:      user.GetName(),
@@ -91,12 +91,13 @@ func (g *ProviderGitHub) Claims(ctx context.Context, exchange *oauth2.Token) (*C
 		for k, e := range emails {
 			// If it is the primary email or it's the last email (no primary email set?), set the email.
 			if e.GetPrimary() || k == len(emails) {
-				claims.Email = e.GetEmail()
-				claims.EmailVerified = e.GetVerified()
+				basicClaims.Email = e.GetEmail()
+				basicClaims.EmailVerified = e.GetVerified()
 				break
 			}
 		}
 	}
 
-	return claims, nil
+	claims := toClaims(basicClaims)
+	return &claims, nil
 }

--- a/selfservice/strategy/oidc/provider_slack.go
+++ b/selfservice/strategy/oidc/provider_slack.go
@@ -72,7 +72,7 @@ func (d *ProviderSlack) Claims(ctx context.Context, exchange *oauth2.Token) (*Cl
 		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
 	}
 
-	claims := &Claims{
+	basicClaims := BasicClaims{
 		Issuer:            "https://slack.com/oauth/",
 		Subject:           identity.User.ID,
 		Name:              identity.User.Name,
@@ -84,5 +84,6 @@ func (d *ProviderSlack) Claims(ctx context.Context, exchange *oauth2.Token) (*Cl
 		Team:              identity.Team.ID,
 	}
 
-	return claims, nil
+	claims := toClaims(basicClaims)
+	return &claims, nil
 }

--- a/selfservice/strategy/oidc/provider_vk.go
+++ b/selfservice/strategy/oidc/provider_vk.go
@@ -111,7 +111,7 @@ func (g *ProviderVK) Claims(ctx context.Context, exchange *oauth2.Token) (*Claim
 		gender = "male"
 	}
 
-	return &Claims{
+	basicClaims := BasicClaims{
 		Issuer:     u.String(),
 		Subject:    strconv.Itoa(user.Id),
 		GivenName:  user.FirstName,
@@ -121,5 +121,7 @@ func (g *ProviderVK) Claims(ctx context.Context, exchange *oauth2.Token) (*Claim
 		Email:      user.Email,
 		Gender:     gender,
 		Birthdate:  user.BirthDay,
-	}, nil
+	}
+	claims := toClaims(basicClaims)
+	return &claims, nil
 }

--- a/selfservice/strategy/oidc/provider_yandex.go
+++ b/selfservice/strategy/oidc/provider_yandex.go
@@ -96,7 +96,7 @@ func (g *ProviderYandex) Claims(ctx context.Context, exchange *oauth2.Token) (*C
 		user.Picture = ""
 	}
 
-	return &Claims{
+	basicClaims := BasicClaims{
 		Issuer:     u.String(),
 		Subject:    user.Id,
 		GivenName:  user.FirstName,
@@ -105,5 +105,7 @@ func (g *ProviderYandex) Claims(ctx context.Context, exchange *oauth2.Token) (*C
 		Email:      user.Email,
 		Gender:     user.Gender,
 		Birthdate:  user.BirthDay,
-	}, nil
+	}
+	claims := toClaims(basicClaims)
+	return &claims, nil
 }

--- a/selfservice/strategy/oidc/strategy_registration.go
+++ b/selfservice/strategy/oidc/strategy_registration.go
@@ -132,7 +132,7 @@ func (s *Strategy) processRegistration(w http.ResponseWriter, r *http.Request, a
 	}
 
 	var jsonClaims bytes.Buffer
-	if err := json.NewEncoder(&jsonClaims).Encode(claims); err != nil {
+	if err := json.NewEncoder(&jsonClaims).Encode(claims.AdditionalClaims); err != nil {
 		return nil, s.handleError(w, r, a, provider.Config().ID, nil, err)
 	}
 


### PR DESCRIPTION
Prior to this commit, it was not possible to get a claim that was previously requested with `requested_claims` or simply a non-common claim (like in our case "roles").

This commit introduces a concept of a BasicClaim (a struct that contains a list of common claims) and uses the former `Claim` type as a container of both `BasicClaim` and `AdditionalClaims map[string]interface{}`.

This way, we can use in jsonnet the `AdditionalClaims` property and thus get access of a `map[string]interface{}` that contains all the fields that are otherwise ignored in the BasicClaim.

The idea of keeping the two structs around is simply to maintain typing on common fields (since we use them a lot in the code). This avoids the problem of verifying if you have a key in the map and causing unecessary panics due to this change.

## Context

Our IdP returns some additional claims on top of the "common ones" described in [selfservice/strategy/oidc/provider.go](https://github.com/ory/kratos/blob/e4d021a037a6b44f8bd66372e9c260c640e87b9d/selfservice/strategy/oidc/provider.go#L16-L40). This causes the non-standard claims to be missing in the `claims` object used with the jsonnet mapper.

### Example of an `id_token`

```json
{
  "user_id": "0c5298d0-485e-47ab-9b08-0ce901b75e076",
  "user_name": "denysvitali",
  "name": "Denys Vitali",
  "given_name": "Denys",
  "family_name": "Vitali",
  "phone_number": "+41-58-123 45 67",
  "email": "Name.Surname@swisscom.com",
  "email_verified": true,
  "previous_logon_time": 1624546902,
  "user_attributes": {
    "employee_type": [
      "staff"
    ],
    "office": [
      "Zür-Har3"
    ],
    "department": [
      "DEV"
    ],
    "mobile_number": [
      "+41-79-123 45 67"
    ],
    "employee_id": [
      "1005428"
    ]
  },
  "roles": [
    "AD_Role1",
    "..."
  ],
  "sub": "0c5298d0-485e-47ab-9b08-0ce901b75e07"
}
```


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [X] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

I'm not entirely proud of my `toClaims(basicClaims BasicClaims) Claims` function, I'm open for suggestions ;)