### PR TITLE
fix: quickstart/email-password kratos.yml

### DIFF
--- a/contrib/quickstart/kratos/email-password/kratos.yml
+++ b/contrib/quickstart/kratos/email-password/kratos.yml
@@ -77,7 +77,7 @@ identity:
   default_schema_id: default
   schemas:
     - id: default
-      schema: file:///etc/config/kratos/identity.schema.json
+      url: file:///etc/config/kratos/identity.schema.json
 
 courier:
   smtp:


### PR DESCRIPTION
identity.schemas.0.**schema** renamed to **url** according to the latest config schema:

https://github.com/ory/kratos/blob/22cb0816d7c7f66b9978a6b950361bb4f575d30d/embedx/config.schema.json#L2051-L2061

## Related issue(s)

#2339 

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).