### PR TITLE
feat: rate limit failed password attempts

### DIFF
--- a/cmd/clidoc/main.go
+++ b/cmd/clidoc/main.go
@@ -87,6 +87,7 @@ func init() {
 		"NewErrorValidationAddressNotVerified":                    text.NewErrorValidationAddressNotVerified(),
 		"NewErrorValidationNoTOTPDevice":                          text.NewErrorValidationNoTOTPDevice(),
 		"NewErrorValidationNoLookup":                              text.NewErrorValidationNoLookup(),
+		"NewErrorPasswordRateLimit":                               text.NewErrorPasswordRateLimit(),
 		"NewErrorValidationNoWebAuthnDevice":                      text.NewErrorValidationNoWebAuthnDevice(),
 		"NewInfoLoginReAuth":                                      text.NewInfoLoginReAuth(),
 		"NewInfoLoginMFA":                                         text.NewInfoLoginMFA(),

--- a/cmd/daemon/serve.go
+++ b/cmd/daemon/serve.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"crypto/tls"
+	"github.com/ory/kratos/selfservice/strategy/password"
 	"net/http"
 	"sync"
 
@@ -273,6 +274,7 @@ func bgTasks(d driver.Registry, wg *sync.WaitGroup, cmd *cobra.Command, args []s
 	if d.Config(ctx).IsBackgroundCourierEnabled() {
 		go courier.Watch(ctx, d)
 	}
+	go password.CleanupRateLimits()
 }
 
 func ServeAll(d driver.Registry, opts ...Option) func(cmd *cobra.Command, args []string) {

--- a/cmd/daemon/serve.go
+++ b/cmd/daemon/serve.go
@@ -2,11 +2,8 @@ package daemon
 
 import (
 	"crypto/tls"
-	"github.com/ory/kratos/selfservice/strategy/password"
 	"net/http"
 	"sync"
-
-	"github.com/ory/kratos/selfservice/flow/recovery"
 
 	"github.com/ory/x/reqlog"
 
@@ -35,11 +32,13 @@ import (
 	"github.com/ory/kratos/selfservice/errorx"
 	"github.com/ory/kratos/selfservice/flow/login"
 	"github.com/ory/kratos/selfservice/flow/logout"
+	"github.com/ory/kratos/selfservice/flow/recovery"
 	"github.com/ory/kratos/selfservice/flow/registration"
 	"github.com/ory/kratos/selfservice/flow/settings"
 	"github.com/ory/kratos/selfservice/flow/verification"
 	"github.com/ory/kratos/selfservice/strategy/link"
 	"github.com/ory/kratos/selfservice/strategy/oidc"
+	"github.com/ory/kratos/selfservice/strategy/password"
 	"github.com/ory/kratos/session"
 	"github.com/ory/kratos/x"
 )

--- a/docs/docs/concepts/security.mdx
+++ b/docs/docs/concepts/security.mdx
@@ -397,7 +397,10 @@ login, account recovery) integration documentation.
 
 ## Bruteforce Attacks
 
-Will be addressed in a future release.
+### Rate Limiting
+Repeatedly trying to login with the wrong password (or for a non-existent user)
+will result in increasingly slower responses to the attempting client, up to
+the configured `selfservice.methods.password.config.rate_limit_max_duration` (Default 30s)
 
 ## Phishing Attacks
 

--- a/docs/docs/concepts/security.mdx
+++ b/docs/docs/concepts/security.mdx
@@ -398,9 +398,11 @@ login, account recovery) integration documentation.
 ## Bruteforce Attacks
 
 ### Rate Limiting
+
 Repeatedly trying to login with the wrong password (or for a non-existent user)
-will result in increasingly slower responses to the attempting client, up to
-the configured `selfservice.methods.password.config.rate_limit_max_duration` (Default 30s)
+will result in increasingly slower responses to the attempting client, up to the
+configured `selfservice.methods.password.config.rate_limit_max_duration`
+(Default 30s)
 
 ## Phishing Attacks
 

--- a/driver/config/config.go
+++ b/driver/config/config.go
@@ -146,6 +146,7 @@ const (
 	ViperKeyPasswordHaveIBeenPwnedEnabled                    = "selfservice.methods.password.config.haveibeenpwned_enabled"
 	ViperKeyPasswordMaxBreaches                              = "selfservice.methods.password.config.max_breaches"
 	ViperKeyIgnoreNetworkErrors                              = "selfservice.methods.password.config.ignore_network_errors"
+	ViperKeyMaxPasswordRateLimitMaxDuration                  = "selfservice.methods.password.config.rate_limit_max_duration"
 	ViperKeyTOTPIssuer                                       = "selfservice.methods.totp.config.issuer"
 	ViperKeyWebAuthnRPDisplayName                            = "selfservice.methods.webauthn.config.rp.display_name"
 	ViperKeyWebAuthnRPID                                     = "selfservice.methods.webauthn.config.rp.id"
@@ -200,6 +201,7 @@ type (
 		HaveIBeenPwnedEnabled bool   `json:"haveibeenpwned_enabled"`
 		MaxBreaches           uint   `json:"max_breaches"`
 		IgnoreNetworkErrors   bool   `json:"ignore_network_errors"`
+		RateLimitMaxDuration  string `json:"rate_limit_max_duration"`
 	}
 	Schemas []Schema
 	Config  struct {
@@ -1047,6 +1049,7 @@ func (p *Config) PasswordPolicyConfig() *PasswordPolicy {
 		HaveIBeenPwnedEnabled: p.p.BoolF(ViperKeyPasswordHaveIBeenPwnedEnabled, true),
 		MaxBreaches:           uint(p.p.Int(ViperKeyPasswordMaxBreaches)),
 		IgnoreNetworkErrors:   p.p.BoolF(ViperKeyIgnoreNetworkErrors, true),
+		RateLimitMaxDuration:  p.p.StringF(ViperKeyMaxPasswordRateLimitMaxDuration, "30s"),
 	}
 }
 

--- a/driver/config/config_test.go
+++ b/driver/config/config_test.go
@@ -189,7 +189,7 @@ func TestViperProvider(t *testing.T) {
 				config  string
 				enabled bool
 			}{
-				{id: "password", enabled: true, config: `{"haveibeenpwned_host":"api.pwnedpasswords.com","haveibeenpwned_enabled":true,"ignore_network_errors":true,"max_breaches":0}`},
+				{id: "password", enabled: true, config: `{"haveibeenpwned_host":"api.pwnedpasswords.com","haveibeenpwned_enabled":true,"ignore_network_errors":true,"max_breaches":0,"rate_limit_max_duration":"10s"}`},
 				{id: "oidc", enabled: true, config: `{"providers":[{"client_id":"a","client_secret":"b","id":"github","provider":"github","mapper_url":"http://test.kratos.ory.sh/default-identity.schema.json"}]}`},
 				{id: "totp", enabled: true, config: `{"issuer":"issuer.ory.sh"}`},
 			} {

--- a/driver/config/stub/.kratos.yaml
+++ b/driver/config/stub/.kratos.yaml
@@ -63,6 +63,8 @@ selfservice:
         issuer: issuer.ory.sh
     password:
       enabled: true
+      config:
+        rate_limit_max_duration: 10s
     oidc:
       enabled: true
       config:

--- a/embedx/config.schema.json
+++ b/embedx/config.schema.json
@@ -1121,6 +1121,12 @@
                       "description": "If set to false the password validation fails when the network or the Have I Been Pwnd API is down.",
                       "type": "boolean",
                       "default": true
+                    },
+                    "rate_limit_max_duration": {
+                      "title": "Rate Limit Max Duration",
+                      "description": "When a user is being increasingly rate-limited because they're entering incorrect passwords too rapidly, this is the max time they'll be delayed.",
+                      "type": "string",
+                      "default": "30s"
                     }
                   },
                   "additionalProperties": false

--- a/go.mod
+++ b/go.mod
@@ -95,5 +95,6 @@ require (
 	golang.org/x/net v0.0.0-20211020060615-d418f374d309
 	golang.org/x/oauth2 v0.0.0-20210810183815-faf39c7919d5
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac
 	golang.org/x/tools v0.1.7
 )

--- a/go.sum
+++ b/go.sum
@@ -1572,7 +1572,6 @@ github.com/ory/instrumentedsql/opentracing v0.0.0-20210903114257-c8963b546c5c h1
 github.com/ory/instrumentedsql/opentracing v0.0.0-20210903114257-c8963b546c5c/go.mod h1:61Z4zNpOoshtEmLmp6T13G9adSk66/dYTfTBEnCLwVQ=
 github.com/ory/jsonschema/v3 v3.0.1/go.mod h1:jgLHekkFk0uiGdEWGleC+tOm6JSSP8cbf17PnBuGXlw=
 github.com/ory/jsonschema/v3 v3.0.3/go.mod h1:JvXwbx7IxAkIAo7Qo5OSC1lea+w12DtYGV8h+MTAfnA=
-github.com/ory/jsonschema/v3 v3.0.4 h1:xI5eEjhl7p8aU2568esHv1t5jpKIHvaEII+hlBt7dnQ=
 github.com/ory/jsonschema/v3 v3.0.4/go.mod h1:lC4vfZfOalFjz1P1bSHcXbCQXbLjrKvTfX83SmyU6BU=
 github.com/ory/jsonschema/v3 v3.0.5-0.20211222152031-b530fb44a010 h1:EAoq3pyp2tfTHJpfHTruF7mfGDtpiOiLgMTM/oG4dyA=
 github.com/ory/jsonschema/v3 v3.0.5-0.20211222152031-b530fb44a010/go.mod h1:BYoDlVglsc+iEG4x+dH3GGz850bOI5ZnokRF6xorA9w=

--- a/schema/errors.go
+++ b/schema/errors.go
@@ -246,3 +246,14 @@ func NewNoWebAuthnRegistered() error {
 		Messages: new(text.Messages).Add(text.NewErrorValidationNoWebAuthnDevice()),
 	})
 }
