### PR TITLE
fix: omitempty for VerifiedAt and StateChangedAt

### DIFF
--- a/identity/handler.go
+++ b/identity/handler.go
@@ -220,7 +220,8 @@ func (h *Handler) create(w http.ResponseWriter, r *http.Request, _ httprouter.Pa
 		return
 	}
 
-	i := &Identity{SchemaID: cr.SchemaID, Traits: []byte(cr.Traits), State: StateActive, StateChangedAt: sqlxx.NullTime(time.Now())}
+	stateChangedAt := sqlxx.NullTime(time.Now())
+	i := &Identity{SchemaID: cr.SchemaID, Traits: []byte(cr.Traits), State: StateActive, StateChangedAt: &stateChangedAt}
 	if err := h.r.IdentityManager().Create(r.Context(), i); err != nil {
 		h.r.Writer().WriteError(w, r, err)
 		return
@@ -318,8 +319,10 @@ func (h *Handler) update(w http.ResponseWriter, r *http.Request, ps httprouter.P
 			h.r.Writer().WriteError(w, r, herodot.ErrBadRequest.WithReasonf("%s", err).WithWrap(err))
 		}
 
+		stateChangedAt := sqlxx.NullTime(time.Now())
+
 		identity.State = ur.State
-		identity.StateChangedAt = sqlxx.NullTime(time.Now())
+		identity.StateChangedAt = &stateChangedAt
 	}
 
 	identity.Traits = []byte(ur.Traits)

