### PR TITLE
fix: update node.txt

### DIFF
--- a/docs/versioned_docs/version-v0.7/self-service/flows/code/logout/samples/browser/node.txt
+++ b/docs/versioned_docs/version-v0.7/self-service/flows/code/logout/samples/browser/node.txt
@@ -1,10 +1,8 @@
-import { Configuration, PublicApi } from '@ory/kratos-client';
-const kratos = new PublicApi(new Configuration({ basePath: 'https://playground.projects.oryapis.com/api/kratos/public/' }));
-
-const flowId = '' // usually something like: req.query.flow
+import { Configuration, V0alpha1Api } from '@ory/kratos-client';
+const kratos = new V0alpha1Api(new Configuration({ basePath: 'https://playground.projects.oryapis.com/api/kratos/public/' }));
 
 const route = (req: Request, res: Response) => {
-  kratos.createSelfServiceLogoutUrlForBrowsers(req.cookies['ory_kratos_session']).then(({data}) => {
+  kratos.createSelfServiceLogoutFlowUrlForBrowsers(req.cookies['ory_kratos_session']).then(({data}) => {
     .then(({ data }) => {
       console.log(data.logout_url) // The logout URL
 


### PR DESCRIPTION
fix: naming of createSelfServiceLogoutUrlForBrowsers

"@ory/kratos-client": "^0.7.1-alpha.1" doesn't have function **createSelfServiceLogoutUrlForBrowsers**. Renamed  createSelfServiceLogoutUrlForBrowsers to createSelfServiceLogout**Flow**UrlForBrowsers


## Related issue(s)

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [ x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [ x] I have read the [security policy](../security/policy).
- [ x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ x] I have added or changed [the documentation](docs/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
