### PR TITLE
fix: Accept header checking

### DIFF
--- a/selfservice/flow/login/handler.go
+++ b/selfservice/flow/login/handler.go
@@ -334,14 +334,14 @@ func (h *Handler) initBrowserFlow(w http.ResponseWriter, r *http.Request, ps htt
 			return
 		}
 
-		x.AcceptToRedirectOrJSON(w, r, h.d.Writer(), err, returnTo.String())
+		x.ContentNegotiationRedirection(w, r, err, h.d.Writer(), returnTo.String())
 		return
 	} else if err != nil {
 		h.d.SelfServiceErrorManager().Forward(r.Context(), w, r, err)
 		return
 	}
 
-	x.AcceptToRedirectOrJSON(w, r, h.d.Writer(), a, a.AppendTo(h.d.Config(r.Context()).SelfServiceFlowLoginUI()).String())
+	x.ContentNegotiationRedirection(w, r, a, h.d.Writer(), a.AppendTo(h.d.Config(r.Context()).SelfServiceFlowLoginUI()).String())
 }
 
 // nolint:deadcode,unused

--- a/selfservice/flow/recovery/handler.go
+++ b/selfservice/flow/recovery/handler.go
@@ -184,7 +184,7 @@ func (h *Handler) initBrowserFlow(w http.ResponseWriter, r *http.Request, _ http
 	}
 
 	redirTo := f.AppendTo(h.d.Config(r.Context()).SelfServiceFlowRecoveryUI()).String()
-	x.AcceptToRedirectOrJSON(w, r, h.d.Writer(), f, redirTo)
+	x.ContentNegotiationRedirection(w, r, f, h.d.Writer(), redirTo)
 }
 
 // nolint:deadcode,unused

--- a/selfservice/flow/registration/handler.go
+++ b/selfservice/flow/registration/handler.go
@@ -234,7 +234,7 @@ func (h *Handler) initBrowserFlow(w http.ResponseWriter, r *http.Request, ps htt
 	}
 
 	redirTo := a.AppendTo(h.d.Config(r.Context()).SelfServiceFlowRegistrationUI()).String()
-	x.AcceptToRedirectOrJSON(w, r, h.d.Writer(), a, redirTo)
+	x.ContentNegotiationRedirection(w, r, a, h.d.Writer(), redirTo)
 }
 
 // nolint:deadcode,unused

--- a/selfservice/flow/settings/handler.go
+++ b/selfservice/flow/settings/handler.go
@@ -274,7 +274,7 @@ func (h *Handler) initBrowserFlow(w http.ResponseWriter, r *http.Request, ps htt
 	}
 
 	redirTo := f.AppendTo(h.d.Config(r.Context()).SelfServiceFlowSettingsUI()).String()
-	x.AcceptToRedirectOrJSON(w, r, h.d.Writer(), f, redirTo)
+	x.ContentNegotiationRedirection(w, r, f, h.d.Writer(), redirTo)
 }
 
 // nolint:deadcode,unused

--- a/selfservice/flow/verification/handler.go
+++ b/selfservice/flow/verification/handler.go
@@ -168,7 +168,7 @@ func (h *Handler) initBrowserFlow(w http.ResponseWriter, r *http.Request, ps htt
 	}
 
 	redirTo := req.AppendTo(h.d.Config(r.Context()).SelfServiceFlowVerificationUI()).String()
-	x.AcceptToRedirectOrJSON(w, r, h.d.Writer(), req, redirTo)
+	x.ContentNegotiationRedirection(w, r, req, h.d.Writer(), redirTo)
 }
 
 // swagger:parameters getSelfServiceVerificationFlow

--- a/x/isjsonrequest.go
+++ b/x/isjsonrequest.go
@@ -2,18 +2,16 @@ package x
 
 import (
 	"net/http"
-
-	"github.com/golang/gddo/httputil"
 )
 
-var offers = []string{"text/html", "text/*", "*/*", "application/json"}
-var defaultOffer = "text/html"
-
 func IsJSONRequest(r *http.Request) bool {
-	return httputil.NegotiateContentType(r, offers, defaultOffer) == "application/json" ||
+	return AcceptsJSON(r) ||
 		r.Header.Get("Content-Type") == "application/json"
 }
 
 func IsBrowserRequest(r *http.Request) bool {
-	return httputil.NegotiateContentType(r, offers, defaultOffer) == "text/html"
+	return AcceptsContentType(r, "text/html") ||
+		AcceptsContentType(r, "text/*") ||
+		AcceptsContentType(r, "*/*") ||
+		!AcceptsJSON(r)
 }

--- a/x/isjsonrequest_test.go
+++ b/x/isjsonrequest_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/golang/gddo/httputil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -26,12 +25,8 @@ func TestIsBrowserOrAPIRequest(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("case=%d/ua=%s", k, tc.ua), func(t *testing.T) {
 			r := &http.Request{Header: map[string][]string{"Accept": {tc.h}}}
-			t.Logf("isBrowser: %s", httputil.NegotiateContentType(r, offers, defaultOffer))
-
-			t.Logf("isJSON: %s", httputil.NegotiateContentType(r,
-				[]string{"application/json"},
-				"text/html",
-			))
+			t.Logf("isBrowser: %t", IsBrowserRequest(r))
+			t.Logf("isJSON: %t", IsJSONRequest(r))
 
 			assert.Equal(t, tc.e, IsBrowserRequest(r))
 			assert.Equal(t, !tc.e, IsJSONRequest(r))


### PR DESCRIPTION
This fixes the checking of the accept header for specific mime types. It also removes the usage of `github.com/golang/gddo/httputil` which hasn't been updated in 4 years and is responsible for the breakage (described in the linked issue).

## Related issue(s)
https://github.com/ory/kratos/issues/2063

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further Comments

I found that the `AcceptToRedirectOrJSON` and `ContentNegotiationRedirection` were duplicated, so i removed the former and replaced all occurences with the later.