### PR TITLE
docs: improve text around bcrypt

### DIFF
--- a/docs/docs/concepts/credentials/username-email-password.mdx
+++ b/docs/docs/concepts/credentials/username-email-password.mdx
@@ -36,9 +36,8 @@ hashers:
 
 :::warning
 
-Due to the way BCrypt is implemented in Golang, passwords will be truncated
-after 72 characters before being hashed. This implies that all characters in the
-password after position 72 will be ignored!
+BCrypt has a maximum length of 72 bytes for passwords. If a longer password
+is attempted to be used, an error will be returned to the user.
 
 :::
 


### PR DESCRIPTION
I think this is closer to how things are implemented, from what I have observed in the current code. So password is not silently truncated, but an error is returned. Also, the limit of 72 bytes (not characters!) is a property of the bcrypt algorithm itself and not the implementation.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).
