### PR TITLE
fix: change SQLite database mode to 0600

### DIFF
--- a/.docker/Dockerfile-build
+++ b/.docker/Dockerfile-build
@@ -11,6 +11,7 @@ ADD internal/httpclient/go.* internal/httpclient/
 
 ENV GO111MODULE on
 ENV CGO_ENABLED 1
+ENV CGO_CPPFLAGS -DSQLITE_DEFAULT_FILE_PERMISSIONS=0600
 
 RUN go mod download
 


### PR DESCRIPTION
The default mode is 0644, which is allows broader access than necessary.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

I haven't added an automated test, as I didn't see a clean place to add it (maybe `test/e2e/run.sh` but there are no assertions there, and Cypress seems more about asserting what happens in the browser. If I should add a test, let me know where.

Instead, here's "proof" that it works:

```
$ docker-compose -f quickstart.yml -f quickstart-standalone.yml up --build --force-recreate
[...]
Ctrl+C
$ sudo ls -l /var/lib/docker/volumes/kratos_kratos-sqlite/_data
total 380
-rw-r--r-- 1 10000 systemd-journal 385024 Mar 25 16:24 db.sqlite
$ sudo rm /var/lib/docker/volumes/kratos_kratos-sqlite/_data/db.sqlite
$ git checkout sqlite-mode
$ sudo ls -l /var/lib/docker/volumes/kratos_kratos-sqlite/_data
total 380
-rw------- 1 10000 systemd-journal 385024 Mar 25 16:25 db.sqlite
```
