### PR TITLE
fix: add output-dir input to cli-next

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -202,6 +202,7 @@ jobs:
       - uses: ory/ci/docs/cli-next@master
         with:
           token: ${{ secrets.ORY_BOT_PAT }}
+          output-dir: docs/kratos/cli
 
   changelog:
     name: Generate changelog


### PR DESCRIPTION
The `docs/cli-next` invocation was missing a required `output-dir` argument.