### PR TITLE
feat github-app provider

### DIFF
--- a/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
+++ b/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
@@ -237,7 +237,8 @@ Slack is now an option to log in via Kratos.
 />
 
 To set up "Sign in with GitHub" you must create either a
-[GitHub OAuth2 Client](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/) or
+[GitHub OAuth2 Client](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/)
+or
 [GitHub App Client](https://docs.github.com/en/developers/apps/building-github-apps/creating-a-github-app).
 
 Set the "Authorization callback URL" to:
@@ -267,8 +268,8 @@ at
 Not all GitHub fields are supported however. Check the list of supported fields
 [in Kratos' source code](https://github.com/ory/kratos/blob/v0.2.1-alpha.1/selfservice/strategy/oidc/provider_github.go#L72-L98).
 
-Only for `Github Oauth2` as `GitHub App` does not have scope.
-See the [Differences between GitHub Apps and OAuth2](https://docs.github.com/en/developers/apps/getting-started-with-apps/differences-between-github-apps-and-oauth-apps)
+Only for `Github Oauth2` as `GitHub App` does not have scope. See the
+[Differences between GitHub Apps and OAuth2](https://docs.github.com/en/developers/apps/getting-started-with-apps/differences-between-github-apps-and-oauth-apps)
 
 :::
 
@@ -337,7 +338,6 @@ selfservice:
             client_secret: .... # Replace this with the OAuth2 Client Secret provided by GitHub
             mapper_url: file:///etc/config/kratos/oidc.github.jsonnet
 ```
-
 
 Next, open the login endpoint of the SecureApp and you should see the GitHub
 Login option!

--- a/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
+++ b/docs/docs/guides/sign-in-with-github-google-facebook-linkedin.mdx
@@ -236,8 +236,9 @@ Slack is now an option to log in via Kratos.
   allowfullscreen
 />
 
-To set up "Sign in with GitHub" you must create a
-[GitHub OAuth2 Client](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/).
+To set up "Sign in with GitHub" you must create either a
+[GitHub OAuth2 Client](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/) or
+[GitHub App Client](https://docs.github.com/en/developers/apps/building-github-apps/creating-a-github-app).
 
 Set the "Authorization callback URL" to:
 
@@ -265,6 +266,9 @@ at
 [GitHub's Scope Docs](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
 Not all GitHub fields are supported however. Check the list of supported fields
 [in Kratos' source code](https://github.com/ory/kratos/blob/v0.2.1-alpha.1/selfservice/strategy/oidc/provider_github.go#L72-L98).
+
+Only for `Github Oauth2` as `GitHub App` does not have scope.
+See the [Differences between GitHub Apps and OAuth2](https://docs.github.com/en/developers/apps/getting-started-with-apps/differences-between-github-apps-and-oauth-apps)
 
 :::
 
@@ -294,7 +298,9 @@ local claims = {
 }
 ```
 
-Now, enable the GitHub provider in the Ory Kratos config located at
+For `GitHub App` use `github-app` and for `GitHub OAuth2` use `github`
+
+Now, enable the GitHub OAuth2 provider in the Ory Kratos config located at
 `<kratos-directory>/contrib/quickstart/kratos/email-password/kratos.yml`.
 
 ```yaml title="contrib/quickstart/kratos/email-password/kratos.yml"
@@ -313,6 +319,25 @@ selfservice:
             scope:
               - user:email
 ```
+
+Or enable the GitHub App provider in the Ory Kratos config located at
+`<kratos-directory>/contrib/quickstart/kratos/email-password/kratos.yml`.
+
+```yaml title="contrib/quickstart/kratos/email-password/kratos.yml"
+# $ kratos -c path/to/my/kratos/config.yml serve
+selfservice:
+  methods:
+    oidc:
+      enabled: true
+      config:
+        providers:
+          - id: github # this is `<provider-id>` in the Authorization callback URL. DO NOT CHANGE IT ONCE SET!
+            provider: github-app
+            client_id: .... # Replace this with the OAuth2 Client ID provided by GitHub
+            client_secret: .... # Replace this with the OAuth2 Client Secret provided by GitHub
+            mapper_url: file:///etc/config/kratos/oidc.github.jsonnet
+```
+
 
 Next, open the login endpoint of the SecureApp and you should see the GitHub
 Login option!

--- a/driver/config/.schema/config.schema.json
+++ b/driver/config/.schema/config.schema.json
@@ -310,11 +310,12 @@
         },
         "provider": {
           "title": "Provider",
-          "description": "Can be one of github, gitlab, generic, google, microsoft, discord, slack, facebook, auth0, vk, yandex.",
+          "description": "Can be one of github, github-app, gitlab, generic, google, microsoft, discord, slack, facebook, auth0, vk, yandex.",
           "type": "string",
           "enum": [
             "github",
             "gitlab",
+            "gitlab-app",
             "generic",
             "google",
             "microsoft",

--- a/selfservice/strategy/oidc/provider_config.go
+++ b/selfservice/strategy/oidc/provider_config.go
@@ -20,6 +20,7 @@ type Configuration struct {
 	// - generic
 	// - google
 	// - github
+	// - github-app
 	// - gitlab
 	// - microsoft
 	// - discord
@@ -100,6 +101,8 @@ func (c ConfigurationCollection) Provider(id string, public *url.URL) (Provider,
 				return NewProviderGoogle(&p, public), nil
 			case addProviderName("github"):
 				return NewProviderGitHub(&p, public), nil
+			case addProviderName("github-app"):
+				return NewProviderGitHubApp(&p, public), nil
 			case addProviderName("gitlab"):
 				return NewProviderGitLab(&p, public), nil
 			case addProviderName("microsoft"):

--- a/selfservice/strategy/oidc/provider_github-app.go
+++ b/selfservice/strategy/oidc/provider_github-app.go
@@ -1,0 +1,90 @@
+package oidc
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/pkg/errors"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/github"
+
+	ghapi "github.com/google/go-github/v27/github"
+
+	"github.com/ory/herodot"
+)
+
+type ProviderGitHubApp struct {
+	config *Configuration
+	public *url.URL
+}
+
+func NewProviderGitHubApp(
+	config *Configuration,
+	public *url.URL,
+) *ProviderGitHubApp {
+	return &ProviderGitHubApp{
+		config: config,
+		public: public,
+	}
+}
+
+func (g *ProviderGitHubApp) Config() *Configuration {
+	return g.config
+}
+
+func (g *ProviderGitHubApp) oauth2() *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:     g.config.ClientID,
+		ClientSecret: g.config.ClientSecret,
+		Endpoint:     github.Endpoint,
+		Scopes:       g.config.Scope,
+		RedirectURL:  g.config.Redir(g.public),
+	}
+}
+
+func (g *ProviderGitHubApp) OAuth2(ctx context.Context) (*oauth2.Config, error) {
+	return g.oauth2(), nil
+}
+
+func (g *ProviderGitHubApp) AuthCodeURLOptions(r ider) []oauth2.AuthCodeOption {
+	return []oauth2.AuthCodeOption{}
+}
+
+func (g *ProviderGitHubApp) Claims(ctx context.Context, exchange *oauth2.Token) (*Claims, error) {
+	gh := ghapi.NewClient(g.oauth2().Client(ctx, exchange))
+
+	user, _, err := gh.Users.Get(ctx, "")
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+
+	claims := &Claims{
+		Subject:   fmt.Sprintf("%d", user.GetID()),
+		Issuer:    github.Endpoint.TokenURL,
+		Name:      user.GetName(),
+		Nickname:  user.GetLogin(),
+		Website:   user.GetBlog(),
+		Picture:   user.GetAvatarURL(),
+		Profile:   user.GetHTMLURL(),
+		UpdatedAt: user.GetUpdatedAt().Unix(),
+	}
+
+	// GitHub does not provide the user's private emails in the call to `/user`. Therefore, if scope "user:email" is set,
+	// we want to make another request to `/user/emails` and merge that with our claims.
+	emails, _, err := gh.Users.ListEmails(ctx, nil)
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+
+	for k, e := range emails {
+		// If it is the primary email or it's the last email (no primary email set?), set the email.
+		if e.GetPrimary() || k == len(emails) {
+			claims.Email = e.GetEmail()
+			claims.EmailVerified = e.GetVerified()
+			break
+		}
+	}
+
+	return claims, nil
+}


### PR DESCRIPTION
This change if for adding GitHub App as provider.
The main difference between GitHub Oauth2 and GitHub App here is that with GitHub App you can get the refresh token

@aeneasr 


## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further Comments

We can also remove part of code of the current GitHub provider as it cn handle both cases
