### PR TITLE
docs: Add content-type to allowed headers

### DIFF
--- a/docs/docs/guides/setting-up-cors.mdx
+++ b/docs/docs/guides/setting-up-cors.mdx
@@ -26,6 +26,7 @@ serve:
       allowed_headers:
         - Authorization
         - Cookie
+        - Content-Type
       exposed_headers:
         - Content-Type
         - Set-Cookie

--- a/docs/versioned_docs/version-v0.8/guides/setting-up-cors.mdx
+++ b/docs/versioned_docs/version-v0.8/guides/setting-up-cors.mdx
@@ -26,6 +26,7 @@ serve:
       allowed_headers:
         - Authorization
         - Cookie
+        - Content-Type
       exposed_headers:
         - Content-Type
         - Set-Cookie


### PR DESCRIPTION
It's a documentation update. Cors fails in case when Kratos public is not on the same subdomain as client. 
I could be fixed by adding `Content-Type` to allow headers. 
Refer to https://github.com/ory/kratos/discussions/1993

