### PR TITLE
chore: update repository template to ec210015

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,2 +1,3 @@
 todo:
   keyword: "@todo"
+  label: todo


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/ec210015daa04f26c81a639228ace6f6e8abaf11.