### PR TITLE
fix: Add missing sample app paths to oathkeeper config

### DIFF
--- a/contrib/quickstart/oathkeeper/access-rules.yml
+++ b/contrib/quickstart/oathkeeper/access-rules.yml
@@ -26,7 +26,7 @@
     preserve_host: true
     url: "http://kratos-selfservice-ui-node:4435"
   match:
-    url: "http://127.0.0.1:4455/<{error,recovery,verify,auth/*,**.css,**.js}{/,}>"
+    url: "http://127.0.0.1:4455/<{welcome,registration,login,verification,error,recovery,verify,auth/*,**.css,**.js,**.png}{/,}>"
     methods:
       - GET
   authenticators:


### PR DESCRIPTION
Add "welcome,registration,login,verification" and "**.png" to the paths oathkeeper forwards to self service ui.

Currently the self service UI doesn't work when using `quickstart-oathkeeper.yml` from https://www.ory.sh/kratos/docs/guides/zero-trust-iap-proxy-identity-access-proxy/. This is due to the paths above missing from the access rules.

## Related issue(s)

Fixes https://github.com/ory/kratos/issues/2048

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