--- a/identity/handler_test.go
+++ b/identity/handler_test.go
@@ -164,10 +164,11 @@ func TestHandler(t *testing.T) {
 			for name, ts := range map[string]*httptest.Server{"public": publicTS, "admin": adminTS} {
 				t.Run("endpoint="+name, func(t *testing.T) {
 					res := send(t, ts, "POST", "/identities", http.StatusCreated, json.RawMessage(`{"traits": {"bar":"baz"}}`))
+					stateChangedAt := sqlxx.NullTime(res.Get("state_changed_at").Time())
 
 					i.Traits = []byte(res.Get("traits").Raw)
 					i.ID = x.ParseUUID(res.Get("id").String())
-					i.StateChangedAt = sqlxx.NullTime(res.Get("state_changed_at").Time())
+					i.StateChangedAt = &stateChangedAt
 					assert.NotEmpty(t, res.Get("id").String())
 
 					assert.EqualValues(t, "baz", res.Get("traits.bar").String(), "%s", res.Raw)

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -77,7 +77,7 @@ type Identity struct {
 	State State `json:"state" faker:"-" db:"state"`
 
 	// StateChangedAt contains the last time when the identity's state changed.
-	StateChangedAt sqlxx.NullTime `json:"state_changed_at" faker:"-" db:"state_changed_at"`
+	StateChangedAt *sqlxx.NullTime `json:"state_changed_at,omitempty" faker:"-" db:"state_changed_at"`
 
 	// Traits represent an identity's traits. The identity is able to create, modify, and delete traits
 	// in a self-service manner. The input will always be validated against the JSON Schema defined
@@ -208,6 +208,7 @@ func NewIdentity(traitsSchemaID string) *Identity {
 		traitsSchemaID = config.DefaultIdentityTraitsSchemaID
 	}
 
+	stateChangedAt := sqlxx.NullTime(time.Now())
 	return &Identity{
 		ID:                  x.NewUUID(),
 		Credentials:         map[CredentialsType]Credentials{},
@@ -215,7 +216,7 @@ func NewIdentity(traitsSchemaID string) *Identity {
 		SchemaID:            traitsSchemaID,
 		VerifiableAddresses: []VerifiableAddress{},
 		State:               StateActive,
-		StateChangedAt:      sqlxx.NullTime(time.Now()),
+		StateChangedAt:      &stateChangedAt,
 		l:                   new(sync.RWMutex),
 	}
 }

--- a/identity/identity_verification.go
+++ b/identity/identity_verification.go
@@ -68,7 +68,7 @@ type VerifiableAddress struct {
 	//
 	// example: 2014-01-01T23:28:56.782Z
 	// required: false
-	VerifiedAt sqlxx.NullTime `json:"verified_at,omitempty" faker:"-" db:"verified_at"`
+	VerifiedAt *sqlxx.NullTime `json:"verified_at,omitempty" faker:"-" db:"verified_at"`
 
 	// When this entry was created
 	//

--- a/identity/identity_verification_test.go
+++ b/identity/identity_verification_test.go
@@ -2,9 +2,10 @@ package identity
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ory/x/sqlxx"
 
 	"github.com/ory/kratos/x"
 )
@@ -12,11 +13,12 @@ import (
 func TestNewVerifiableEmailAddress(t *testing.T) {
 	iid := x.NewUUID()
 	a := NewVerifiableEmailAddress("foo@ory.sh", iid)
+	var nullTime *sqlxx.NullTime
 
 	assert.Equal(t, a.Value, "foo@ory.sh")
 	assert.Equal(t, a.Via, VerifiableAddressTypeEmail)
 	assert.Equal(t, a.Status, VerifiableAddressStatusPending)
 	assert.Equal(t, a.Verified, false)
-	assert.EqualValues(t, time.Time{}, a.VerifiedAt)
+	assert.EqualValues(t, nullTime, a.VerifiedAt)
 	assert.NotEmpty(t, a.ID)
 }

--- a/persistence/sql/migratest/fixtures/identity/196d8c1e-4f04-40f0-94b3-5ec43996b28a.json
+++ b/persistence/sql/migratest/fixtures/identity/196d8c1e-4f04-40f0-94b3-5ec43996b28a.json
@@ -3,7 +3,6 @@
   "schema_id": "default",
   "schema_url": "https://www.ory.sh/schemas/default",
   "state": "active",
-  "state_changed_at": null,
   "traits": {
     "email": "foobar@ory.sh"
   },

--- a/persistence/sql/migratest/fixtures/identity/2ae6a5a7-2983-49e7-a4d8-7740b37c88cb.json
+++ b/persistence/sql/migratest/fixtures/identity/2ae6a5a7-2983-49e7-a4d8-7740b37c88cb.json
@@ -3,7 +3,6 @@
   "schema_id": "default",
   "schema_url": "https://www.ory.sh/schemas/default",
   "state": "active",
-  "state_changed_at": null,
   "traits": {
     "email": "d7b10@ory.sh"
   },

--- a/persistence/sql/migratest/fixtures/identity/359963ec-b09b-4ea0-aece-fb4dd95f304a.json
+++ b/persistence/sql/migratest/fixtures/identity/359963ec-b09b-4ea0-aece-fb4dd95f304a.json
@@ -3,7 +3,6 @@
   "schema_id": "default",
   "schema_url": "https://www.ory.sh/schemas/default",
   "state": "active",
-  "state_changed_at": null,
   "traits": {
     "email": "d7b11@ory.sh"
   },

--- a/persistence/sql/migratest/fixtures/identity/5ff66179-c240-4703-b0d8-494592cefff5.json
+++ b/persistence/sql/migratest/fixtures/identity/5ff66179-c240-4703-b0d8-494592cefff5.json
@@ -3,7 +3,6 @@
   "schema_id": "default",
   "schema_url": "https://www.ory.sh/schemas/default",
   "state": "active",
-  "state_changed_at": null,
   "traits": {
     "email": "bazbar@ory.sh"
   },

--- a/persistence/sql/migratest/fixtures/identity/a251ebc2-880c-4f76-a8f3-38e6940eab0e.json
+++ b/persistence/sql/migratest/fixtures/identity/a251ebc2-880c-4f76-a8f3-38e6940eab0e.json
@@ -3,7 +3,6 @@
   "schema_id": "default",
   "schema_url": "https://www.ory.sh/schemas/default",
   "state": "active",
-  "state_changed_at": null,
   "traits": {
     "email": "foobar@ory.sh"
   },

--- a/persistence/sql/migratest/fixtures/identity/d7b9addb-ac15-4bc2-9fa5-562e0bf48755.json
+++ b/persistence/sql/migratest/fixtures/identity/d7b9addb-ac15-4bc2-9fa5-562e0bf48755.json
@@ -3,7 +3,6 @@
   "schema_id": "default",
   "schema_url": "https://www.ory.sh/schemas/default",
   "state": "active",
-  "state_changed_at": null,
   "traits": {
     "email": "d7b9@ory.sh"
   },

--- a/persistence/sql/migratest/fixtures/identity/ed253b2c-48ed-4c58-9b6f-1dc963c30a66.json
+++ b/persistence/sql/migratest/fixtures/identity/ed253b2c-48ed-4c58-9b6f-1dc963c30a66.json
@@ -3,7 +3,6 @@
   "schema_id": "default",
   "schema_url": "https://www.ory.sh/schemas/default",
   "state": "active",
-  "state_changed_at": null,
   "traits": {
     "email": "bazbar@ory.sh"
   },

--- a/persistence/sql/migratest/fixtures/identity_verification_address/45e867e9-2745-4f16-8dd4-84334a252b61.json
+++ b/persistence/sql/migratest/fixtures/identity_verification_address/45e867e9-2745-4f16-8dd4-84334a252b61.json
@@ -4,7 +4,6 @@
   "verified": false,
   "via": "email",
   "status": "pending",
-  "verified_at": null,
   "created_at": "2013-10-07T08:23:19Z",
   "updated_at": "2013-10-07T08:23:19Z"
 }

--- a/persistence/sql/migratest/fixtures/identity_verification_address/b2d59320-8564-4400-a39f-a22a497a23f1.json
+++ b/persistence/sql/migratest/fixtures/identity_verification_address/b2d59320-8564-4400-a39f-a22a497a23f1.json
@@ -4,7 +4,6 @@
   "verified": false,
   "via": "email",
   "status": "pending",
-  "verified_at": null,
   "created_at": "2013-10-07T08:23:19Z",
   "updated_at": "2013-10-07T08:23:19Z"
 }

--- a/persistence/sql/migratest/fixtures/identity_verification_address/c2427b6d-312b-46d9-9285-536db7ae11fd.json
+++ b/persistence/sql/migratest/fixtures/identity_verification_address/c2427b6d-312b-46d9-9285-536db7ae11fd.json
@@ -4,7 +4,6 @@
   "verified": false,
   "via": "email",
   "status": "pending",
-  "verified_at": null,
   "created_at": "2013-10-07T08:23:19Z",
   "updated_at": "2013-10-07T08:23:19Z"
 }

--- a/persistence/sql/migratest/fixtures/identity_verification_address/d4718a67-aec2-418d-8173-6ebc7bde3b86.json
+++ b/persistence/sql/migratest/fixtures/identity_verification_address/d4718a67-aec2-418d-8173-6ebc7bde3b86.json
@@ -4,7 +4,6 @@
   "verified": false,
   "via": "email",
   "status": "pending",
-  "verified_at": null,
   "created_at": "2013-10-07T08:23:19Z",
   "updated_at": "2013-10-07T08:23:19Z"
 }

--- a/persistence/sql/migratest/fixtures/session/8571e374-38f2-4f46-8ad3-b9d914e174d3.json
+++ b/persistence/sql/migratest/fixtures/session/8571e374-38f2-4f46-8ad3-b9d914e174d3.json
@@ -9,7 +9,6 @@
     "schema_id": "default",
     "schema_url": "https://www.ory.sh/schemas/default",
     "state": "active",
-    "state_changed_at": null,
     "traits": {
       "email": "bazbar@ory.sh"
     },
@@ -20,7 +19,6 @@
         "verified": false,
         "via": "email",
         "status": "pending",
-        "verified_at": null,
         "created_at": "2013-10-07T08:23:19Z",
         "updated_at": "2013-10-07T08:23:19Z"
       }

--- a/persistence/sql/migratest/fixtures/session/dcde5aaa-f789-4d3d-ae1f-76da8d57e67c.json
+++ b/persistence/sql/migratest/fixtures/session/dcde5aaa-f789-4d3d-ae1f-76da8d57e67c.json
@@ -9,7 +9,6 @@
     "schema_id": "default",
     "schema_url": "https://www.ory.sh/schemas/default",
     "state": "active",
-    "state_changed_at": null,
     "traits": {
       "email": "bazbar@ory.sh"
     },
@@ -20,7 +19,6 @@
         "verified": false,
         "via": "email",
         "status": "pending",
-        "verified_at": null,
         "created_at": "2013-10-07T08:23:19Z",
         "updated_at": "2013-10-07T08:23:19Z"
       }

