### PR TITLE
fix: skip prompt on discord authorization by default

### DIFF
--- a/selfservice/strategy/oidc/provider_discord.go
+++ b/selfservice/strategy/oidc/provider_discord.go
@@ -56,7 +56,9 @@ func (d *ProviderDiscord) AuthCodeURLOptions(r ider) []oauth2.AuthCodeOption {
 			oauth2.SetAuthURLParam("prompt", "consent"),
 		}
 	}
-	return []oauth2.AuthCodeOption{}
+	return []oauth2.AuthCodeOption{
+		oauth2.SetAuthURLParam("prompt", "none"),
+	}
 }
 
 func (d *ProviderDiscord) Claims(ctx context.Context, exchange *oauth2.Token) (*Claims, error) {


### PR DESCRIPTION
When a value for prompt isn't provided, discord defaults prompt="consent". This change makes it so that if isForced is not true, prompt is "none". I didn't find any tests in the original commit that added this provider and I haven't run the tests locally, so I'm hoping CI can make sure I don't break anything :)

## Related issue(s)

#1593

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).
