### PR TITLE
fix: Require minimum length of 8 characters password

### DIFF
--- a/selfservice/strategy/password/validator.go
+++ b/selfservice/strategy/password/validator.go
@@ -15,10 +15,11 @@ import (
 
 	"github.com/arbovm/levenshtein"
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/pkg/errors"
+
 	"github.com/ory/herodot"
 	"github.com/ory/x/httpx"
 	"github.com/ory/x/stringsx"
-	"github.com/pkg/errors"
 
 	"github.com/ory/kratos/driver/config"
 )

--- a/selfservice/strategy/password/validator.go
+++ b/selfservice/strategy/password/validator.go
@@ -3,11 +3,6 @@ package password
 import (
 	"bufio"
 	"context"
-	"time"
-
-	"github.com/hashicorp/go-retryablehttp"
-
-	"github.com/ory/kratos/driver/config"
 
 	/* #nosec G505 sha1 is used for k-anonymity */
 	"crypto/sha1"
@@ -16,15 +11,16 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/arbovm/levenshtein"
-
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/ory/herodot"
 	"github.com/ory/x/httpx"
-
+	"github.com/ory/x/stringsx"
 	"github.com/pkg/errors"
 
-	"github.com/ory/herodot"
-	"github.com/ory/x/stringsx"
+	"github.com/ory/kratos/driver/config"
 )
 
 // Validator implements a validation strategy for passwords. One example is that the password