+
+func NewPasswordRateLimitError() error {
+	return errors.WithStack(&ValidationError{
+		ValidationError: &jsonschema.ValidationError{
+			Message:     `You have entered too many incorrect passwords too quickly`,
+			InstancePtr: "#/",
+			Context:     &ValidationErrorContextPasswordPolicyViolation{},
+		},
+		Messages: new(text.Messages).Add(text.NewErrorPasswordRateLimit()),
+	})
+}

--- a/selfservice/strategy/password/login.go
+++ b/selfservice/strategy/password/login.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/gofrs/uuid"
 	"net/http"
 	"time"
+
+	"github.com/gofrs/uuid"
 
 	"github.com/ory/kratos/session"
 
@@ -24,7 +25,6 @@ import (
 	"github.com/ory/kratos/ui/node"
 	"github.com/ory/kratos/x"
 )
-
 
 func (s *Strategy) RegisterLoginRoutes(r *x.RouterPublic) {
 }
@@ -62,13 +62,11 @@ func (s *Strategy) Login(w http.ResponseWriter, r *http.Request, f *login.Flow, 
 		return nil, s.handleLoginError(w, r, f, &p, err)
 	}
 
-
 	visitorLimiter := getVisitor(r, p)
 	waitErr := visitorLimiter.Wait(r.Context())
 	if waitErr != nil {
 		return nil, s.handleLoginError(w, r, f, &p, errors.WithStack(schema.NewPasswordRateLimitError()))
 	}
