### PR TITLE
fix: typo tests in cmd/serve

### DIFF
--- a/internal/testhelpers/e2e_server.go
+++ b/internal/testhelpers/e2e_server.go
@@ -112,9 +112,10 @@ func waitToComeAlive(t *testing.T, publicUrl, adminUrl string) {
 			}
 		}
 		return nil
-	}),
+	},
 		retry.MaxDelay(time.Second),
-		retry.Attempts(60))
+		retry.Attempts(60)),
+	)
 }
 
 func CheckE2EServerOnHTTPS(t *testing.T, publicPort, adminPort int) (publicUrl, adminUrl string) {


### PR DESCRIPTION
Just fix tests in `cmd/serve` due to some typo.

## Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).
