### PR TITLE
feat: TLS certs auto-reload

### DIFF
--- a/cmd/daemon/cert_refresh.go
+++ b/cmd/daemon/cert_refresh.go
@@ -1,0 +1,150 @@
+package daemon
+
+import (
+
+	// #nosec G505 - This is required for certificate chains alongside sha256
+	"crypto/tls"
+	"crypto/x509"
+	"path"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/ory/kratos/driver"
+	"github.com/ory/kratos/driver/config"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+type certificatesProvider struct {
+	certs              []tls.Certificate
+	mu                 sync.Mutex
+	certLocation       *config.CertLocation
+	d                  driver.Registry
+	watcher            *fsnotify.Watcher
+	getTLSCertificates func() ([]tls.Certificate, *config.CertLocation, error)
+}
+
+func newCertificatesProvider(certs []tls.Certificate, certLocation *config.CertLocation, d driver.Registry, getTLSCertificates func() ([]tls.Certificate, *config.CertLocation, error)) *certificatesProvider {
+	ret := &certificatesProvider{
+		certLocation:       certLocation,
+		d:                  d,
+		getTLSCertificates: getTLSCertificates,
+	}
+	ret.load(certs)
+	if certLocation != nil {
+		ret.watchCertificatesChanges()
+	}
+
+	runtime.SetFinalizer(ret, func(ret *certificatesProvider) { ret.stop() })
+
+	return ret
+}
+
+func (p *certificatesProvider) load(certs []tls.Certificate) {
+	for i := range certs {
+		tlsCert := &certs[i]
+		if tlsCert.Leaf != nil {
+			continue
+		}
+		for _, bCert := range tlsCert.Certificate {
+			cert, _ := x509.ParseCertificate(bCert)
+			if !cert.IsCA {
+				tlsCert.Leaf = cert
+			}
+		}
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.certs = certs
+}
+
+func (p *certificatesProvider) watchCertificatesChanges() {
+	var err error
+	p.watcher, err = fsnotify.NewWatcher()
+	if err != nil {
+		p.d.Logger().WithError(err).Fatalf("Could not activate certificate change watcher")
+	}
+
+	go func() {
+		p.d.Logger().Infof("Starting tls certificate auto-refresh")
+		for {
+			select {
+			case _, ok := <-p.watcher.Events:
+				if !ok {
+					return
+				}
+
+				p.waitForAllFilesChanges()
+
+				p.d.Logger().Infof("TLS certificates changed, updating")
+				certs, _, err := p.getTLSCertificates()
+				if err != nil {
+					p.d.Logger().WithError(err).Fatalf("Error in the new tls certificates")
+					return
+				}
+				p.load(certs)
+			case err, ok := <-p.watcher.Errors:
+				if !ok {
+					return
+				}
+				p.d.Logger().WithError(err).Fatalf("Error occured in the tls certificate change watcher")
+			}
+		}
+	}()
+
+	certPath := path.Dir(p.certLocation.CertPath)
+	keyPath := path.Dir(p.certLocation.KeyPath)
+
+	err = p.watcher.Add(certPath)
+	if err != nil {
+		p.d.Logger().WithError(err).Fatalf("Error watching the certFolder for tls certificate change")
+	}
+
+	if certPath != keyPath {
+		err = p.watcher.Add(keyPath)
+		if err != nil {
+			p.d.Logger().WithError(err).Fatalf("Error watching the keyFolder for tls certificate change")
+		}
+	}
+}
+
+func (p *certificatesProvider) waitForAllFilesChanges() {
+	flushUntil := time.After(2 * time.Second)
+	p.d.Logger().Infof("TLS certificates files changed, waiting for changes to finish")
+	stop := false
+	for {
+		select {
+		case <-flushUntil:
+			stop = true
+		case <-p.watcher.Events:
+			continue
+		}
+
+		if stop {
+			break
+		}
+	}
+}
+
+func (p *certificatesProvider) getCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if hello != nil {
+		for _, cert := range p.certs {
+			if cert.Leaf != nil && cert.Leaf.VerifyHostname(hello.ServerName) == nil {
+				return &cert, nil
+			}
+		}
+	}
+	return &p.certs[0], nil
+}
+
+func (p *certificatesProvider) stop() {
+	if p.watcher != nil {
+		p.watcher.Close()
+		p.watcher = nil
+	}
+}

--- a/driver/config/config_test.go
+++ b/driver/config/config_test.go
@@ -771,7 +771,9 @@ func TestLoadingTLSConfig(t *testing.T) {
 		p := config.MustNew(t, logger, os.Stderr, configx.SkipValidation())
 		p.MustSet(config.ViperKeyPublicTLSKeyBase64, keyBase64)
 		p.MustSet(config.ViperKeyPublicTLSCertBase64, certBase64)
-		assert.NotNil(t, p.GetTSLCertificatesForPublic())
+		certs, location, _ := p.GetTSLCertificatesForPublic()
+		assert.NotNil(t, certs)
+		assert.Nil(t, location)
 		assert.Equal(t, "Setting up HTTPS for public", hook.LastEntry().Message)
 	})
 
@@ -784,7 +786,9 @@ func TestLoadingTLSConfig(t *testing.T) {
 		p := config.MustNew(t, logger, os.Stderr, configx.SkipValidation())
 		p.MustSet(config.ViperKeyPublicTLSKeyPath, keyPath)
 		p.MustSet(config.ViperKeyPublicTLSCertPath, certPath)
-		assert.NotNil(t, p.GetTSLCertificatesForPublic())
+		certs, location, _ := p.GetTSLCertificatesForPublic()
+		assert.NotNil(t, certs)
+		assert.NotNil(t, location)
 		assert.Equal(t, "Setting up HTTPS for public", hook.LastEntry().Message)
 	})
 