--- a/persistence/sql/migratest/fixtures/session/f38cdebe-e567-42c9-a562-1bd4dee40998.json
+++ b/persistence/sql/migratest/fixtures/session/f38cdebe-e567-42c9-a562-1bd4dee40998.json
@@ -9,7 +9,6 @@
     "schema_id": "default",
     "schema_url": "https://www.ory.sh/schemas/default",
     "state": "active",
-    "state_changed_at": null,
     "traits": {
       "email": "bazbar@ory.sh"
     },
@@ -20,7 +19,6 @@
         "verified": false,
         "via": "email",
         "status": "pending",
-        "verified_at": null,
         "created_at": "2013-10-07T08:23:19Z",
         "updated_at": "2013-10-07T08:23:19Z"
       }

--- a/persistence/sql/migratest/fixtures/settings_flow/194c5b05-0487-4a11-bcbc-f301c9ff9678.json
+++ b/persistence/sql/migratest/fixtures/settings_flow/194c5b05-0487-4a11-bcbc-f301c9ff9678.json
@@ -14,7 +14,6 @@
     "schema_id": "default",
     "schema_url": "https://www.ory.sh/schemas/default",
     "state": "active",
-    "state_changed_at": null,
     "traits": {
       "email": "foobar@ory.sh"
     },
