### PR TITLE
fix: Do not send session after registration without hook

### DIFF
--- a/selfservice/flow/registration/hook.go
+++ b/selfservice/flow/registration/hook.go
@@ -184,7 +184,15 @@ func (e *HookExecutor) PostRegistrationHook(w http.ResponseWriter, r *http.Reque
 		Debug("Post registration execution hooks completed successfully.")
 
 	if a.Type == flow.TypeAPI || x.IsJSONRequest(r) {
-		e.d.Writer().Write(w, r, &APIFlowResponse{Identity: i, Session: s})
+		body := APIFlowResponse{Identity: i}
+		// only include the session if it is actually persisted
+		for _, afterHook := range c.SelfServiceFlowRegistrationAfterHooks(ct.String()) {
+			if afterHook.Name == "session" {
+				body.Session = s
+				break
+			}
+		}
+		e.d.Writer().Write(w, r, &body)
 		return nil
 	}
 

--- a/selfservice/flow/registration/hook.go
+++ b/selfservice/flow/registration/hook.go
@@ -184,15 +184,7 @@ func (e *HookExecutor) PostRegistrationHook(w http.ResponseWriter, r *http.Reque
 		Debug("Post registration execution hooks completed successfully.")
 
 	if a.Type == flow.TypeAPI || x.IsJSONRequest(r) {
-		body := APIFlowResponse{Identity: i}
-		// only include the session if it is actually persisted
-		for _, afterHook := range c.SelfServiceFlowRegistrationAfterHooks(ct.String()) {
-			if afterHook.Name == "session" {
-				body.Session = s
-				break
-			}
-		}
-		e.d.Writer().Write(w, r, &body)
+		e.d.Writer().Write(w, r, &APIFlowResponse{Identity: i})
 		return nil
 	}
 

--- a/selfservice/hook/session_issuer.go
+++ b/selfservice/hook/session_issuer.go
@@ -42,7 +42,8 @@ func (e *SessionIssuer) ExecutePostRegistrationPostPersistHook(w http.ResponseWr
 
 	if a.Type == flow.TypeAPI {
 		e.r.Writer().Write(w, r, &registration.APIFlowResponse{
-			Session: s, Token: s.Token,
+			Session:  s,
+			Token:    s.Token,
 			Identity: s.Identity,
 		})
 		return errors.WithStack(registration.ErrHookAbortFlow)

--- a/selfservice/hook/session_issuer_test.go
+++ b/selfservice/hook/session_issuer_test.go
@@ -57,7 +57,7 @@ func TestSessionIssuer(t *testing.T) {
 			f := &registration.Flow{Type: flow.TypeAPI}
 
 			require.NoError(t, reg.PrivilegedIdentityPool().CreateIdentity(context.Background(), i))
-			err := h.ExecutePostRegistrationPostPersistHook(w, &r, f, s)
+			err := h.ExecutePostRegistrationPostPersistHook(w, &http.Request{Header: http.Header{"Accept": {"application/json"}}}, f, s)
 			require.True(t, errors.Is(err, registration.ErrHookAbortFlow), "%+v", err)
 
 			got, err := reg.SessionPersister().GetSession(context.Background(), s.ID)
@@ -70,6 +70,29 @@ func TestSessionIssuer(t *testing.T) {
 			assert.Equal(t, i.ID.String(), gjson.GetBytes(body, "identity.id").String())
 			assert.Equal(t, s.ID.String(), gjson.GetBytes(body, "session.id").String())
 			assert.Equal(t, got.Token, gjson.GetBytes(body, "session_token").String())
+		})
+
+		t.Run("flow=spa", func(t *testing.T) {
+			w := httptest.NewRecorder()
+
+			i := identity.NewIdentity(config.DefaultIdentityTraitsSchemaID)
+			s := &session.Session{ID: x.NewUUID(), Identity: i, Token: randx.MustString(12, randx.AlphaLowerNum), LogoutToken: randx.MustString(12, randx.AlphaLowerNum)}
+			f := &registration.Flow{Type: flow.TypeBrowser}
+
+			require.NoError(t, reg.PrivilegedIdentityPool().CreateIdentity(context.Background(), i))
+			err := h.ExecutePostRegistrationPostPersistHook(w, &http.Request{Header: http.Header{"Accept": {"application/json"}}}, f, s)
+			require.True(t, errors.Is(err, registration.ErrHookAbortFlow), "%+v", err)
+
+			got, err := reg.SessionPersister().GetSession(context.Background(), s.ID)
+			require.NoError(t, err)
+			assert.Equal(t, s.ID.String(), got.ID.String())
+			assert.True(t, got.AuthenticatedAt.After(time.Now().Add(-time.Minute)))
+
+			assert.NotEmpty(t, w.Header().Get("Set-Cookie"))
+			body := w.Body.Bytes()
+			assert.Equal(t, i.ID.String(), gjson.GetBytes(body, "identity.id").String())
+			assert.Equal(t, s.ID.String(), gjson.GetBytes(body, "session.id").String())
+			assert.Empty(t, gjson.GetBytes(body, "session_token").String())
 		})
 	})
 }


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

This fixes the registration hooks to not include a `session` property in the response for API and SPA flows if there is no `"session"` hook configured. This new behavior matches up with pre-existing documentation.

## Related issue(s)

Fixes #2093

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [X] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [X] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [X] I have added tests that prove my fix is effective or that my feature
      works.
- [X] I have added or changed [the documentation](docs/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

* Since the presence of the `"session"` hook determines whether a valid session will be created, checking for that works well here. I do not know whether there is a more explicit way of verifying session validity that does not depend on the config.
* I would have liked to use the `hook.KeySessionIssuer` constant but that resulted in a circular import.
* No idea what to do about the session being passed to `ContentNegotiationRedirection`.