@@ -797,8 +801,10 @@ func TestLoadingTLSConfig(t *testing.T) {
 		p := config.MustNew(t, logger, os.Stderr, configx.SkipValidation())
 		p.MustSet(config.ViperKeyPublicTLSKeyBase64, "empty")
 		p.MustSet(config.ViperKeyPublicTLSCertBase64, certBase64)
-		assert.Nil(t, p.GetTSLCertificatesForPublic())
-		assert.Equal(t, "TLS has not been configured for public, skipping", hook.LastEntry().Message)
+		certs, location, err := p.GetTSLCertificatesForPublic()
+		assert.Nil(t, certs)
+		assert.Nil(t, location)
+		assert.NotNil(t, err)
 	})
 
 	t.Run("case=public: failing to load certificate from a file", func(t *testing.T) {
@@ -810,8 +816,10 @@ func TestLoadingTLSConfig(t *testing.T) {
 		p := config.MustNew(t, logger, os.Stderr, configx.SkipValidation())
 		p.MustSet(config.ViperKeyPublicTLSKeyPath, "/dev/null")
 		p.MustSet(config.ViperKeyPublicTLSCertPath, certPath)
-		assert.Nil(t, p.GetTSLCertificatesForPublic())
-		assert.Equal(t, "TLS has not been configured for public, skipping", hook.LastEntry().Message)
+		certs, location, err := p.GetTSLCertificatesForPublic()
+		assert.Nil(t, certs)
+		assert.Nil(t, location)
+		assert.NotNil(t, err)
 	})
 
 	t.Run("case=admin: loading inline base64 certificate", func(t *testing.T) {
@@ -823,7 +831,9 @@ func TestLoadingTLSConfig(t *testing.T) {
 		p := config.MustNew(t, logger, os.Stderr, configx.SkipValidation())
 		p.MustSet(config.ViperKeyAdminTLSKeyBase64, keyBase64)
 		p.MustSet(config.ViperKeyAdminTLSCertBase64, certBase64)
-		assert.NotNil(t, p.GetTSLCertificatesForAdmin())
+		certs, location, _ := p.GetTSLCertificatesForAdmin()
+		assert.NotNil(t, certs)
+		assert.Nil(t, location)
 		assert.Equal(t, "Setting up HTTPS for admin", hook.LastEntry().Message)
 	})
 
@@ -836,7 +846,9 @@ func TestLoadingTLSConfig(t *testing.T) {
 		p := config.MustNew(t, logger, os.Stderr, configx.SkipValidation())
 		p.MustSet(config.ViperKeyAdminTLSKeyPath, keyPath)
 		p.MustSet(config.ViperKeyAdminTLSCertPath, certPath)
-		assert.NotNil(t, p.GetTSLCertificatesForAdmin())
+		certs, location, _ := p.GetTSLCertificatesForAdmin()
+		assert.NotNil(t, certs)
+		assert.NotNil(t, location)
 		assert.Equal(t, "Setting up HTTPS for admin", hook.LastEntry().Message)
 	})
 
@@ -849,8 +861,10 @@ func TestLoadingTLSConfig(t *testing.T) {
 		p := config.MustNew(t, logger, os.Stderr, configx.SkipValidation())
 		p.MustSet(config.ViperKeyAdminTLSKeyBase64, "empty")
 		p.MustSet(config.ViperKeyAdminTLSCertBase64, certBase64)
-		assert.Nil(t, p.GetTSLCertificatesForAdmin())
-		assert.Equal(t, "TLS has not been configured for admin, skipping", hook.LastEntry().Message)
+		certs, location, err := p.GetTSLCertificatesForAdmin()
+		assert.Nil(t, certs)
+		assert.Nil(t, location)
+		assert.NotNil(t, err)
 	})
 
 	t.Run("case=admin: failing to load certificate from a file", func(t *testing.T) {
@@ -862,8 +876,10 @@ func TestLoadingTLSConfig(t *testing.T) {
 		p := config.MustNew(t, logger, os.Stderr, configx.SkipValidation())
 		p.MustSet(config.ViperKeyAdminTLSKeyPath, "/dev/null")
 		p.MustSet(config.ViperKeyAdminTLSCertPath, certPath)
-		assert.Nil(t, p.GetTSLCertificatesForAdmin())
-		assert.Equal(t, "TLS has not been configured for admin, skipping", hook.LastEntry().Message)
+		certs, location, err := p.GetTSLCertificatesForAdmin()
+		assert.Nil(t, certs)
+		assert.Nil(t, location)
+		assert.NotNil(t, err)
 	})
 
 }

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/duo-labs/webauthn v0.0.0-20220212025243-7c9ee999e33e
 	github.com/fatih/color v1.13.0
 	github.com/form3tech-oss/jwt-go v3.2.3+incompatible
+	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-errors/errors v1.0.1
 	github.com/go-openapi/strfmt v0.20.3


### PR DESCRIPTION
Kubernetes is able to auto-renew certificates with cert-manager and update files in the container. I would be cool if Ory Kratos could support auto certificate update on file change.

## Related issue(s)
None

## Checklist

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [X] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [X] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further Comments
Adds dependencies to fsnotify to support Mac/Windows/Linux.

This is an example of a working PoC. I need feedback, 95% of the changes are similar as proposed for hydra ;-)