@@ -25,7 +24,6 @@
         "verified": false,
         "via": "email",
         "status": "pending",
-        "verified_at": null,
         "created_at": "2013-10-07T08:23:19Z",
         "updated_at": "2013-10-07T08:23:19Z"
       },
@@ -35,7 +33,6 @@
         "verified": false,
         "via": "email",
         "status": "pending",
-        "verified_at": null,
         "created_at": "2013-10-07T08:23:19Z",
         "updated_at": "2013-10-07T08:23:19Z"
       },
@@ -45,7 +42,6 @@
         "verified": false,
         "via": "email",
         "status": "pending",
-        "verified_at": null,
         "created_at": "2013-10-07T08:23:19Z",
         "updated_at": "2013-10-07T08:23:19Z"
       }

--- a/persistence/sql/migratest/fixtures/settings_flow/19ede218-928c-4e02-ab49-b76e12b34f31.json
+++ b/persistence/sql/migratest/fixtures/settings_flow/19ede218-928c-4e02-ab49-b76e12b34f31.json
@@ -15,7 +15,6 @@
     "schema_id": "default",
     "schema_url": "https://www.ory.sh/schemas/default",
     "state": "active",
-    "state_changed_at": null,
     "traits": {
       "email": "foobar@ory.sh"
     },
@@ -26,7 +25,6 @@
         "verified": false,
         "via": "email",
         "status": "pending",
-        "verified_at": null,
         "created_at": "2013-10-07T08:23:19Z",
         "updated_at": "2013-10-07T08:23:19Z"
       },
@@ -36,7 +34,6 @@
         "verified": false,
         "via": "email",
         "status": "pending",
-        "verified_at": null,
         "created_at": "2013-10-07T08:23:19Z",
         "updated_at": "2013-10-07T08:23:19Z"
       },
@@ -46,7 +43,6 @@
         "verified": false,
         "via": "email",
         "status": "pending",
-        "verified_at": null,
         "created_at": "2013-10-07T08:23:19Z",
         "updated_at": "2013-10-07T08:23:19Z"
       }

--- a/persistence/sql/migratest/fixtures/settings_flow/21c5f714-3089-49d2-b387-f244d4dd9e00.json
+++ b/persistence/sql/migratest/fixtures/settings_flow/21c5f714-3089-49d2-b387-f244d4dd9e00.json
@@ -15,7 +15,6 @@
     "schema_id": "default",
     "schema_url": "https://www.ory.sh/schemas/default",
     "state": "active",
