### PR TITLE
feat: Make windows install / usage instructions clearer

### DIFF
--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -49,7 +49,7 @@ $ kratos help
 
 You can install Ory Kratos using [scoop](https://scoop.sh) on Windows:
 
-- Note: You will need to use PowerShell to work with scoop / Kratos
+- You will need to use PowerShell to work with scoop / Kratos
 
 ```shell
 > scoop bucket add ory-kratos https://github.com/ory/scoop-kratos.git

--- a/docs/versioned_docs/version-v0.7/install.md
+++ b/docs/versioned_docs/version-v0.7/install.md
@@ -49,7 +49,7 @@ $ kratos help
 
 You can install Ory Kratos using [scoop](https://scoop.sh) on Windows:
 
-- Note: You will need to use PowerShell to work with scoop / Kratos
+- You will need to use PowerShell to work with scoop / Kratos
 
 ```shell
 > scoop bucket add ory-kratos https://github.com/ory/scoop-kratos.git


### PR DESCRIPTION
This change makes the windows install process / usage a bit more clear. It now explicitly states that when using Windows, the use of PowerShell is needed to properly use Kratos.

## Related issue(s)


## Checklist


- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).


