### PR TITLE
fix: Make health endpoints access logging configurable

### DIFF
--- a/cmd/daemon/serve.go
+++ b/cmd/daemon/serve.go
@@ -82,7 +82,14 @@ func ServePublic(r driver.Registry, wg *sync.WaitGroup, cmd *cobra.Command, args
 	for _, mw := range modifiers.mwf {
 		n.UseFunc(mw)
 	}
-	n.Use(reqlog.NewMiddlewareFromLogger(l, "public#"+c.SelfPublicURL(nil).String()))
+	publicLogger := reqlog.NewMiddlewareFromLogger(
+		l,
+		"public#"+c.SelfPublicURL(nil).String(),
+	)
+	if r.Config(ctx).DisablePublicHealthAccessLog() {
+		publicLogger.ExcludePaths(healthx.AliveCheckPath, healthx.ReadyCheckPath)
+	}
+	n.Use(publicLogger)
 	n.Use(sqa(ctx, cmd, r))
 	n.Use(r.PrometheusManager())
 
@@ -141,7 +148,14 @@ func ServeAdmin(r driver.Registry, wg *sync.WaitGroup, cmd *cobra.Command, args 
 	for _, mw := range modifiers.mwf {
 		n.UseFunc(mw)
 	}
-	n.Use(reqlog.NewMiddlewareFromLogger(l, "admin#"+c.SelfPublicURL(nil).String()))
+	adminLogger := reqlog.NewMiddlewareFromLogger(
+		l,
+		"admin#"+c.SelfPublicURL(nil).String(),
+	)
+	if r.Config(ctx).DisableAdminHealthAccessLog() {
+		adminLogger.ExcludePaths(healthx.AliveCheckPath, healthx.ReadyCheckPath)
+	}
+	n.Use(adminLogger)
 	n.Use(sqa(ctx, cmd, r))
 	n.Use(r.PrometheusManager())
 

--- a/cmd/daemon/serve.go
+++ b/cmd/daemon/serve.go
@@ -86,7 +86,7 @@ func ServePublic(r driver.Registry, wg *sync.WaitGroup, cmd *cobra.Command, args
 		l,
 		"public#"+c.SelfPublicURL(nil).String(),
 	)
-	if r.Config(ctx).DisablePublicHealthAccessLog() {
+	if r.Config(ctx).DisablePublicHealthRequestLog() {
 		publicLogger.ExcludePaths(healthx.AliveCheckPath, healthx.ReadyCheckPath)
 	}
 	n.Use(publicLogger)
@@ -152,7 +152,7 @@ func ServeAdmin(r driver.Registry, wg *sync.WaitGroup, cmd *cobra.Command, args 
 		l,
 		"admin#"+c.SelfPublicURL(nil).String(),
 	)
-	if r.Config(ctx).DisableAdminHealthAccessLog() {
+	if r.Config(ctx).DisableAdminHealthRequestLog() {
 		adminLogger.ExcludePaths(healthx.AliveCheckPath, healthx.ReadyCheckPath)
 	}
 	n.Use(adminLogger)

--- a/docs/docs/milestones.md
+++ b/docs/docs/milestones.md
@@ -33,13 +33,13 @@ Something is not working.
 - [ ] Fetching a settings request after error is missing identity data
       ([kratos#689](https://github.com/ory/kratos/issues/689)) -
       [@hackerman](https://github.com/aeneasr)
-- [ ] Feature Request: Have access to username in email templates
-      ([kratos#925](https://github.com/ory/kratos/issues/925))
 - [ ] Implement email TTL for non-working/non-existant emails
       ([kratos#944](https://github.com/ory/kratos/issues/944)) -
       [@hackerman](https://github.com/aeneasr)
 - [ ] Courier Watcher should start a (tracing-) span
       ([kratos#1886](https://github.com/ory/kratos/issues/1886))
+- [x] Feature Request: Have access to username in email templates
+      ([kratos#925](https://github.com/ory/kratos/issues/925))
 - [x] panic: a handle is already registered for path
       '/self-service/recovery/methods/link'
       ([kratos#1068](https://github.com/ory/kratos/issues/1068))
@@ -81,8 +81,6 @@ New feature or request.
       ([kratos#707](https://github.com/ory/kratos/issues/707))
 - [ ] improve multi schema handling in different auth flows
       ([kratos#765](https://github.com/ory/kratos/issues/765))
-- [ ] Add i18n support to mail templates
-      ([kratos#834](https://github.com/ory/kratos/issues/834))
 - [ ] Add option for disabling registration
       ([kratos#882](https://github.com/ory/kratos/issues/882)) -
       [@hackerman](https://github.com/aeneasr)
@@ -112,6 +110,8 @@ New feature or request.
 - [x] Validate identity schema on load
       ([kratos#701](https://github.com/ory/kratos/issues/701)) -
       [@Alano Terblanche](https://github.com/Benehiko)
+- [x] Add i18n support to mail templates
+      ([kratos#834](https://github.com/ory/kratos/issues/834))
 - [x] Allow account recovery for identities without email address
       ([kratos#1419](https://github.com/ory/kratos/issues/1419))
 - [x] Field validation answer status code 422 instead of 400

--- a/driver/config/config.go
+++ b/driver/config/config.go
@@ -64,6 +64,7 @@ const (
 	ViperKeySecretsDefault                                   = "secrets.default"
 	ViperKeySecretsCookie                                    = "secrets.cookie"
 	ViperKeySecretsCipher                                    = "secrets.cipher"
+	ViperKeyDisablePublicHealthAccessLog                     = "serve.public.access_log.disable_for_health"
 	ViperKeyPublicBaseURL                                    = "serve.public.base_url"
 	ViperKeyPublicDomainAliases                              = "serve.public.domain_aliases"
 	ViperKeyPublicPort                                       = "serve.public.port"
@@ -75,6 +76,7 @@ const (
 	ViperKeyPublicTLSKeyBase64                               = "serve.public.tls.key.base64"
 	ViperKeyPublicTLSCertPath                                = "serve.public.tls.cert.path"
 	ViperKeyPublicTLSKeyPath                                 = "serve.public.tls.key.path"
+	ViperKeyDisableAdminHealthAccessLog                      = "serve.admin.access_log.disable_for_health"
 	ViperKeyAdminBaseURL                                     = "serve.admin.base_url"
 	ViperKeyAdminPort                                        = "serve.admin.port"
 	ViperKeyAdminHost                                        = "serve.admin.host"
@@ -697,6 +699,10 @@ func (p *Config) baseURL(keyURL, keyHost, keyPort string, defaultPort int) *url.
 	return p.guessBaseURL(keyHost, keyPort, defaultPort)
 }
 
+func (p *Config) DisablePublicHealthAccessLog() bool {
+	return p.p.Bool(ViperKeyDisablePublicHealthAccessLog)
+}
+
 type DomainAlias struct {
 	BasePath    string `json:"base_path"`
 	Scheme      string `json:"scheme"`
@@ -747,6 +753,10 @@ func (p *Config) SelfPublicURL(r *http.Request) *url.URL {
 	}
 
 	return primary
+}
+
+func (p *Config) DisableAdminHealthAccessLog() bool {
+	return p.p.Bool(ViperKeyDisableAdminHealthAccessLog)
 }
 
 func (p *Config) SelfAdminURL() *url.URL {

--- a/driver/config/config.go
+++ b/driver/config/config.go
@@ -64,7 +64,7 @@ const (
 	ViperKeySecretsDefault                                   = "secrets.default"
 	ViperKeySecretsCookie                                    = "secrets.cookie"
 	ViperKeySecretsCipher                                    = "secrets.cipher"
-	ViperKeyDisablePublicHealthAccessLog                     = "serve.public.access_log.disable_for_health"
+	ViperKeyDisablePublicHealthRequestLog                    = "serve.public.request_log.disable_for_health"
 	ViperKeyPublicBaseURL                                    = "serve.public.base_url"
 	ViperKeyPublicDomainAliases                              = "serve.public.domain_aliases"
 	ViperKeyPublicPort                                       = "serve.public.port"
@@ -76,7 +76,7 @@ const (
 	ViperKeyPublicTLSKeyBase64                               = "serve.public.tls.key.base64"
 	ViperKeyPublicTLSCertPath                                = "serve.public.tls.cert.path"
 	ViperKeyPublicTLSKeyPath                                 = "serve.public.tls.key.path"
-	ViperKeyDisableAdminHealthAccessLog                      = "serve.admin.access_log.disable_for_health"
+	ViperKeyDisableAdminHealthRequestLog                     = "serve.admin.request_log.disable_for_health"
 	ViperKeyAdminBaseURL                                     = "serve.admin.base_url"
 	ViperKeyAdminPort                                        = "serve.admin.port"
 	ViperKeyAdminHost                                        = "serve.admin.host"
@@ -699,8 +699,8 @@ func (p *Config) baseURL(keyURL, keyHost, keyPort string, defaultPort int) *url.
 	return p.guessBaseURL(keyHost, keyPort, defaultPort)
 }
 
-func (p *Config) DisablePublicHealthAccessLog() bool {
-	return p.p.Bool(ViperKeyDisablePublicHealthAccessLog)
+func (p *Config) DisablePublicHealthRequestLog() bool {
+	return p.p.Bool(ViperKeyDisablePublicHealthRequestLog)
 }
 
 type DomainAlias struct {
@@ -755,8 +755,8 @@ func (p *Config) SelfPublicURL(r *http.Request) *url.URL {
 	return primary
 }
 
-func (p *Config) DisableAdminHealthAccessLog() bool {
-	return p.p.Bool(ViperKeyDisableAdminHealthAccessLog)
+func (p *Config) DisableAdminHealthRequestLog() bool {
+	return p.p.Bool(ViperKeyDisableAdminHealthRequestLog)
 }
 
 func (p *Config) SelfAdminURL() *url.URL {

--- a/embedx/config.schema.json
+++ b/embedx/config.schema.json
@@ -1350,6 +1350,16 @@
         "admin": {
           "type": "object",
           "properties": {
+            "access_log": {
+              "type": "object",
+              "properties": {
+                "disable_for_health": {
+                  "type": "boolean",
+                  "default": false
+                }
+              },
+              "additionalProperties": false
+            },
             "base_url": {
               "title": "Admin Base URL",
               "description": "The URL where the admin endpoint is exposed at.",
@@ -1388,6 +1398,16 @@
         "public": {
           "type": "object",
           "properties": {
+            "access_log": {
+              "type": "object",
+              "properties": {
+                "disable_for_health": {
+                  "type": "boolean",
+                  "default": false
+                }
+              },
+              "additionalProperties": false
+            },
             "cors": {
               "type": "object",
               "additionalProperties": false,

--- a/embedx/config.schema.json
+++ b/embedx/config.schema.json
@@ -1350,10 +1350,12 @@
         "admin": {
           "type": "object",
           "properties": {
-            "access_log": {
+            "request_log": {
               "type": "object",
               "properties": {
                 "disable_for_health": {
+                  "title": "Disable health endpoints request logging",
+                  "description": "Disable request logging for /health/alive and /health/ready endpoints",
                   "type": "boolean",
                   "default": false
                 }
@@ -1398,10 +1400,12 @@
         "public": {
           "type": "object",
           "properties": {
-            "access_log": {
+            "request_log": {
               "type": "object",
               "properties": {
                 "disable_for_health": {
+                  "title": "Disable health endpoints request logging",
+                  "description": "Disable request logging for /health/alive and /health/ready endpoints",
                   "type": "boolean",
                   "default": false
                 }


### PR DESCRIPTION
This PR introduces a new boolean configuration parameter that allows turning off logging of health endpoints requests in the access log. The implementation is basically a rip-off from Ory Hydra and the configuration parameter is the same:

```
serve.public.access_log.disable_for_health
serve.admin.access_log.disable_for_health
```
The default value is _false_.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further Comments

Couldn't find any documentation to update, so if I'm missing anything, please direct me to the right place.
