### PR TITLE
docs: Update docker.md - Outdated information

### DIFF
--- a/docs/docs/guides/docker.md
+++ b/docs/docs/guides/docker.md
@@ -84,10 +84,10 @@ FROM oryd/kratos:latest
 COPY contrib/quickstart/kratos/email-password/kratos.yml /home/ory
 ```
 
-**Note that in both cases**, you must supply the location of the configuration file using the `--config` flag when running the container.
+**Note that in both cases**, you must supply the location of the configuration
+file using the `--config` flag when running the container.
 
 `$ docker run <theimage> --config /home/ory/kratos.yml`
-
 
 ### Examples
 

--- a/docs/docs/guides/docker.md
+++ b/docs/docs/guides/docker.md
@@ -52,8 +52,7 @@ verify signatures and encrypt things:
 
 ### Volumes
 
-If the file `$HOME/.kratos.yaml` exists, it will be used as the configuration
-file. The provided Kratos Docker images currently do not include a default
+The provided Kratos Docker images currently do not include a default
 configuration file, but make it easy to pass in your own configuration file(s)
 by either binding a local directory or by creating your own custom Docker Image
 and adding the configuration file(s) to the custom image.
@@ -84,6 +83,11 @@ below:
 FROM oryd/kratos:latest
 COPY contrib/quickstart/kratos/email-password/kratos.yml /home/ory
 ```
+
+**Note that in both cases**, you must supply the location of the configuration file using the `--config` flag when running the container.
+
+`$ docker run <theimage> --config /home/ory/kratos.yml`
+
 
 ### Examples
 


### PR DESCRIPTION
Kratos does not automatically use a config file that exists at `$HOME/.kratos.yaml`, or any other similar pattern. The documentation in the Docker Images section of the guides could lead developers to believe that the --config flag is unnecessary if they are binding the directory the configuration file is in to $HOME or using a custom docker image to provide the file.

This will make Kratos easier to work with for people starting out.

```
BREAKING CHANGES: None.
```


## Related issue(s)

https://github.com/ory/kratos/issues/1619


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
