### PR TITLE
fix: add hiring notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
     <a href="https://www.ory.sh/kratos/docs/">Guide</a> |
     <a href="https://www.ory.sh/kratos/docs/sdk/api">API Docs</a> |
     <a href="https://godoc.org/github.com/ory/kratos">Code Docs</a><br/><br/>
-    <a href="https://opencollective.com/ory">Support this project!</a>
+    <a href="https://opencollective.com/ory">Support this project!</a><br/><br/>
+    <a href="https://www.ory.sh/jobs/">Work with us: Ory is hiring!</a>
 </h4>
 
 ---

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
     <a href="https://www.ory.sh/kratos/docs/sdk/api">API Docs</a> |
     <a href="https://godoc.org/github.com/ory/kratos">Code Docs</a><br/><br/>
     <a href="https://opencollective.com/ory">Support this project!</a><br/><br/>
-    <a href="https://www.ory.sh/jobs/">Work with us: Ory is hiring!</a>
+    <a href="https://www.ory.sh/jobs/">Work in Open Source, Ory is hiring!</a>
 </h4>
 
 ---


### PR DESCRIPTION
Adds a notice that Ory is hiring to the top of README. 
When this is approved, I would make the same changes to hydra etc. 
As discussed with @BlueAcidFrog