### PR TITLE
feat: custom smtp header config

### DIFF
--- a/courier/courier.go
+++ b/courier/courier.go
@@ -157,6 +157,12 @@ func (m *Courier) DispatchMessage(ctx context.Context, msg Message) error {
 
 		gm.SetHeader("To", msg.Recipient)
 		gm.SetHeader("Subject", msg.Subject)
+
+		headers := m.d.Config(ctx).CourierSMTPHeaders()
+		for k, v := range headers {
+			gm.SetHeader(k, v)
+		}
+
 		gm.SetBody("text/plain", msg.Body)
 
 		tmpl, err := NewEmailTemplateFromMessage(m.d.Config(ctx), msg)

--- a/courier/courier_test.go
+++ b/courier/courier_test.go
@@ -70,8 +70,12 @@ func TestSMTP(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, uuid.Nil, id)
 
-	// The third email contains a sender name
+	// The third email contains a sender name and custom headers
 	conf.MustSet(config.ViperKeyCourierSMTPFromName, "Bob")
+	conf.MustSet(config.ViperKeyCourierSMTPHeaders+".test-stub-header1", "foo")
+	conf.MustSet(config.ViperKeyCourierSMTPHeaders+".test-stub-header2", "bar")
+	customerHeaders := conf.CourierSMTPHeaders()
+	require.Len(t, customerHeaders, 2)
 	id, err = c.QueueEmail(ctx, templates.NewTestStub(conf, &templates.TestStubModel{
 		To:      "test-recipient-3@example.org",
 		Subject: "test-subject-3",
@@ -122,6 +126,8 @@ func TestSMTP(t *testing.T) {
 		assert.Contains(t, string(body), "test-stub@ory.sh")
 	}
 
-	// Assertion for the third email with sender name
+	// Assertion for the third email with sender name and headers
 	assert.Contains(t, string(body), "Bob")
+	assert.Contains(t, string(body), `"test-stub-header1":["foo"]`)
+	assert.Contains(t, string(body), `"test-stub-header2":["bar"]`)
 }

--- a/docs/docs/concepts/email-sms.md
+++ b/docs/docs/concepts/email-sms.md
@@ -112,6 +112,21 @@ Hi, please verify your account by clicking the following link:
 Hi, please verify your account by clicking the following link: {{ .VerificationURL }}
 ```
 
+### Custom Headers
+
+You can configure custom SMTP headers. For example, if integrating with AWS SES
+SMTP interface, the headers can be configured for cross-account sending:
+
+```yaml title="path/to/my/kratos/config.yml"
+# $ kratos -c path/to/my/kratos/config.yml serve
+courier:
+  smtp:
+    headers:
+      X-SES-SOURCE-ARN: arn:aws:ses:us-west-2:123456789012:identity/example.com
+      X-SES-FROM-ARN: arn:aws:ses:us-west-2:123456789012:identity/example.com
+      X-SES-RETURN-PATH-ARN: arn:aws:ses:us-west-2:123456789012:identity/example.com
+```
+
 ## Sending SMS
 
 The Sending SMS feature is not supported at present. It will be available in a

--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -2171,6 +2171,46 @@ courier:
     #
     from_name: Bob
 
+    ## SMTP Headers ##
+    #
+    # These headers will be passed in the SMTP conversation -- e.g. when using the AWS SES SMTP interface for cross-account sending.
+    #
+    # Examples:
+    # - X-SES-SOURCE-ARN: arn:aws:ses:us-west-2:123456789012:identity/example.com
+    #   X-SES-FROM-ARN: arn:aws:ses:us-west-2:123456789012:identity/example.com
+    #   X-SES-RETURN-PATH-ARN: arn:aws:ses:us-west-2:123456789012:identity/example.com
+    #
+    headers:
+      ## X-SES-SOURCE-ARN ##
+      #
+      # Set this value using environment variables on
+      # - Linux/macOS:
+      #    $ export COURIER_SMTP_HEADERS_X-SES-SOURCE-ARN=<value>
+      # - Windows Command Line (CMD):
+      #    > set COURIER_SMTP_HEADERS_X-SES-SOURCE-ARN=<value>
+      #
+      X-SES-SOURCE-ARN: arn:aws:ses:us-west-2:123456789012:identity/example.com
+
+      ## X-SES-FROM-ARN ##
+      #
+      # Set this value using environment variables on
+      # - Linux/macOS:
+      #    $ export COURIER_SMTP_HEADERS_X-SES-FROM-ARN=<value>
+      # - Windows Command Line (CMD):
+      #    > set COURIER_SMTP_HEADERS_X-SES-FROM-ARN=<value>
+      #
+      X-SES-FROM-ARN: arn:aws:ses:us-west-2:123456789012:identity/example.com
+
+      ## X-SES-RETURN-PATH-ARN ##
+      #
+      # Set this value using environment variables on
+      # - Linux/macOS:
+      #    $ export COURIER_SMTP_HEADERS_X-SES-RETURN-PATH-ARN=<value>
+      # - Windows Command Line (CMD):
+      #    > set COURIER_SMTP_HEADERS_X-SES-RETURN-PATH-ARN=<value>
+      #
+      X-SES-RETURN-PATH-ARN: arn:aws:ses:us-west-2:123456789012:identity/example.com
+
     ## SMTP Sender Address ##
     #
     # The recipient of an email will see this as the sender address.

--- a/driver/config/.schema/config.schema.json
+++ b/driver/config/.schema/config.schema.json
@@ -1098,6 +1098,18 @@
               "examples": [
                 "Bob"
               ]
+            },
+            "headers": {
+              "title": "SMTP Headers",
+              "description": "These headers will be passed in the SMTP conversation -- e.g. when using the AWS SES SMTP interface for cross-account sending.",
+              "type": "object",
+              "examples": [
+                {
+                  "X-SES-SOURCE-ARN": "arn:aws:ses:us-west-2:123456789012:identity/example.com",
+                  "X-SES-FROM-ARN": "arn:aws:ses:us-west-2:123456789012:identity/example.com",
+                  "X-SES-RETURN-PATH-ARN": "arn:aws:ses:us-west-2:123456789012:identity/example.com"
+                }
+              ]
             }
           },
           "required": [

--- a/driver/config/config.go
+++ b/driver/config/config.go
@@ -48,6 +48,7 @@ const (
 	ViperKeyCourierTemplatesPath                                    = "courier.template_override_path"
 	ViperKeyCourierSMTPFrom                                         = "courier.smtp.from_address"
 	ViperKeyCourierSMTPFromName                                     = "courier.smtp.from_name"
+	ViperKeyCourierSMTPHeaders                                      = "courier.smtp.headers"
 	ViperKeySecretsDefault                                          = "secrets.default"
 	ViperKeySecretsCookie                                           = "secrets.cookie"
 	ViperKeyPublicBaseURL                                           = "serve.public.base_url"
@@ -712,6 +713,10 @@ func (p *Config) CourierSMTPFromName() string {
 
 func (p *Config) CourierTemplatesRoot() string {
 	return p.p.StringF(ViperKeyCourierTemplatesPath, "courier/builtin/templates")
+}
+
+func (p *Config) CourierSMTPHeaders() map[string]string {
+	return p.p.StringMap(ViperKeyCourierSMTPHeaders)
 }
 
 func splitUrlAndFragment(s string) (string, string) {


### PR DESCRIPTION
This adds a simple configuration option for passing custom headers to the SMTP server.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)
https://github.com/ory/kratos/issues/1725
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further Comments

All automated tests pass for me locally, and I also confirmed with a manual test that the headers are propagated correctly to SES.  One thing I'm not quite sure how to test is the yaml config json schema validation.  It might be nice to add a `propertyNames.pattern` regex validation for the headers object and/or prohibit reserved headers like `To`, `Subject`, etc.  But, it works with these minimal changes.
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
