### PR TITLE
Attempt to fix flaky tests when calling StartE2EServer()

### DIFF
--- a/internal/testhelpers/e2e_server.go
+++ b/internal/testhelpers/e2e_server.go
@@ -113,7 +113,7 @@ func waitToComeAlive(t *testing.T, publicUrl, adminUrl string) {
 		}
 		return nil
 	},
-		retry.MaxDelay(time.Second),
+		retry.MaxDelay(2*time.Second),
 		retry.Attempts(60)),
 	)
 }


### PR DESCRIPTION
It seems that tests are failing on the `master`. I don't have statistics since I do not (and can't) have access to CircleCI tests results but it seems that it boils down to `waitToComeAlive()` not being able to to succeed. I've increased the timeout for the health checks requests and it seems to help... we will see when this PR gets checked by CircleCI. Could be that the increased number of migrations is causing some issues but increasing the number of retries did not seem to help.

## Related issue(s)
None.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

