### PR TITLE
feat: Linkedin login

### DIFF
--- a/embedx/config.schema.json
+++ b/embedx/config.schema.json
@@ -326,7 +326,8 @@
             "vk",
             "yandex",
             "apple",
-            "spotify"
+            "spotify",
+            "linkedin"
           ],
           "examples": [
             "google"

--- a/selfservice/strategy/oidc/provider_config.go
+++ b/selfservice/strategy/oidc/provider_config.go
@@ -142,6 +142,8 @@ func (c ConfigurationCollection) Provider(id string, reg dependencies) (Provider
 				return NewProviderApple(&p, reg), nil
 			case addProviderName("spotify"):
 				return NewProviderSpotify(&p, reg), nil
+			case addProviderName("linkedin"):
+				return NewProviderLinkedIn(&p, reg), nil
 			}
 			return nil, errors.Errorf("provider type %s is not supported, supported are: %v", p.Provider, providerNames)
 		}

--- a/selfservice/strategy/oidc/provider_config.go
+++ b/selfservice/strategy/oidc/provider_config.go
@@ -29,6 +29,7 @@ type Configuration struct {
 	// - vk
 	// - yandex
 	// - apple
+	// - linkedin
 	Provider string `json:"provider"`
 
 	// Label represents an optional label which can be used in the UI generation.

--- a/selfservice/strategy/oidc/provider_linkedin.go
+++ b/selfservice/strategy/oidc/provider_linkedin.go
@@ -8,7 +8,6 @@ import (
 	"golang.org/x/oauth2/linkedin"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 
 	"github.com/ory/herodot"
 )
@@ -58,16 +57,16 @@ const (
 
 type ProviderLinkedIn struct {
 	config *Configuration
-	public *url.URL
+	reg    dependencies
 }
 
 func NewProviderLinkedIn(
 	config *Configuration,
-	public *url.URL,
+	reg dependencies,
 ) *ProviderLinkedIn {
 	return &ProviderLinkedIn{
 		config: config,
-		public: public,
+		reg:    reg,
 	}
 }
 
@@ -75,18 +74,18 @@ func (l *ProviderLinkedIn) Config() *Configuration {
 	return l.config
 }
 
-func (l *ProviderLinkedIn) oauth2() *oauth2.Config {
+func (l *ProviderLinkedIn) oauth2(ctx context.Context) *oauth2.Config {
 	return &oauth2.Config{
 		ClientID:     l.config.ClientID,
 		ClientSecret: l.config.ClientSecret,
 		Endpoint:     linkedin.Endpoint,
 		Scopes:       l.config.Scope,
-		RedirectURL:  l.config.Redir(l.public),
+		RedirectURL:  l.config.Redir(l.reg.Config(ctx).SelfPublicURL()),
 	}
 }
 
 func (l *ProviderLinkedIn) OAuth2(ctx context.Context) (*oauth2.Config, error) {
-	return l.oauth2(), nil
+	return l.oauth2(ctx), nil
 }
 
 func (l *ProviderLinkedIn) AuthCodeURLOptions(r ider) []oauth2.AuthCodeOption {

--- a/selfservice/strategy/oidc/provider_linkedin.go
+++ b/selfservice/strategy/oidc/provider_linkedin.go
@@ -1,0 +1,148 @@
+package oidc
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/pkg/errors"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/linkedin"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"github.com/ory/herodot"
+)
+
+type Profile struct {
+	LocalizedLastName string `json:"localizedLastName"`
+	ProfilePicture    struct {
+		DisplayImage string `json:"displayImage"`
+	} `json:"profilePicture"`
+	FirstName struct {
+		Localized struct {
+			EnUS string `json:"en_US"`
+		} `json:"localized"`
+		PreferredLocale struct {
+			Country  string `json:"country"`
+			Language string `json:"language"`
+		} `json:"preferredLocale"`
+	} `json:"firstName"`
+	LastName struct {
+		Localized struct {
+			EnUS string `json:"en_US"`
+		} `json:"localized"`
+		PreferredLocale struct {
+			Country  string `json:"country"`
+			Language string `json:"language"`
+		} `json:"preferredLocale"`
+	} `json:"lastName"`
+	ID                 string `json:"id"`
+	LocalizedFirstName string `json:"localizedFirstName"`
+}
+
+type EmailAddress struct {
+	Elements []struct {
+		Handle struct {
+			EmailAddress string `json:"emailAddress"`
+		} `json:"handle~"`
+		HandleUrn string `json:"handle"`
+	} `json:"elements"`
+}
+
+type APIUrl string
+
+const (
+	ProfileUrl APIUrl = "https://api.linkedin.com/v2/me"
+	EmailUrl          = "https://api.linkedin.com/v2/emailAddress?q=members&projection=(elements*(handle~))"
+)
+
+type ProviderLinkedIn struct {
+	config *Configuration
+	public *url.URL
+}
+
+func NewProviderLinkedIn(
+	config *Configuration,
+	public *url.URL,
+) *ProviderLinkedIn {
+	return &ProviderLinkedIn{
+		config: config,
+		public: public,
+	}
+}
+
+func (l *ProviderLinkedIn) Config() *Configuration {
+	return l.config
+}
+
+func (l *ProviderLinkedIn) oauth2() *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:     l.config.ClientID,
+		ClientSecret: l.config.ClientSecret,
+		Endpoint:     linkedin.Endpoint,
+		Scopes:       l.config.Scope,
+		RedirectURL:  l.config.Redir(l.public),
+	}
+}
+
+func (l *ProviderLinkedIn) OAuth2(ctx context.Context) (*oauth2.Config, error) {
+	return l.oauth2(), nil
+}
+
+func (l *ProviderLinkedIn) AuthCodeURLOptions(r ider) []oauth2.AuthCodeOption {
+	return []oauth2.AuthCodeOption{}
+}
+
+func (l *ProviderLinkedIn) ApiCall(url APIUrl, result interface{}, exchange *oauth2.Token) error {
+	var bearer = "Bearer " + exchange.AccessToken
+	req, err := http.NewRequest("GET", string(url), nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Add("Authorization", bearer)
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(body, result)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (l *ProviderLinkedIn) Claims(ctx context.Context, exchange *oauth2.Token) (*Claims, error) {
+	//grantedScopes := stringsx.Splitx(fmt.Sprintf("%s", exchange.Extra("scope")), ",")
+	//for _, check := range l.Config().Scope {
+	//	if !stringslice.Has(grantedScopes, check) {
+	//		return nil, errors.WithStack(ErrScopeMissing)
+	//	}
+	//}
+
+	var profile Profile
+	var emailaddress EmailAddress
+	err := l.ApiCall(ProfileUrl, &profile, exchange)
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+	err = l.ApiCall(EmailUrl, &emailaddress, exchange)
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+
+	claims := &Claims{
+		Email:    emailaddress.Elements[0].Handle.EmailAddress,
+		Name:     profile.LocalizedFirstName,
+		LastName: profile.LocalizedLastName,
+	}
+
+	return claims, nil
+}

--- a/selfservice/strategy/oidc/provider_linkedin.go
+++ b/selfservice/strategy/oidc/provider_linkedin.go
@@ -120,6 +120,9 @@ func (l *ProviderLinkedIn) ApiCall(url APIUrl, result interface{}, exchange *oau
 }
 
 func (l *ProviderLinkedIn) Claims(ctx context.Context, exchange *oauth2.Token) (*Claims, error) {
+	// For some reason linkedin does not correctly returned selected scope even though it is successfully applied
+	// therefor skip the check for now
+
 	//grantedScopes := stringsx.Splitx(fmt.Sprintf("%s", exchange.Extra("scope")), ",")
 	//for _, check := range l.Config().Scope {
 	//	if !stringslice.Has(grantedScopes, check) {


### PR DESCRIPTION
This adds Linkedin oidc login provider to kratos.

I have mainly adapted the Github provider and it works virtually the same. LinkedIn like Github does not implement OpenID connect and just like the github provider, this new linkedin provider will call the linkedin API to retrieve information for claims.

I have not added test since github provider does not contain those either.

two remarks I acknowledge are not great in the current implementation:
* there is no proper linkedin api golang package, I therefor added a a function which does a basic http request
* I couldn't get scope checking to work correctly. It seems as if the scopes are not added correctly in the response. I have disabled the scope check for now

## Related issue(s)

None

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further Comments

None
