### PR TITLE
fix: static parameter for warning message in config.baseURL(...)

### DIFF
--- a/driver/config/config.go
+++ b/driver/config/config.go
@@ -568,13 +568,13 @@ func (p *Config) baseURL(keyURL, keyHost, keyPort string, defaultPort int) *url.
 	case string:
 		parsed, err := url.ParseRequestURI(t)
 		if err != nil {
-			p.l.WithError(err).Errorf("Configuration key %s is not a valid URL. Falling back to optimistically guessing the server's base URL. Please set a value to avoid problems with redirects and cookies.", ViperKeyPublicBaseURL)
+			p.l.WithError(err).Errorf("Configuration key %s is not a valid URL. Falling back to optimistically guessing the server's base URL. Please set a value to avoid problems with redirects and cookies.", keyURL)
 			return p.guessBaseURL(keyHost, keyPort, defaultPort)
 		}
 		return parsed
 	}
 
-	p.l.Warnf("Configuration key %s was left empty. Optimistically guessing the server's base URL. Please set a value to avoid problems with redirects and cookies.", ViperKeyPublicBaseURL)
+	p.l.Warnf("Configuration key %s was left empty. Optimistically guessing the server's base URL. Please set a value to avoid problems with redirects and cookies.", keyURL)
 	return p.guessBaseURL(keyHost, keyPort, defaultPort)
 }
 


### PR DESCRIPTION
- replaced ViperKeyPublicBaseURL with keyURL in function baseURL(..) to produce correct warning message


## Related issue(s)
https://github.com/ory/kratos/issues/1672

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works. - only formatting
- [ ] I have added or changed [the documentation](docs/docs). - not needed
