### PR TITLE
feat: Vue Standalone

### DIFF
--- a/contrib/quickstart/kratos/email-password/kratos.yml
+++ b/contrib/quickstart/kratos/email-password/kratos.yml
@@ -7,6 +7,8 @@ serve:
     base_url: http://127.0.0.1:4433/
     cors:
       enabled: true
+      allowed_origins:
+        - http://127.0.0.1:4455
   admin:
     base_url: http://kratos:4434/
 

--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -133,9 +133,15 @@ git clone https://github.com/ory/kratos.git
 cd kratos
 git checkout v0.8.0-alpha.3
 
+# To build the standalone React app, run:
 docker-compose -f quickstart.yml -f quickstart-standalone.yml up --build --force-recreate
 # If you have SELinux, run:
 docker-compose -f quickstart.yml -f quickstart-selinux.yml -f quickstart-standalone.yml up --build --force-recreate
+
+# To build the standalone Vue app, run:
+docker-compose -f quickstart.yml -f quickstart-standalone-vue.yml up --build --force-recreate
+# If you have SELinux, run:
+docker-compose -f quickstart.yml -f quickstart-selinux.yml -f quickstart-standalone-vue.yml up --build --force-recreate
 ```
 
 This might take a minute or two. Once the output slows down and logs indicate a

--- a/quickstart-standalone-vue.yml
+++ b/quickstart-standalone-vue.yml
@@ -1,0 +1,10 @@
+version: '3.7'
+
+services:
+  kratos-selfservice-ui-node:
+    image: timalanfarrow/kratos-selfservice-ui-vue3-typescript:v0.8.2-alpha.1
+    ports:
+      - "4455:4455"
+    environment:
+      - VITE_APP_ORY_BASE_PATH=http://127.0.0.1:4433
+    command: http-server-spa dist index.html 4455


### PR DESCRIPTION
This change introduces updated Docker configuration for a standalone Vue UI. It references a docker image that I published based off of this public repository: [timalanfarrow/kratos-selfservice-ui-vue3-typescript.git](https://github.com/timalanfarrow/kratos-selfservice-ui-vue3-typescript). I figured I would include my image (published on Docker hub, see [`#2202`](https://github.com/ory/kratos/issues/2202)) so that you can easily pull and test it, but I don't think it should be merged until it references an image managed by Ory.

## Related issue(s)

[`#2202`](https://github.com/ory/kratos/issues/2202)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further Comments

I left most of the context necessary for discussion in [`#2202`](https://github.com/ory/kratos/issues/2202)