@@ -145,8 +141,8 @@ func (s *DefaultPasswordValidator) fetch(hpw []byte, apiDNSName string) error {
 }
 
 func (s *DefaultPasswordValidator) Validate(ctx context.Context, identifier, password string) error {
-	if len(password) < 6 {
-		return errors.Errorf("password length must be at least 6 characters but only got %d", len(password))
+	if len(password) < 8 {
+		return errors.Errorf("password length must be at least 8 characters but only got %d", len(password))
 	}
 
 	compIdentifier, compPassword := strings.ToLower(identifier), strings.ToLower(password)

--- a/selfservice/strategy/password/validator_test.go
+++ b/selfservice/strategy/password/validator_test.go
@@ -63,11 +63,14 @@ func TestDefaultPasswordValidationStrategy(t *testing.T) {
 			{id: "asdflasdflasdf", pw: "asdflasdflpiuhefnciluaksdzuföfhg", pass: true},
 		} {
 			t.Run(fmt.Sprintf("case=%d", k), func(t *testing.T) {
-				err := s.Validate(context.Background(), tc.id, tc.pw)
-				if tc.pass {
-					require.NoError(t, err, "err: %+v, id: %s, pw: %s", err, tc.id, tc.pw)
+				c := tc
+				t.Parallel()
+
+				err := s.Validate(context.Background(), c.id, c.pw)
+				if c.pass {
+					require.NoError(t, err, "err: %+v, id: %s, pw: %s", err, c.id, c.pw)
 				} else {
-					require.Error(t, err, "id: %s, pw: %s", tc.id, tc.pw)
+					require.Error(t, err, "id: %s, pw: %s", c.id, c.pw)
 				}
 			})
 		}

--- a/selfservice/strategy/password/validator_test.go
+++ b/selfservice/strategy/password/validator_test.go
@@ -12,8 +12,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ory/x/httpx"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ory/x/httpx"
 
 	"github.com/ory/kratos/driver/config"
 	"github.com/ory/kratos/internal"

--- a/selfservice/strategy/password/validator_test.go
+++ b/selfservice/strategy/password/validator_test.go
@@ -57,7 +57,7 @@ func TestDefaultPasswordValidationStrategy(t *testing.T) {
 			{id: "hello@example.com", pw: "h3ll0@example", pass: false},
 			{pw: "hello@example.com", id: "hello@exam", pass: false},
 			{id: "abcd", pw: "9d3c8a1b", pass: true},
-			{id: "a", pw: "kjOkla", pass: true},
+			{id: "a", pw: "kjOklafe", pass: true},
 			{id: "ab", pw: "0000ab0000", pass: true},
 			// longest common substring with long password
 			{id: "d4f6090b-5a84", pw: "d4f6090b-5a84-2184-4404-8d1b-8da3eb00ebbe", pass: true},

--- a/selfservice/strategy/password/validator_test.go
+++ b/selfservice/strategy/password/validator_test.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/ory/x/httpx"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ory/kratos/driver/config"
@@ -42,6 +41,7 @@ func TestDefaultPasswordValidationStrategy(t *testing.T) {
 			{pw: "password", pass: false},
 			{pw: "1234567890", pass: false},
 			{pw: "qwertyui", pass: false},
+			{pw: "l3f9to", pass: false},
 			{pw: "l3f9toh1uaf81n21", pass: true},
 			{pw: "l3f9toh1uaf81n21", id: "l3f9toh1uaf81n21", pass: false},
 			{pw: "l3f9toh1", pass: true},
@@ -63,7 +63,6 @@ func TestDefaultPasswordValidationStrategy(t *testing.T) {
 			{id: "asdflasdflasdf", pw: "asdflasdflpiuhefnciluaksdzuföfhg", pass: true},
 		} {
 			t.Run(fmt.Sprintf("case=%d", k), func(t *testing.T) {
-				t.Parallel()
 				err := s.Validate(context.Background(), tc.id, tc.pw)
 				if tc.pass {
 					require.NoError(t, err, "err: %+v, id: %s, pw: %s", err, tc.id, tc.pw)

--- a/test/e2e/cypress/integration/profiles/email/registration/errors.spec.ts
+++ b/test/e2e/cypress/integration/profiles/email/registration/errors.spec.ts
@@ -36,8 +36,8 @@ describe('Registration failures with email profile', () => {
           .type(identity)
           .should('have.value', identity)
         cy.get('input[name="password"]')
-          .type('123456')
-          .should('have.value', '123456')
+          .type('12345678')
+          .should('have.value', '12345678')
 
         cy.shouldHaveCsrfError({ app })
       })
@@ -56,8 +56,8 @@ describe('Registration failures with email profile', () => {
             .type(identity)
             .should('have.value', identity)
           cy.get('input[name="password"]')
-            .type('123456')
-            .should('have.value', '123456')
+            .type('12345678')
+            .should('have.value', '12345678')
 
           cy.submitPasswordForm()
           cy.get('*[data-testid^="ui/message"]').should(

--- a/test/e2e/cypress/integration/profiles/email/settings/errors.spec.ts
+++ b/test/e2e/cypress/integration/profiles/email/settings/errors.spec.ts
@@ -149,7 +149,7 @@ context('Settings failures with email profile', () => {
         })
 
         it('fails if password policy is violated', () => {
-          cy.get('input[name="password"]').clear().type('123456')
+          cy.get('input[name="password"]').clear().type('12345678')
           cy.get('button[value="password"]').click()
           cy.get('*[data-testid^="ui/message"]').should(
             'contain.text',
@@ -282,7 +282,7 @@ context('Settings failures with email profile', () => {
 
       describe('global errors', () => {
         it('fails when CSRF is incorrect', () => {
-          cy.get(appPrefix(app) + 'input[name="password"]').type('123456')
+          cy.get(appPrefix(app) + 'input[name="password"]').type('12345678')
           cy.shouldHaveCsrfError({ app })
         })
 

--- a/test/e2e/cypress/integration/profiles/mfa/totp.spec.ts
+++ b/test/e2e/cypress/integration/profiles/mfa/totp.spec.ts
@@ -222,7 +222,7 @@ context('2FA lookup secrets', () => {
 
       it('should fail to set up totp if verify code is wrong', () => {
         cy.visit(settings)
-        cy.get('input[name="totp_code"]').type('123456')
+        cy.get('input[name="totp_code"]').type('12345678')
         cy.get('*[name="method"][value="totp"]').click()
         cy.get('[data-testid="ui/message/4000008"]').should(
           'contain.text',

--- a/test/e2e/cypress/integration/profiles/mobile/registration/errors.spec.ts
+++ b/test/e2e/cypress/integration/profiles/mobile/registration/errors.spec.ts
@@ -16,7 +16,7 @@ context('Mobile Profile', () => {
     describe('show errors when invalid signup data is used', () => {
       it('should show an error when the password has leaked before', () => {
         cy.get('input[data-testid="traits.email"]').type(email)
-        cy.get('input[data-testid="password"]').type('123456')
+        cy.get('input[data-testid="password"]').type('12345678')
         cy.get('input[data-testid="traits.website"]').type(website)
         cy.get('div[data-testid="submit-form"]').click()
 


### PR DESCRIPTION
## Related issue(s)

Kratos follows [NIST Digital Identity Guidelines - 5.1.1.2 Memorized Secret Verifiers](https://pages.nist.gov/800-63-3/sp800-63b.html) and [password policy](https://www.ory.sh/kratos/docs/concepts/security#password-policy) says

> Passwords must have a minimum length of 8 characters and all characters (unicode, ASCII) must be allowed:

but currently Kratos requires 6 chars minimum. So I fixed to 8 chars.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
