### PR TITLE
fix: remove v0.5.3-alpha.1.pre.0 from version schema

### DIFF
--- a/.schema/version.schema.json
+++ b/.schema/version.schema.json
@@ -65,20 +65,6 @@
                 {
                     "properties": {
                         "version": {
-                            "const": "v0.5.3-alpha.1.pre.0"
-                        }
-                    }
-                },
-                {
-                    "$ref": "https://raw.githubusercontent.com/ory/kratos/v0.5.3-alpha.1.pre.0/.schema/config.schema.json"
-                }
-            ]
-        },
-        {
-            "allOf": [
-                {
-                    "properties": {
-                        "version": {
                             "const": "v0.5.3-alpha.1"
                         }
                     }


### PR DESCRIPTION
schema URLs for pre-release tags will not resolve as the tags get deleted after release. removing this version to avoid IDE/tooling errors when validating a `kratos.json` config file.

resolves ory/kratos#1485

## Related issue

See discussion with @zepatrik and @aeneasr at #1485

## Checklist

- [x ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x ] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x ] I have read the [security policy](../security/policy).
- [x ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).