-    "state_changed_at": null,
     "traits": {
       "email": "foobar@ory.sh"
     },
@@ -26,7 +25,6 @@
         "verified": false,
         "via": "email",
         "status": "pending",
-        "verified_at": null,
         "created_at": "2013-10-07T08:23:19Z",
         "updated_at": "2013-10-07T08:23:19Z"
       },
@@ -36,7 +34,6 @@
         "verified": false,
         "via": "email",
         "status": "pending",
-        "verified_at": null,
         "created_at": "2013-10-07T08:23:19Z",
         "updated_at": "2013-10-07T08:23:19Z"
       },
@@ -46,7 +43,6 @@
         "verified": false,
         "via": "email",
         "status": "pending",
-        "verified_at": null,
         "created_at": "2013-10-07T08:23:19Z",
         "updated_at": "2013-10-07T08:23:19Z"
       }

--- a/persistence/sql/migratest/fixtures/settings_flow/74fd6c53-7651-453e-90b8-2c5adbf911bb.json
+++ b/persistence/sql/migratest/fixtures/settings_flow/74fd6c53-7651-453e-90b8-2c5adbf911bb.json
@@ -14,7 +14,6 @@
     "schema_id": "default",
     "schema_url": "https://www.ory.sh/schemas/default",
     "state": "active",
-    "state_changed_at": null,
     "traits": {
       "email": "bazbar@ory.sh"
     },
@@ -25,7 +24,6 @@
         "verified": false,
         "via": "email",
         "status": "pending",
-        "verified_at": null,
         "created_at": "2013-10-07T08:23:19Z",
         "updated_at": "2013-10-07T08:23:19Z"
       }

--- a/persistence/sql/migratest/fixtures/settings_flow/77fe4fb3-2d4e-4532-b568-c44b0aece0aa.json
+++ b/persistence/sql/migratest/fixtures/settings_flow/77fe4fb3-2d4e-4532-b568-c44b0aece0aa.json
@@ -15,7 +15,6 @@
     "schema_id": "default",
     "schema_url": "https://www.ory.sh/schemas/default",
     "state": "active",
-    "state_changed_at": null,
     "traits": {
       "email": "foobar@ory.sh"
     },
@@ -26,7 +25,6 @@
         "verified": false,
         "via": "email",
         "status": "pending",
-        "verified_at": null,
         "created_at": "2013-10-07T08:23:19Z",
         "updated_at": "2013-10-07T08:23:19Z"
       },
@@ -36,7 +34,6 @@
         "verified": false,
         "via": "email",
         "status": "pending",
-        "verified_at": null,
         "created_at": "2013-10-07T08:23:19Z",
         "updated_at": "2013-10-07T08:23:19Z"
       },
@@ -46,7 +43,6 @@
         "verified": false,
         "via": "email",
         "status": "pending",
-        "verified_at": null,
         "created_at": "2013-10-07T08:23:19Z",
         "updated_at": "2013-10-07T08:23:19Z"
       }

--- a/persistence/sql/migratest/fixtures/settings_flow/90b4f970-b9ae-42bc-a0a7-73ec750e0aa1.json
+++ b/persistence/sql/migratest/fixtures/settings_flow/90b4f970-b9ae-42bc-a0a7-73ec750e0aa1.json
@@ -15,7 +15,6 @@
     "schema_id": "default",
     "schema_url": "https://www.ory.sh/schemas/default",
     "state": "active",
-    "state_changed_at": null,
     "traits": {
       "email": "foobar@ory.sh"
     },
@@ -26,7 +25,6 @@
         "verified": false,
         "via": "email",
         "status": "pending",
-        "verified_at": null,
         "created_at": "2013-10-07T08:23:19Z",
         "updated_at": "2013-10-07T08:23:19Z"
       },
@@ -36,7 +34,6 @@
         "verified": false,
         "via": "email",
         "status": "pending",
-        "verified_at": null,
         "created_at": "2013-10-07T08:23:19Z",
         "updated_at": "2013-10-07T08:23:19Z"
       },
