### PR TITLE
chore: use json.Marshal for the message context

### DIFF
--- a/docs/docs/concepts/ui-user-interface.mdx
+++ b/docs/docs/concepts/ui-user-interface.mdx
@@ -1330,8 +1330,8 @@ will be overwritten!
   "text": "Remove security key \"{name}\"",
   "type": "info",
   "context": {
-    "display_name": "{name}",
-    "added_at": "2020-01-01T00:59:59Z"
+    "added_at": "2020-01-01T00:59:59Z",
+    "display_name": "{name}"
   }
 }
 ```
@@ -1559,8 +1559,8 @@ will be overwritten!
   "text": "\"{value}\" is not valid \"{format}\"",
   "type": "error",
   "context": {
-    "expected_format": "{format}",
-    "actual_value": "{value}"
+    "actual_value": "{value}",
+    "expected_format": "{format}"
   }
 }
 ```

--- a/text/context.go
+++ b/text/context.go
@@ -1,15 +1,16 @@
 package text
 
-import "github.com/tidwall/sjson"
+import (
+	"encoding/json"
+)
 
 func context(ctx map[string]interface{}) []byte {
-	json := `{}`
-	var err error
-	for key, value := range ctx {
-		json, err = sjson.Set(json, key, value)
-		if err != nil {
-			panic(err)
-		}
+	if len(ctx) == 0 {
+		return []byte("{}")
 	}
-	return []byte(json)
+	res, err := json.Marshal(ctx)
+	if err != nil {
+		panic(err)
+	}
+	return res
 }


### PR DESCRIPTION
## Related issue(s)

The docs is auto-generating with useless changes, see e.g. https://github.com/ory/kratos/commit/64bf08d356051089bf163583ec382fdd16565c57 because we used `sjson` which does not order keys.
For less CI spam I am proposing to instead use `json.Marshal`. A quick benchmark shows that in this specific case `sjson` is only insignificantly faster:

<details>
  <summary>Go benchmark</summary>

```go
package sjsonbench_test

import (
	"encoding/json"
	"github.com/tidwall/sjson"
	"testing"
	"time"
)

var now = time.Now()

func BenchmarkSJSON(b *testing.B) {
	for i := 0; i < b.N; i++ {
		j := "{}"
		j, err := sjson.Set(j, "foobar", "some value")
		if err != nil {
			b.Errorf("error: %s", err)
		}
		j, err = sjson.Set(j, "asdf", 13241345)
		if err != nil {
			b.Errorf("error: %s", err)
		}
		j, err = sjson.Set(j, "jkhad", map[string]interface{}{"expired_at": now})
		if err != nil {
			b.Errorf("error: %s", err)
		}
	}
}

func BenchmarkGoJSON(b *testing.B) {
	for i := 0; i < b.N; i++ {
		_, err := json.Marshal(map[string]interface{}{
			"foobar": "some value",
			"asdf":   13241345,
			"jkhad":  map[string]interface{}{"expired_at": now},
		})
		if err != nil {
			b.Errorf("error: %s", err)
		}
	}
}

  ```
  
</details>

```
$ go test -bench .
goos: linux
goarch: amd64
pkg: sjsonbench
cpu: Intel(R) Core(TM) i7-7500U CPU @ 2.70GHz
BenchmarkSJSON-4          295066              4535 ns/op
BenchmarkGoJSON-4         234032              5213 ns/op
PASS
ok      sjsonbench      3.522s
$ # Without the third key
$ go test -bench .
goos: linux
goarch: amd64
pkg: sjsonbench
cpu: Intel(R) Core(TM) i7-7500U CPU @ 2.70GHz
BenchmarkSJSON-4          895790              1165 ns/op
BenchmarkGoJSON-4         675788              1684 ns/op
PASS
ok      sjsonbench      2.219s
```

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further Comments

Alternatively, we could also explicitly sort the keys before rendering the docs pages.