### PR TITLE
feat: add configurable timeout for unsent messages (#944)

### DIFF
--- a/courier/courier_dispatcher_test.go
+++ b/courier/courier_dispatcher_test.go
@@ -1,0 +1,52 @@
+package courier_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/ory/kratos/courier"
+	templates "github.com/ory/kratos/courier/template/email"
+	"github.com/ory/kratos/driver/config"
+	"github.com/ory/kratos/internal"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessageTTL(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	ctx := context.Background()
+
+	conf, reg := internal.NewRegistryDefaultWithDSN(t, "")
+	conf.MustSet(config.ViperKeyCourierMessageTTL, 1*time.Nanosecond)
+
+	reg.Logger().Level = logrus.TraceLevel
+
+	c := reg.Courier(ctx)
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	id, err := c.QueueEmail(ctx, templates.NewTestStub(reg, &templates.TestStubModel{
+		To:      "test-recipient-1@example.org",
+		Subject: "test-subject-1",
+		Body:    "test-body-1",
+	}))
+	require.NoError(t, err)
+	require.NotEqual(t, uuid.Nil, id)
+
+	c.DispatchQueue(ctx)
+
+	time.Sleep(1 * time.Second)
+
+	var message courier.Message
+	err = reg.Persister().GetConnection(ctx).
+		Where("status = ?", courier.MessageStatusAbandoned).
+		First(&message)
+
+	require.NoError(t, err)
+	require.Equal(t, id, message.ID)
+}

--- a/courier/message.go
+++ b/courier/message.go
@@ -15,6 +15,7 @@ const (
 	MessageStatusQueued MessageStatus = iota + 1
 	MessageStatusSent
 	MessageStatusProcessing
+	MessageStatusAbandoned
 )
 
 type MessageType int

--- a/courier/test/persistence.go
+++ b/courier/test/persistence.go
@@ -89,6 +89,10 @@ func TestPersister(ctx context.Context, newNetworkUnlessExisting NetworkWrapper,
 			require.NoError(t, p.SetMessageStatus(ctx, messages[0].ID, courier.MessageStatusSent))
 			_, err = p.NextMessages(ctx, 1)
 			require.ErrorIs(t, err, courier.ErrQueueEmpty)
+
+			require.NoError(t, p.SetMessageStatus(ctx, messages[0].ID, courier.MessageStatusAbandoned))
+			_, err = p.NextMessages(ctx, 1)
+			require.ErrorIs(t, err, courier.ErrQueueEmpty)
 		})
 
 		t.Run("case=network", func(t *testing.T) {

--- a/driver/config/config.go
+++ b/driver/config/config.go
@@ -72,6 +72,7 @@ const (
 	ViperKeyCourierSMSRequestConfig                          = "courier.sms.request_config"
 	ViperKeyCourierSMSEnabled                                = "courier.sms.enabled"
 	ViperKeyCourierSMSFrom                                   = "courier.sms.from"
+	ViperKeyCourierMessageTTL                                = "courier.message_ttl"
 	ViperKeySecretsDefault                                   = "secrets.default"
 	ViperKeySecretsCookie                                    = "secrets.cookie"
 	ViperKeySecretsCipher                                    = "secrets.cipher"
@@ -248,6 +249,7 @@ type (
 		CourierTemplatesVerificationValid() *CourierEmailTemplate
 		CourierTemplatesRecoveryInvalid() *CourierEmailTemplate
 		CourierTemplatesRecoveryValid() *CourierEmailTemplate
+		CourierMessageTTL() time.Duration
 	}
 )
 
@@ -925,6 +927,10 @@ func (p *Config) CourierTemplatesRecoveryInvalid() *CourierEmailTemplate {
 
 func (p *Config) CourierTemplatesRecoveryValid() *CourierEmailTemplate {
 	return p.CourierTemplatesHelper(ViperKeyCourierTemplatesRecoveryValidEmail)
+}
+
+func (p *Config) CourierMessageTTL() time.Duration {
+	return p.p.DurationF(ViperKeyCourierMessageTTL, time.Hour)
 }
 
 func (p *Config) CourierSMTPHeaders() map[string]string {

--- a/driver/config/config_test.go
+++ b/driver/config/config_test.go
@@ -1067,6 +1067,7 @@ func TestCourierSMS(t *testing.T) {
 		conf, _ := config.New(ctx, logrusx.New("", ""), os.Stderr,
 			configx.WithConfigFiles("stub/.kratos.courier.sms.yaml"), configx.SkipValidation())
 		assert.True(t, conf.CourierSMSEnabled())
+		assert.Equal(t, conf.CourierMessageTTL(), 300)
 		snapshotx.SnapshotTExcept(t, conf.CourierSMSRequestConfig(), nil)
 		assert.Equal(t, "+49123456789", conf.CourierSMSFrom())
 	})
@@ -1077,6 +1078,21 @@ func TestCourierSMS(t *testing.T) {
 		assert.False(t, conf.CourierSMSEnabled())
 		snapshotx.SnapshotTExcept(t, conf.CourierSMSRequestConfig(), nil)
 		assert.Equal(t, "Ory Kratos", conf.CourierSMSFrom())
+	})
+}
+
+func TestCourierMessageTTL(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("case=configs set", func(t *testing.T) {
+		conf, _ := config.New(ctx, logrusx.New("", ""), os.Stderr,
+			configx.WithConfigFiles("stub/.kratos.courier.messageTTL.yaml"), configx.SkipValidation())
+		assert.Equal(t, conf.CourierMessageTTL(), time.Duration(5*time.Minute))
+	})
+
+	t.Run("case=defaults", func(t *testing.T) {
+		conf, _ := config.New(ctx, logrusx.New("", ""), os.Stderr, configx.SkipValidation())
+		assert.Equal(t, conf.CourierMessageTTL(), time.Duration(1*time.Hour))
 	})
 }
 

--- a/driver/config/config_test.go
+++ b/driver/config/config_test.go
@@ -1067,7 +1067,6 @@ func TestCourierSMS(t *testing.T) {
 		conf, _ := config.New(ctx, logrusx.New("", ""), os.Stderr,
 			configx.WithConfigFiles("stub/.kratos.courier.sms.yaml"), configx.SkipValidation())
 		assert.True(t, conf.CourierSMSEnabled())
-		assert.Equal(t, conf.CourierMessageTTL(), 300)
 		snapshotx.SnapshotTExcept(t, conf.CourierSMSRequestConfig(), nil)
 		assert.Equal(t, "+49123456789", conf.CourierSMSFrom())
 	})