@@ -46,7 +43,6 @@
         "verified": false,
         "via": "email",
         "status": "pending",
-        "verified_at": null,
         "created_at": "2013-10-07T08:23:19Z",
         "updated_at": "2013-10-07T08:23:19Z"
       }

--- a/persistence/sql/migratest/fixtures/settings_flow/a79bfcf1-68ae-49de-8b23-4f96921b8341.json
+++ b/persistence/sql/migratest/fixtures/settings_flow/a79bfcf1-68ae-49de-8b23-4f96921b8341.json
@@ -15,7 +15,6 @@
     "schema_id": "default",
     "schema_url": "https://www.ory.sh/schemas/default",
     "state": "active",
-    "state_changed_at": null,
     "traits": {
       "email": "foobar@ory.sh"
     },
@@ -26,7 +25,6 @@
         "verified": false,
         "via": "email",
         "status": "pending",
-        "verified_at": null,
         "created_at": "2013-10-07T08:23:19Z",
         "updated_at": "2013-10-07T08:23:19Z"
       },
@@ -36,7 +34,6 @@
         "verified": false,
         "via": "email",
         "status": "pending",
-        "verified_at": null,
         "created_at": "2013-10-07T08:23:19Z",
         "updated_at": "2013-10-07T08:23:19Z"
       },
@@ -46,7 +43,6 @@
         "verified": false,
         "via": "email",
         "status": "pending",
-        "verified_at": null,
         "created_at": "2013-10-07T08:23:19Z",
         "updated_at": "2013-10-07T08:23:19Z"
       }

--- a/persistence/sql/migratest/fixtures/settings_flow/aeba85bd-1a8c-44bf-8fc3-3be83c01a3dc.json
+++ b/persistence/sql/migratest/fixtures/settings_flow/aeba85bd-1a8c-44bf-8fc3-3be83c01a3dc.json
@@ -15,7 +15,6 @@
     "schema_id": "default",
     "schema_url": "https://www.ory.sh/schemas/default",
     "state": "active",
-    "state_changed_at": null,
     "traits": {
       "email": "foobar@ory.sh"
     },
@@ -26,7 +25,6 @@
         "verified": false,
         "via": "email",
         "status": "pending",
-        "verified_at": null,
         "created_at": "2013-10-07T08:23:19Z",
         "updated_at": "2013-10-07T08:23:19Z"
       },
@@ -36,7 +34,6 @@
         "verified": false,
         "via": "email",
         "status": "pending",
-        "verified_at": null,
         "created_at": "2013-10-07T08:23:19Z",
         "updated_at": "2013-10-07T08:23:19Z"
       },
@@ -46,7 +43,6 @@
         "verified": false,
         "via": "email",
         "status": "pending",
-        "verified_at": null,
         "created_at": "2013-10-07T08:23:19Z",
         "updated_at": "2013-10-07T08:23:19Z"
       }

--- a/persistence/sql/migratest/fixtures/settings_flow/cdfd1eed-34a4-491d-ad0a-7579d3a0a7ba.json
+++ b/persistence/sql/migratest/fixtures/settings_flow/cdfd1eed-34a4-491d-ad0a-7579d3a0a7ba.json
@@ -15,7 +15,6 @@
     "schema_id": "default",
     "schema_url": "https://www.ory.sh/schemas/default",
     "state": "active",
-    "state_changed_at": null,
     "traits": {
       "email": "foobar@ory.sh"
     },
@@ -26,7 +25,6 @@
         "verified": false,
         "via": "email",
         "status": "pending",
-        "verified_at": null,
         "created_at": "2013-10-07T08:23:19Z",
         "updated_at": "2013-10-07T08:23:19Z"
       },
@@ -36,7 +34,6 @@
         "verified": false,
         "via": "email",
         "status": "pending",
-        "verified_at": null,
         "created_at": "2013-10-07T08:23:19Z",
         "updated_at": "2013-10-07T08:23:19Z"
       },
@@ -46,7 +43,6 @@
         "verified": false,
         "via": "email",
         "status": "pending",
