### PR TITLE
chore: use live mailchimp list ids

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -268,8 +268,8 @@ jobs:
     steps:
       - uses: ory/ci/newsletter@master
         with:
-          mailchimp_list_id: 058a056618
-          mailchmip_segment_id: 11398953
+          mailchimp_list_id: f605a41b53
+          mailchmip_segment_id: 6479477
           mailchimp_api_key: ${{ secrets.MAILCHIMP_API_KEY }}
           draft: 'true'
           ssh_key: ${{ secrets.ORY_BOT_SSH_KEY }}
@@ -295,8 +295,8 @@ jobs:
     steps:
       - uses: ory/ci/newsletter@master
         with:
-          mailchimp_list_id: 058a056618
-          mailchmip_segment_id: 11398953
+          mailchimp_list_id: f605a41b53
+          mailchmip_segment_id: 6479477
           mailchimp_api_key: ${{ secrets.MAILCHIMP_API_KEY }}
           draft: 'false'
           ssh_key: ${{ secrets.ORY_BOT_SSH_KEY }}


### PR DESCRIPTION
The current ones are for a test audience. This switches to the live mailing list.