### PR TITLE
fix: provide access to root path and error page

### DIFF
--- a/contrib/quickstart/oathkeeper/access-rules.yml
+++ b/contrib/quickstart/oathkeeper/access-rules.yml
@@ -26,7 +26,7 @@
     preserve_host: true
     url: "http://kratos-selfservice-ui-node:4435"
   match:
-    url: "http://127.0.0.1:4455/<{registration,welcome,recovery,verification,login,**.css,**.js,**.png}>"
+    url: "http://127.0.0.1:4455/<{registration,welcome,recovery,verification,login,error,**.css,**.js,**.png,}>"
     methods:
       - GET
   authenticators:


### PR DESCRIPTION
This is a fix for 2 minor issues I found while working on #2311:

1. http://127.0.0.1:4455/ returns a `404` instead of redirecting to http://127.0.0.1:4455/welcome (which is the behaviour in the standalone setup)
2. http://127.0.0.1:4455/error should be accessible in order to display more friendly and more detailed error messages.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).
