### PR TITLE
fix: outdated label

### DIFF
--- a/docs/docs/concepts/security.mdx
+++ b/docs/docs/concepts/security.mdx
@@ -195,7 +195,7 @@ Password-based authentication flows are subject to frequent abuse through
 :::info
 
 Further improvements are work in progress and are tracked on
-[GitHub](https://github.com/ory/kratos/labels/package%2Fselfservice%2Fpassword)
+[GitHub](https://github.com/ory/kratos/labels/package%2Fselfservice%2Fpassword).
 
 :::
 
@@ -269,12 +269,12 @@ Ory Kratos implements a password policy that:
   [HIBP API](https://haveibeenpwned.com/API/v2),
 - Checks if a password is too similar to one of the identifiers (in a future
   release [kratos#184](https://github.com/ory/kratos/issues/184)),
-- Makes passwords not expire.
+- Does not expire passwords.
 
 This is a rundown of all the practices Ory Kratos implements and why. **Some
 things need to be implemented by yourself** as they must be implemented in the
-User Interface that interfaces with Ory Kratos. You can find these in section
-[User Interface Guidelines](#user-interface-guidelines).
+User Interface that interfaces with Ory Kratos. You can find these in the
+[User Interface Guidelines](#user-interface-guidelines) section.
 
 ##### Password Complexity
 

--- a/docs/docs/concepts/security.mdx
+++ b/docs/docs/concepts/security.mdx
@@ -195,7 +195,7 @@ Password-based authentication flows are subject to frequent abuse through
 :::info
 
 Further improvements are work in progress and are tracked on
-[GitHub](https://github.com/ory/kratos/issues?q=is%3Aopen+label%3Amodule%3Ass%2Fpassword+)
+[GitHub](https://github.com/ory/kratos/labels/package%2Fselfservice%2Fpassword)
 
 :::
 

--- a/docs/versioned_docs/version-v0.7/concepts/security.mdx
+++ b/docs/versioned_docs/version-v0.7/concepts/security.mdx
@@ -269,12 +269,12 @@ Ory Kratos implements a password policy that:
   [HIBP API](https://haveibeenpwned.com/API/v2),
 - Checks if a password is too similar to one of the identifiers (in a future
   release [kratos#184](https://github.com/ory/kratos/issues/184)),
-- Makes passwords not expire.
+- Does not expire passwords.
 
 This is a rundown of all the practices Ory Kratos implements and why. **Some
 things need to be implemented by yourself** as they must be implemented in the
-User Interface that interfaces with Ory Kratos. You can find these in section
-[User Interface Guidelines](#user-interface-guidelines).
+User Interface that interfaces with Ory Kratos. You can find these in the [User Interface Guidelines](#user-interface-guidelines) section.
+
 
 ##### Password Complexity
 

--- a/docs/versioned_docs/version-v0.7/concepts/security.mdx
+++ b/docs/versioned_docs/version-v0.7/concepts/security.mdx
@@ -195,7 +195,7 @@ Password-based authentication flows are subject to frequent abuse through
 :::info
 
 Further improvements are work in progress and are tracked on
-[GitHub](https://github.com/ory/kratos/issues?q=is%3Aopen+label%3Amodule%3Ass%2Fpassword+)
+[GitHub](https://github.com/ory/kratos/labels/package%2Fselfservice%2Fpassword)
 
 :::
 


### PR DESCRIPTION
just came across this, I think the `module:ss/password` label is not used anymore. 
Also tweaked two sentences a bit that sounded off.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
