### PR TITLE
fix: URL with hash sign in after_verification_return_to stays encoded

### DIFF
--- a/x/http_secure_redirect.go
+++ b/x/http_secure_redirect.go
@@ -87,7 +87,7 @@ func SecureRedirectTo(r *http.Request, defaultReturnTo *url.URL, opts ...SecureR
 
 	if len(source.Query().Get("return_to")) == 0 {
 		return o.defaultReturnTo, nil
-	} else if returnTo, err = url.ParseRequestURI(source.Query().Get("return_to")); err != nil {
+	} else if returnTo, err = url.Parse(source.Query().Get("return_to")); err != nil {
 		return nil, herodot.ErrInternalServerError.WithWrap(err).WithReasonf("Unable to parse the return_to query parameter as an URL: %s", err)
 	}
 

--- a/x/http_secure_redirect_test.go
+++ b/x/http_secure_redirect_test.go
@@ -143,6 +143,14 @@ func TestSecureRedirectTo(t *testing.T) {
 		return res, string(body)
 	}
 
+	t.Run("case=return to a relative path with anchor works", func(t *testing.T) {
+		s := newServer(t, false, true, false, func(ts *httptest.Server) []x.SecureRedirectOption {
+			return []x.SecureRedirectOption{x.SecureRedirectAllowURLs([]url.URL{*urlx.ParseOrPanic("/foo")})}
+		})
+		_, body := makeRequest(t, s, "?return_to=/foo/kratos%23abcd")
+		assert.Equal(t, body, "/foo/kratos#abcd")
+	})
+
 	t.Run("case=return to default URL if nothing is allowed", func(t *testing.T) {
 		s := newServer(t, false, false, false, nil)
 		_, body := makeRequest(t, s, "?return_to=/foo")


### PR DESCRIPTION
Fixes a problem that when `after_verification_return_to` parameter containing hashtag # is specified, the server redirects to URL containing hashtag in URLEncoded form `%23`.

For example, specify `after_verification_return_to=/foo/kratos#abcd`

Incorrect behavior (before the fix): 
The verification flow redirects to `/foo/kratos%23abcd`

Correct behavior (after the fix): 
The verification flow redirects to `/foo/kratos#abcd`

## Related issue(s)
Fixes #2068

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

