### PR TITLE
fix: <tag> need to be enclosed by single tick

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -4831,7 +4831,7 @@ keys in the forms key `{"methods": { "traits": { ... }, "password": { ... } }}`.
 - Updates issue and pull request templates
   ([#315](https://github.com/ory/kratos/issues/315))
   ([8b68db1](https://github.com/ory/kratos/commit/8b68db140a7fc1c0eaa9318c1759ea9d8d0c27df))
-- Use git checkout <tag> in quickstart
+- Use git checkout `<tag>` in quickstart
   ([#339](https://github.com/ory/kratos/issues/339))
   ([2d2562b](https://github.com/ory/kratos/commit/2d2562b587a69a2891ff29d927cb001e15d75b5d)),
   closes [#335](https://github.com/ory/kratos/issues/335)


### PR DESCRIPTION
## Related issue

#1523 

## Proposed changes

The file `docs/CHANGELOG.md`  generating error when it is running `npm start`

The fix is to add backtick in the `<tag>` text

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

