### PR TITLE
fix: adding the link to documentation section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ a few things you can do to help out:
 - **Reviewing documentation changes.** Most documentation just needs a review
   for proper spelling and grammar. If you think a document can be improved in
   any way, feel free to hit the `edit` button at the top of the page. More info
-  on contributing to documentation here.
+  on contributing to documentation [here](#documentation).
 
 - **Help with tests.** Some pull requests may lack proper tests or test plans.
   These are needed for the change to be implemented safely.


### PR DESCRIPTION
a link for (#documentation) was missing, so I added the link to the last sentence in "How can I contribute?" section.
I didn't find any develop branch, so I raised the pr for master branch, if I have to change it, please let me know.
