### PR TITLE
fix: githup-app name in config

### DIFF
--- a/embedx/config.schema.json
+++ b/embedx/config.schema.json
@@ -314,8 +314,8 @@
           "type": "string",
           "enum": [
             "github",
+            "github-app",
             "gitlab",
-            "gitlab-app",
             "generic",
             "google",
             "microsoft",


### PR DESCRIPTION
There was an error, my bad, in  the config.schema.json with the name of the gitHub-app provider

## Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further Comments
