### PR TITLE
fix(sdk): Fix validation for an identity has webauthn or lookup_secret credentials

### DIFF
--- a/.schema/openapi/patches/identity.yaml
+++ b/.schema/openapi/patches/identity.yaml
@@ -9,3 +9,5 @@
     - password
     - totp
     - oidc
+    - webauthn
+    - lookup_secret

--- a/internal/httpclient/api/openapi.yaml
+++ b/internal/httpclient/api/openapi.yaml
@@ -3060,6 +3060,8 @@ components:
       - password
       - totp
       - oidc
+      - webauthn
+      - lookup_secret
       title: CredentialsType  represents several different credential types, like
         password credentials, passwordless credentials,
       type: string

--- a/internal/httpclient/docs/IdentityCredentialsType.md
+++ b/internal/httpclient/docs/IdentityCredentialsType.md
@@ -9,6 +9,10 @@
 
 * `OIDC` (value: `"oidc"`)
 
+* `WEBAUTHN` (value: `"webauthn"`)
+
+* `LOOKUP_SECRET` (value: `"lookup_secret"`)
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/internal/httpclient/model_identity_credentials_type.go
+++ b/internal/httpclient/model_identity_credentials_type.go
@@ -21,9 +21,11 @@ type IdentityCredentialsType string
 
 // List of identityCredentialsType
 const (
-	IDENTITYCREDENTIALSTYPE_PASSWORD IdentityCredentialsType = "password"
-	IDENTITYCREDENTIALSTYPE_TOTP     IdentityCredentialsType = "totp"
-	IDENTITYCREDENTIALSTYPE_OIDC     IdentityCredentialsType = "oidc"
+	IDENTITYCREDENTIALSTYPE_PASSWORD      IdentityCredentialsType = "password"
+	IDENTITYCREDENTIALSTYPE_TOTP          IdentityCredentialsType = "totp"
+	IDENTITYCREDENTIALSTYPE_OIDC          IdentityCredentialsType = "oidc"
+	IDENTITYCREDENTIALSTYPE_WEBAUTHN      IdentityCredentialsType = "webauthn"
+	IDENTITYCREDENTIALSTYPE_LOOKUP_SECRET IdentityCredentialsType = "lookup_secret"
 )
 
 func (v *IdentityCredentialsType) UnmarshalJSON(src []byte) error {
@@ -33,7 +35,7 @@ func (v *IdentityCredentialsType) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := IdentityCredentialsType(value)
-	for _, existing := range []IdentityCredentialsType{"password", "totp", "oidc"} {
+	for _, existing := range []IdentityCredentialsType{"password", "totp", "oidc", "webauthn", "lookup_secret"} {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil

--- a/spec/api.json
+++ b/spec/api.json
@@ -476,7 +476,9 @@
         "enum": [
           "password",
           "totp",
-          "oidc"
+          "oidc",
+          "webauthn",
+          "lookup_secret"
         ],
         "title": "CredentialsType  represents several different credential types, like password credentials, passwordless credentials,",
         "type": "string"


### PR DESCRIPTION
## Related issue(s)

When an identity has `webauthn` or `lookup_secret` credentials, `AdminGetIdentity` http client returns validation error because these values are not `IdentityCredentialsType` list at SDK.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).
