### PR TITLE
fix: add `identity_id` index to `identity_verifiable_addresses` table

### DIFF
--- a/persistence/sql/migrations/sql/20220114135828000000_verified_address_identity_index.cockroach.down.sql
+++ b/persistence/sql/migrations/sql/20220114135828000000_verified_address_identity_index.cockroach.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS "identity_verifiable_addresses_nid_identity_id_idx";

--- a/persistence/sql/migrations/sql/20220114135828000000_verified_address_identity_index.cockroach.up.sql
+++ b/persistence/sql/migrations/sql/20220114135828000000_verified_address_identity_index.cockroach.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "identity_verifiable_addresses_nid_identity_id_idx" ON "identity_verifiable_addresses" (nid, identity_id);

--- a/persistence/sql/migrations/sql/20220114135828000000_verified_address_identity_index.mysql.down.sql
+++ b/persistence/sql/migrations/sql/20220114135828000000_verified_address_identity_index.mysql.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX `identity_verifiable_addresses_nid_identity_id_idx` ON `identity_verifiable_addresses`;

--- a/persistence/sql/migrations/sql/20220114135828000000_verified_address_identity_index.mysql.up.sql
+++ b/persistence/sql/migrations/sql/20220114135828000000_verified_address_identity_index.mysql.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX `identity_verifiable_addresses_nid_identity_id_idx` ON `identity_verifiable_addresses` (`nid`, `identity_id`);

--- a/persistence/sql/migrations/sql/20220114135828000000_verified_address_identity_index.postgres.down.sql
+++ b/persistence/sql/migrations/sql/20220114135828000000_verified_address_identity_index.postgres.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX "identity_verifiable_addresses_nid_identity_id_idx";

--- a/persistence/sql/migrations/sql/20220114135828000000_verified_address_identity_index.postgres.up.sql
+++ b/persistence/sql/migrations/sql/20220114135828000000_verified_address_identity_index.postgres.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "identity_verifiable_addresses_nid_identity_id_idx" ON "identity_verifiable_addresses" (nid, identity_id);

--- a/persistence/sql/migrations/sql/20220114135828000000_verified_address_identity_index.sqlite3.down.sql
+++ b/persistence/sql/migrations/sql/20220114135828000000_verified_address_identity_index.sqlite3.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS "identity_verifiable_addresses_nid_identity_id_idx";

--- a/persistence/sql/migrations/sql/20220114135828000000_verified_address_identity_index.sqlite3.up.sql
+++ b/persistence/sql/migrations/sql/20220114135828000000_verified_address_identity_index.sqlite3.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "identity_verifiable_addresses_nid_identity_id_idx" ON "identity_verifiable_addresses" (nid, identity_id);

--- a/persistence/sql/migrations/templates/20220114135828_verified_address_identity_index.down.fizz
+++ b/persistence/sql/migrations/templates/20220114135828_verified_address_identity_index.down.fizz
@@ -1,0 +1,1 @@
+drop_index("identity_verifiable_addresses", "identity_verifiable_addresses_nid_identity_id_idx")

--- a/persistence/sql/migrations/templates/20220114135828_verified_address_identity_index.up.fizz
+++ b/persistence/sql/migrations/templates/20220114135828_verified_address_identity_index.up.fizz
@@ -1,0 +1,1 @@
+add_index("identity_verifiable_addresses", ["nid", "identity_id"], { "name": "identity_verifiable_addresses_nid_identity_id_idx" })


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

The verifiable addresses are loaded eagerly into the identity. When that happens, the `identity_verifiable_addresses` table is queried by `nid` and `identity_id`. This index should greatly improve performance, especially of the `/sessions/whoami` endpoint.
<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
2. implements a new feature, link the issue containing the design document in the format of `#1234`;
3. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->
