### PR TITLE
feat: read subject id from https://graph.microsoft.com/v1.0/me for microsoft

### DIFF
--- a/embedx/config.schema.json
+++ b/embedx/config.schema.json
@@ -409,6 +409,19 @@
             "contoso.onmicrosoft.com"
           ]
         },
+        "subject_source": {
+          "title": "Microsoft subject source",
+          "description": "Controls from which endpoint the subject identifier is taken by microsoft provider",
+          "type": "string",
+          "enum": [
+            "userinfo",
+            "me"
+          ],
+          "default": "userinfo",
+          "examples": [
+            "userinfo"
+          ]
+        },
         "apple_team_id": {
           "title": "Apple Developer Team ID",
           "description": "Apple Developer Team ID needed for generating a JWT token for client secret",

--- a/embedx/config.schema.json
+++ b/embedx/config.schema.json
@@ -411,7 +411,7 @@
         },
         "subject_source": {
           "title": "Microsoft subject source",
-          "description": "Controls from which endpoint the subject identifier is taken by microsoft provider",
+          "description": "Controls which source the subject identifier is taken from by microsoft provider. If set to `userinfo` (the default) then the identifier is taken from the `sub` field of OIDC ID token or data received from `/userinfo` standard OIDC endpoint. If set to `me` then the `id` field of data structure received from `https://graph.microsoft.com/v1.0/me` is taken as an identifier.",
           "type": "string",
           "enum": [
             "userinfo",

--- a/selfservice/strategy/oidc/provider_config.go
+++ b/selfservice/strategy/oidc/provider_config.go
@@ -59,6 +59,13 @@ type Configuration struct {
 	// `8eaef023-2b34-4da1-9baa-8bc8c9d6a490` or `contoso.onmicrosoft.com`.
 	Tenant string `json:"microsoft_tenant"`
 
+	// SubjectSource is a flag which controls from which endpoint the subject identifier is taken by microsoft provider.
+	// Can be either `userinfo` or `me`.
+	// If the value is `uerinfo` then the subject identifier is taken from sub field of uderifo standard endpoint response.
+	// If the value is `me` then the `id` field of https://graph.microsoft.com/v1.0/me response is taken as subject.
+	// The default is `userinfo`.
+	SubjectSource string `json:"subject_source"`
+
 	// TeamId is the Apple Developer Team ID that's needed for the `apple` `provider` to work.
 	// It can be found Apple Developer website and combined with `apple_private_key` and `apple_private_key_id`
 	// is used to generate `client_secret`

--- a/selfservice/strategy/oidc/provider_microsoft.go
+++ b/selfservice/strategy/oidc/provider_microsoft.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/gofrs/uuid"
@@ -101,13 +102,13 @@ func (m *ProviderMicrosoft) updateSubject(ctx context.Context, claims *Claims, e
 		defer resp.Body.Close()
 
 		var user struct {
-			Id string `json:"id"`
+			ID string `json:"id"`
 		}
 		if err := json.NewDecoder(resp.Body).Decode(&user); err != nil {
 			return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
 		}
 
-		claims.Subject = user.Id
+		claims.Subject = user.ID
 	}
 
 	return claims, nil


### PR DESCRIPTION
Adds the ability to read the OIDC subject ID from the `https://graph.microsoft.com/v1.0/me` endpoint. This introduces a new field `subject_source` to the OIDC configuration.

Closes https://github.com/ory/kratos/pull/2153