### PR TITLE
fix: facebook connect bug

### DIFF
--- a/selfservice/strategy/oidc/provider_facebook.go
+++ b/selfservice/strategy/oidc/provider_facebook.go
@@ -20,7 +20,7 @@ func NewProviderFacebook(
 	config *Configuration,
 	public *url.URL,
 ) *ProviderFacebook {
-	config.IssuerURL = "https://facebook.com"
+	config.IssuerURL = "https://www.facebook.com"
 	return &ProviderFacebook{
 		ProviderGenericOIDC: &ProviderGenericOIDC{
 			config: config,


### PR DESCRIPTION
After updating to version 0.7 Facebook Connect stopped working and we can find errors in the logs:
```
Unable to initialize OpenID Connect Provider: oidc: issuer did not match the issuer returned by provider, expected \"https://facebook.com\" got \"https://www.facebook.com\"
```
It's a minimal change that adds www to the issuer url

## Related issue(s)
https://github.com/ory/kratos/issues/1687

https://github.com/ory/kratos/issues/1686

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
