### PR TITLE
autogen(docs): add instruction for creating user

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,3 +28,13 @@ $ npm build
 
 This command generates static content into the `build` directory and can be
 served using any static contents hosting service.
+
+### Format
+
+```
+npm run format
+```
+
+This command formats all files configured in the `prettierTarget` inside the
+`package.json`. This command is recommended to run before committing any
+documentation changes.

--- a/docs/docs/self-service/flows/user-registration.mdx
+++ b/docs/docs/self-service/flows/user-registration.mdx
@@ -255,6 +255,49 @@ $ curl -s -X GET \
   }
 }
 ```
+## Registering New User Information
+
+Using the `/self-service/registration` with `POST` allows the creation of new user
+information
+
+```shell-session
+$ flowId=$(curl -s -X GET  -H "Accept: application/json" \
+  http://127.0.0.1:4433/self-service/registration/api  \
+  | jq -r '.id')
+
+$ curl -s -X POST  -H "Content-Type: application/json" \
+    -d '{"traits.email": "iminvisibleagain@google.com", \
+    "password": "__MY__PASSWORD__", \
+    "method": "password"}'     \
+    "http://127.0.0.1:4433/self-service/registration?flow=$flow" | jq
+```
+
+On successful response will get JSON response like the following:
+
+```
+{
+  "session_token": "bccG5X0diQLRNrIIH6d3mtTXDpMKKA2C",
+  "session": {
+    "id": "9242f3b6-624d-4bc5-9013-1a051e46b201",
+    "active": true,
+    "expires_at": "2021-07-13T13:40:48.517495939Z",
+    "authenticated_at": "2021-07-12T13:40:48.520295345Z",
+    "issued_at": "2021-07-12T13:40:48.517503557Z",
+    "identity": {
+      "id": "ebee92e2-a3ec-4896-9f4d-a014f41d53e9",
+      "schema_id": "default",
+      "schema_url": "http://127.0.0.1:4433/schemas/default",
+      "state": "active",
+      "state_changed_at": "2021-07-12T23:40:48.516418201+10:00",
+      "traits": {
+        "email": "iminvisibleagain@google.com",
+        "name": {}
+      },
+      ...
+      ...
+      ...
+}
+```
 
 ## Registration Form Payloads
 

--- a/docs/docs/self-service/flows/user-registration.mdx
+++ b/docs/docs/self-service/flows/user-registration.mdx
@@ -255,10 +255,11 @@ $ curl -s -X GET \
   }
 }
 ```
+
 ## Registering New User Information
 
-Using the `/self-service/registration` with `POST` allows the creation of new user
-information
+Using the `/self-service/registration` with `POST` allows the creation of new
+user information
 
 ```shell-session
 $ flowId=$(curl -s -X GET  -H "Accept: application/json" \


### PR DESCRIPTION
## Related issue

Going through the documentation http://localhost:3000/kratos/docs/next/self-service/flows/user-registration from `master` branch found out there is a gap in the document. It is not clear on how to create user registration using API call.

## Proposed changes

This PR add a small section on showing step showing how to add a user via API using `curl`

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