--- a/driver/config/stub/.kratos.courier.messageTTL.yaml
+++ b/driver/config/stub/.kratos.courier.messageTTL.yaml
@@ -1,0 +1,2 @@
+courier:
+  message_ttl: 5m

--- a/embedx/config.schema.json
+++ b/embedx/config.schema.json
@@ -1454,6 +1454,17 @@
             "/conf/courier-templates"
           ]
         },
+        "message_ttl": {
+          "description": "Defines a Time-To-Live for courier messages that could not be delivered. After the defined TTL has expired for a message that message is abandoned.",
+          "type": "string",
+          "pattern": "^([0-9]+(ns|us|ms|s|m|h))+$",
+          "default": "1h",
+          "examples": [
+            "1h",
+            "1m",
+            "1s"
+          ]
+        },
         "smtp": {
           "title": "SMTP Configuration",
           "description": "Configures outgoing emails using the SMTP protocol.",

--- a/test/schema/fixtures/config.schema.test.failure/root.invalidTypes.yaml
+++ b/test/schema/fixtures/config.schema.test.failure/root.invalidTypes.yaml
@@ -33,6 +33,7 @@ courier:
   smtp:
     connection_uri: 0
     from_address: 0
+  message_ttl: invalid-value
 
 serve:
   admin:

--- a/test/schema/fixtures/config.schema.test.success/root.courierSMS.yaml
+++ b/test/schema/fixtures/config.schema.test.success/root.courierSMS.yaml
@@ -9,6 +9,7 @@ identity:
       url: https://example.com
 
 courier:
+  message_ttl: 50m
   smtp:
     connection_uri: smtps://foo:bar@my-mailserver:1234/
     from_address: no-reply@ory.kratos.sh


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->
This PR adds the option to configure a TTL (Time-To-Live) for messages that can not be delivered. After the TTL has passed since the message's creation and it was not delivered, the message is `Abandoned` and the courier will not try to deliver the message again. This is done by setting its `status` to `MessageStatusAbandoned` in the database. The courier will only try to deliver messages with the status `MessageStatusQueued`. 

## Related issue(s)

This PR resolves https://github.com/ory/kratos/issues/944

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
2. implements a new feature, link the issue containing the design document in the format of `#1234`;
3. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
