### PR TITLE
fix(selfservice): Login self service flow with TOTP does not pass on return_to URL

### DIFF
--- a/selfservice/flow/login/hook.go
+++ b/selfservice/flow/login/hook.go
@@ -60,10 +60,18 @@ func NewHookExecutor(d executorDependencies) *HookExecutor {
 	return &HookExecutor{d: d}
 }
 
-func (e *HookExecutor) requiresAAL2(r *http.Request, s *session.Session) (*session.ErrAALNotSatisfied, bool) {
+func (e *HookExecutor) requiresAAL2(r *http.Request, s *session.Session, a *Flow) (*session.ErrAALNotSatisfied, bool) {
 	var aalErr *session.ErrAALNotSatisfied
 	err := e.d.SessionManager().DoesSessionSatisfy(r, s, e.d.Config(r.Context()).SessionWhoAmIAAL())
-	return aalErr, errors.As(err, &aalErr)
+	if ok := errors.As(err, &aalErr); !ok {
+		return nil, false
+	}
+
+	if err := aalErr.PassReturnToParameter(a.RequestURL); err != nil {
+		return aalErr, true
+	}
+
+	return aalErr, true
 }
 
 func (e *HookExecutor) PostLoginHook(w http.ResponseWriter, r *http.Request, a *Flow, i *identity.Identity, s *session.Session) error {
@@ -127,7 +135,7 @@ func (e *HookExecutor) PostLoginHook(w http.ResponseWriter, r *http.Request, a *
 			Info("Identity authenticated successfully and was issued an Ory Kratos Session Token.")
 
 		response := &APIFlowResponse{Session: s, Token: s.Token}
-		if _, required := e.requiresAAL2(r, s); required {
+		if _, required := e.requiresAAL2(r, s, a); required {
 			// If AAL is not satisfied, we omit the identity to preserve the user's privacy in case of a phishing attack.
 			response.Session.Identity = nil
 		}
@@ -151,7 +159,7 @@ func (e *HookExecutor) PostLoginHook(w http.ResponseWriter, r *http.Request, a *
 		s.Token = ""
 
 		response := &APIFlowResponse{Session: s}
-		if _, required := e.requiresAAL2(r, s); required {
+		if _, required := e.requiresAAL2(r, s, a); required {
 			// If AAL is not satisfied, we omit the identity to preserve the user's privacy in case of a phishing attack.
 			response.Session.Identity = nil
 		}
@@ -160,7 +168,7 @@ func (e *HookExecutor) PostLoginHook(w http.ResponseWriter, r *http.Request, a *
 	}
 
 	// If we detect that whoami would require a higher AAL, we redirect!
-	if aalErr, required := e.requiresAAL2(r, s); required {
+	if aalErr, required := e.requiresAAL2(r, s, a); required {
 		http.Redirect(w, r, aalErr.RedirectTo, http.StatusSeeOther)
 		return nil
 	}

--- a/selfservice/flow/login/hook.go
+++ b/selfservice/flow/login/hook.go
@@ -68,7 +68,7 @@ func (e *HookExecutor) requiresAAL2(r *http.Request, s *session.Session, a *Flow
 	}
 
 	if err := aalErr.PassReturnToParameter(a.RequestURL); err != nil {
-		return aalErr, true
+		return nil, false
 	}
 
 	return aalErr, true

--- a/session/manager_test.go
+++ b/session/manager_test.go
@@ -1,0 +1,70 @@
+package session_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ory/herodot"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ory/kratos/session"
+)
+
+func TestErrAALNotSatisfied_PassReturnToParameter(t *testing.T) {
+	cases := []struct {
+		name       string
+		instance   *session.ErrAALNotSatisfied
+		requestURL string
+		wantErr    assert.ErrorAssertionFunc
+		expected   string
+	}{
+		{
+			name: "no parameter",
+			instance: &session.ErrAALNotSatisfied{
+				DefaultError: &herodot.DefaultError{},
+				RedirectTo:   "https://localhost/?foo=bar",
+			},
+			requestURL: "https://localhost:1234/",
+			wantErr:    assert.NoError,
+			expected:   "https://localhost/?foo=bar",
+		},
+		{
+			name: "pass return_to parameter",
+			instance: &session.ErrAALNotSatisfied{
+				DefaultError: &herodot.DefaultError{},
+				RedirectTo:   "https://localhost/?foo=bar",
+			},
+			requestURL: "https://localhost:1234/?return_to=https%3A%2F%2Fory.sh",
+			wantErr:    assert.NoError,
+			expected:   "https://localhost/?foo=bar&return_to=https%3A%2F%2Fory.sh",
+		},
+		{
+			name: "invalid RedirectTo URL",
+			instance: &session.ErrAALNotSatisfied{
+				DefaultError: &herodot.DefaultError{},
+				RedirectTo:   "https://user:{{{@localhost/?foo=bar",
+			},
+			requestURL: "https://localhost:1234/?return_to=https%3A%2F%2Fory.sh",
+			wantErr:    assert.Error,
+		},
+		{
+			name: "invalid request URL URL",
+			instance: &session.ErrAALNotSatisfied{
+				DefaultError: &herodot.DefaultError{},
+				RedirectTo:   "https://localhost/?foo=bar",
+			},
+			requestURL: "https://user:{{{@localhost:1234/?return_to=https%3A%2F%2Fory.sh",
+			wantErr:    assert.Error,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("case=%s", tc.name), func(t *testing.T) {
+			err := tc.instance.PassReturnToParameter(tc.requestURL)
+
+			tc.wantErr(t, err)
+			if err == nil {
+				assert.Equal(t, tc.expected, tc.instance.RedirectTo)
+			}
+		})
+	}
+}

--- a/test/e2e/cypress/integration/profiles/mfa/totp.spec.ts
+++ b/test/e2e/cypress/integration/profiles/mfa/totp.spec.ts
@@ -95,6 +95,53 @@ context('2FA lookup secrets', () => {
         })
       })
 
+      it('signin with 2fa and be redirected', () => {
+        if (app !== 'express') {
+          return
+        }
+
+        cy.visit(settings)
+        cy.requireStrictAal()
+
+        let secret
+        cy.get('[data-testid="node/text/totp_secret_key/text"]').then(($e) => {
+          secret = $e.text().trim()
+        })
+        cy.get('input[name="totp_code"]').then(($e) => {
+          cy.wrap($e).type(authenticator.generate(secret))
+        })
+        cy.get('*[name="method"][value="totp"]').click()
+        cy.expectSettingsSaved()
+        cy.getSession({
+          expectAal: 'aal2',
+          expectMethods: ['password', 'totp']
+        })
+
+        cy.clearAllCookies()
+        cy.visit(`${login}?return_to=https://www.ory.sh/`)
+
+        cy.get('input[name="password_identifier"]').type(email)
+        cy.get('input[name="password"]').type(password)
+        cy.submitPasswordForm()
+
+        // MFA is now requested
+        cy.location('pathname').should((loc) => {
+          expect(loc).to.include('/login')
+        })
+        cy.shouldShow2FAScreen()
+
+        cy.location('pathname').should((loc) => {
+          expect(loc).to.include('/login')
+        })
+
+        cy.shouldShow2FAScreen()
+        cy.get('input[name="totp_code"]').then(($e) => {
+          cy.wrap($e).type(authenticator.generate(secret))
+        })
+        cy.get('*[name="method"][value="totp"]').click()
+        cy.url().should('eq', 'https://www.ory.sh/')
+      })
+
       it('should go through several totp lifecycles', () => {
         cy.visit(settings)
 


### PR DESCRIPTION
## Related issue(s)

#2172

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