-
 
 	i, c, err := s.d.PrivilegedIdentityPool().FindByCredentialsIdentifier(r.Context(), s.ID(), p.Identifier)
 	if err != nil {

--- a/selfservice/strategy/password/rate_limit.go
+++ b/selfservice/strategy/password/rate_limit.go
@@ -1,0 +1,91 @@
+package password
+
+import (
+	"crypto/sha1"
+	"fmt"
+	"github.com/ory/kratos/driver/config"
+	"golang.org/x/time/rate"
+	"math"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+var visitors = make(map[string]*visitor)
+var mu sync.Mutex
+
+type visitor struct {
+	limiter  *rate.Limiter
+	backoff  time.Duration
+	lastSeen time.Time
+}
+
+func getRequestIp(r *http.Request) string {
+	ipAddress := r.RemoteAddr
+	fwdAddress := r.Header.Get("X-Forwarded-For")
+	if fwdAddress != "" {
+		ipAddress = fwdAddress
+		ips := strings.Split(fwdAddress, ", ")
+		if len(ips) > 1 {
+			ipAddress = ips[0]
+		}
+	}
+	return ipAddress
+}
+
+func getVisitorKey(r *http.Request, p submitSelfServiceLoginFlowWithPasswordMethodBody) string {
+	keyString := fmt.Sprintf("%s-%s", p.Identifier, getRequestIp(r))
+	hash := sha1.Sum([]byte(keyString))
+	return fmt.Sprintf("%x", hash)
+}
+
+func getVisitor(r *http.Request, p submitSelfServiceLoginFlowWithPasswordMethodBody) *rate.Limiter {
+	mu.Lock()
+	defer mu.Unlock()
+
+	visitorKey := getVisitorKey(r, p)
+	v, exists := visitors[visitorKey]
+	// reset the clock after some reasonable amount of time, if it hasn't been cleaned up otherwise
+	if !exists || time.Now().Sub(v.lastSeen) > time.Minute*10 {
+		backoff, _ := time.ParseDuration("1s")
+		l := rate.NewLimiter(rate.Every(backoff), 2)
+		visitors[visitorKey] = &visitor{l, backoff, time.Now()}
+		return l
+	}
+
+	v.lastSeen = time.Now()
+	return v.limiter
+}
+
+func increaseRateLimitWait(config *config.Config, r *http.Request, p submitSelfServiceLoginFlowWithPasswordMethodBody) *rate.Limiter {
+	mu.Lock()
+	defer mu.Unlock()
+
+	passwordPolicyConfig := config.PasswordPolicyConfig()
+
+	visitorKey := getVisitorKey(r, p)
+	v, exists := visitors[visitorKey]
+	if exists {
+		max, _ := time.ParseDuration(passwordPolicyConfig.RateLimitMaxDuration)
+		v.backoff = time.Second * time.Duration(math.Min(v.backoff.Seconds()*2.0, max.Seconds()))
+		v.limiter.SetLimit(rate.Every(v.backoff))
+		v.lastSeen = time.Now()
+		return v.limiter
+	}
+	return nil
+}
+
+func CleanupRateLimits() {
+	for {
+		time.Sleep(time.Minute)
+
+		mu.Lock()
+		for ip, v := range visitors {
+			if time.Since(v.lastSeen) > 5*time.Minute {
+				delete(visitors, ip)
+			}
+		}
+		mu.Unlock()
+	}
+}

--- a/selfservice/strategy/password/rate_limit.go
+++ b/selfservice/strategy/password/rate_limit.go
@@ -1,15 +1,17 @@
 package password
 
 import (
-	"crypto/sha1"
+	"crypto/sha256"
 	"fmt"
-	"github.com/ory/kratos/driver/config"
-	"golang.org/x/time/rate"
 	"math"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
+
+	"golang.org/x/time/rate"
+
+	"github.com/ory/kratos/driver/config"
 )
 
 var visitors = make(map[string]*visitor)
@@ -36,7 +38,7 @@ func getRequestIp(r *http.Request) string {
 
 func getVisitorKey(r *http.Request, p submitSelfServiceLoginFlowWithPasswordMethodBody) string {
 	keyString := fmt.Sprintf("%s-%s", p.Identifier, getRequestIp(r))
-	hash := sha1.Sum([]byte(keyString))
+	hash := sha256.Sum256([]byte(keyString))
 	return fmt.Sprintf("%x", hash)
 }
 
@@ -75,7 +77,7 @@ func increasePasswordAttemptWait(config *config.Config, r *http.Request, p submi
 	return nil
 }
 
-func resetRateLimit(r *http.Request, p submitSelfServiceLoginFlowWithPasswordMethodBody){
+func resetRateLimit(r *http.Request, p submitSelfServiceLoginFlowWithPasswordMethodBody) {
 	mu.Lock()
 	visitorKey := getVisitorKey(r, p)
 	delete(visitors, visitorKey)

--- a/text/id.go
+++ b/text/id.go
@@ -94,6 +94,7 @@ const (
 	ErrorValidationLookupAlreadyUsed
 	ErrorValidationNoWebAuthnDevice
 	ErrorValidationNoLookup
+	ErrorValidationPasswordRateLimit
 )
 
 const (

--- a/text/message_validation.go
+++ b/text/message_validation.go
@@ -146,3 +146,12 @@ func NewErrorValidationNoWebAuthnDevice() *Message {
 		Context: context(nil),
 	}
 }
+
+func NewErrorPasswordRateLimit() *Message {
+	return &Message{
+		ID:      ErrorValidationPasswordRateLimit,
+		Text:    "Too many failures too quickly, please wait and try again.",
+		Type:    Error,
+		Context: context(nil),
+	}
+}


### PR DESCRIPTION
Adding a per Identifier+requesting IP [Limiter](https://pkg.go.dev/golang.org/x/time/rate#Limiter), per @aeneasr 's [lovely explanation](https://github.com/ory/kratos/issues/654#issuecomment-728958470).  (hope that suffices for a design doc :))

Starts by making a repeated failed attempt for a user from the same IP wait for 1s.  We double this wait time for every subsequent failed attempt, up to the configurable `selfservice.methods.password.config.rate_limit_max_duration` (Default 30s).  Resets the limiter on successful login.  Adds a background goroutine to forget any tracked attempts older than 10 minutes.


## Related issue(s)

#654 

## Checklist


- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further Comments
I _think_ an in-memory tracking of failed attempts is good enough here.  I don't think it's worth persisting to the DB for, far too chatty and a drag on performance to be worth the coordinated effort across nodes. 
