### PR TITLE
refactor: Cleanup lint errors and add docstring to x

### DIFF
--- a/x/clean_url_test.go
+++ b/x/clean_url_test.go
@@ -29,6 +29,7 @@ func TestCleanPath(t *testing.T) {
 			require.NoError(t, err)
 			defer res.Body.Close()
 			body, err := ioutil.ReadAll(res.Body)
+			require.NoError(t, err)
 			assert.Equal(t, string(body), tc[1])
 		})
 	}

--- a/x/doc.go
+++ b/x/doc.go
@@ -1,0 +1,8 @@
+/*
+Package x provides various helpers that do not have an obvious home elsewhere.
+
+The contract implied here, is that:
+ - Package x does not depend on other parts of kratos
+ - Packages outside kratos do not depend on x.
+*/
+package x

--- a/x/nosurf_test.go
+++ b/x/nosurf_test.go
@@ -36,15 +36,13 @@ func TestNosurfBaseCookieHandler(t *testing.T) {
 	assert.False(t, cookie.Secure, "false because insecure dev mode")
 	assert.True(t, cookie.HttpOnly)
 
+	alNum := regexp.MustCompile("[a-zA-Z_0-9]+")
 	for i := 0; i < 10; i++ {
 		require.NoError(t, conf.Source().Set(config.ViperKeyPublicBaseURL, randx.MustString(16, randx.AlphaNum)))
 		cookie := x.NosurfBaseCookieHandler(reg)(httptest.NewRecorder(), httptest.NewRequest("GET", "https://foo/bar", nil))
 
 		assert.NotEqual(t, "aHR0cDovL2Zvby5jb20vYmFy_csrf_token", cookie.Name, "should no longer be http://foo.com/bar")
-
-		matches, err := regexp.MatchString("[a-zA-Z_0-9]+", cookie.Name)
-		require.NoError(t, err)
-		assert.True(t, matches, "does not have any special chars")
+		assert.True(t, alNum.MatchString(cookie.Name), "does not have any special chars")
 	}
 
 	require.NoError(t, conf.Set(config.ViperKeyCookieSameSite, "None"))


### PR DESCRIPTION
The x package name is neither very descriptive nor has comment
describing what the package is. This addresses the latter.
Also fix two staticcheck warnings by doing minor restructuring of
two tests.