-        "verified_at": null,
         "created_at": "2013-10-07T08:23:19Z",
         "updated_at": "2013-10-07T08:23:19Z"
       }

--- a/persistence/sql/persister_identity.go
+++ b/persistence/sql/persister_identity.go
@@ -213,7 +213,8 @@ func (p *Persister) CreateIdentity(ctx context.Context, i *identity.Identity) er
 		i.SchemaID = config.DefaultIdentityTraitsSchemaID
 	}
 
-	i.StateChangedAt = sqlxx.NullTime(time.Now())
+	stateChangedAt := sqlxx.NullTime(time.Now())
+	i.StateChangedAt = &stateChangedAt
 	if i.State == "" {
 		i.State = identity.StateActive
 	}

--- a/selfservice/hook/verification_test.go
+++ b/selfservice/hook/verification_test.go
@@ -59,9 +59,11 @@ func TestVerifier(t *testing.T) {
 			actual, err = reg.IdentityPool().FindVerifiableAddressByValue(context.Background(), identity.VerifiableAddressTypeEmail, "baz@ory.sh")
 			require.NoError(t, err)
 			assert.EqualValues(t, "baz@ory.sh", actual.Value)
+
+			verifiedAt := sqlxx.NullTime(time.Now())
 			actual.Status = identity.VerifiableAddressStatusCompleted
 			actual.Verified = true
-			actual.VerifiedAt = sqlxx.NullTime(time.Now())
+			actual.VerifiedAt = &verifiedAt
 			require.NoError(t, reg.PrivilegedIdentityPool().UpdateVerifiableAddress(context.Background(), actual))
 
 			i, err = reg.IdentityPool().GetIdentity(context.Background(), i.ID)

--- a/selfservice/strategy/link/strategy_verification.go
+++ b/selfservice/strategy/link/strategy_verification.go
@@ -238,7 +238,8 @@ func (s *Strategy) verificationUseToken(w http.ResponseWriter, r *http.Request, 
 
 	address := token.VerifiableAddress
 	address.Verified = true
-	address.VerifiedAt = sqlxx.NullTime(time.Now().UTC())
+	verifiedAt := sqlxx.NullTime(time.Now().UTC())
+	address.VerifiedAt = &verifiedAt
 	address.Status = identity.VerifiableAddressStatusCompleted
 	if err := s.d.PrivilegedIdentityPool().UpdateVerifiableAddress(r.Context(), address); err != nil {
 		return s.handleVerificationError(w, r, f, body, err)

--- a/selfservice/strategy/link/strategy_verification_test.go
+++ b/selfservice/strategy/link/strategy_verification_test.go
@@ -297,7 +297,7 @@ func TestVerification(t *testing.T) {
 			assert.EqualValues(t, verificationEmail, address.Value)
 			assert.True(t, address.Verified)
 			assert.EqualValues(t, identity.VerifiableAddressStatusCompleted, address.Status)
-			assert.True(t, time.Time(address.VerifiedAt).Add(time.Second*5).After(time.Now()))
+			assert.True(t, time.Time(*address.VerifiedAt).Add(time.Second*5).After(time.Now()))
 		}
 
 		var values = func(v url.Values) {

--- a/test/e2e/cypress/helpers/index.js
+++ b/test/e2e/cypress/helpers/index.js
@@ -13,7 +13,7 @@ const assertVerifiableAddress = ({ isVerified, email }) => ({ identity }) => {
   if (isVerified) {
     expect(address.verified_at).to.not.be.null
   } else {
-    expect(address.verified_at).to.be.null
+    expect(address).to.not.have.property('verified_at')
   }
 }
 


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

Currently the Python SDK is unusable because the spec doesn't match what Kratos actually returns. OpenAPI expects that Kratos only returns date-time strings for `state_changed_at` and `verified_at`. I think the original idea was that if `verified_at` was null it would be omitted entirely. The problem is that `omitempty` doesn't work for structs in Go, only pointers to structs. This means that `verified_at` is returned as null anyways from the API.

This PR changes VerifiedAt and StateChangedAt into pointers so that omitempty works as expected.

## Related issue(s)

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

https://github.com/ory/sdk/issues/95

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [X] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
