### PR TITLE
fix: Do not expose debug in a response when a schema is not found

### DIFF
--- a/schema/handler.go
+++ b/schema/handler.go
@@ -10,8 +10,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ory/kratos/driver/config"
 	"github.com/ory/x/urlx"
+
+	"github.com/ory/kratos/driver/config"
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/pkg/errors"
@@ -105,7 +106,7 @@ func (h *Handler) getByID(w http.ResponseWriter, r *http.Request, ps httprouter.
 
 		s, err = ss.GetByID(id)
 		if err != nil {
-			h.r.Writer().WriteError(w, r, errors.WithStack(herodot.ErrNotFound.WithDebugf("%+v", err)))
+			h.r.Writer().WriteError(w, r, errors.WithStack(herodot.ErrNotFound.WithReason("The schema is not found")))
 			return
 		}
 	}

--- a/schema/handler.go
+++ b/schema/handler.go
@@ -106,7 +106,7 @@ func (h *Handler) getByID(w http.ResponseWriter, r *http.Request, ps httprouter.
 
 		s, err = ss.GetByID(id)
 		if err != nil {
-			h.r.Writer().WriteError(w, r, errors.WithStack(herodot.ErrNotFound.WithReasonf("Identity schema `%s` could not be found.", id))))
+			h.r.Writer().WriteError(w, r, errors.WithStack(herodot.ErrNotFound.WithReasonf("Identity schema `%s` could not be found.", id)))
 			return
 		}
 	}

--- a/schema/handler.go
+++ b/schema/handler.go
@@ -106,7 +106,7 @@ func (h *Handler) getByID(w http.ResponseWriter, r *http.Request, ps httprouter.
 
 		s, err = ss.GetByID(id)
 		if err != nil {
-			h.r.Writer().WriteError(w, r, errors.WithStack(herodot.ErrNotFound.WithReason("The schema is not found")))
+			h.r.Writer().WriteError(w, r, errors.WithStack(herodot.ErrNotFound.WithReasonf("Identity schema `%s` could not be found.", id))))
 			return
 		}
 	}


### PR DESCRIPTION
## Related issue(s)

Do not expose debug in a response when a schema is not found.
This debug property does not look valuable for clients and just risks which is exposing server information such as middleware.

```
$  curl http://localhost:4455/.ory/kratos/public/schemas/not_found
{"error":{"code":404,"status":"Not Found","debug":"id=\nrid=\nerror=The request was malformed or contained invalid parameters\nreason=Unable to find JSON Schema ID: not_found\ndetails=map[]\ndebug=\n\ngithub.com/ory/kratos/schema.Schemas.GetByID\n\t/project/schema/schema.go:37\ngithub.com/ory/kratos/schema.(*Handler).getByID\n\t/project/schema/handler.go:106\ngithub.com/ory/kratos/x.NoCacheHandle.func1\n\t/project/x/nocache.go:18\ngithub.com/ory/kratos/x.NoCacheHandle.func1\n\t/project/x/nocache.go:18\ngithub.com/julienschmidt/httprouter.(*Router).ServeHTTP\n\t/go/pkg/mod/github.com/julienschmidt/httprouter@v1.3.0/router.go:387\ngithub.com/ory/nosurf.(*CSRFHandler).handleSuccess\n\t/go/pkg/mod/github.com/ory/nosurf@v1.2.7/handler.go:234\ngithub.com/ory/nosurf.(*CSRFHandler).ServeHTTP\n\t/go/pkg/mod/github.com/ory/nosurf@v1.2.7/handler.go:185\ngithub.com/urfave/negroni.Wrap.func1\n\t/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:46\ngithub.com/urfave/negroni.HandlerFunc.ServeHTTP\n\t/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:29\ngithub.com/urfave/negroni.middleware.ServeHTTP\n\t/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:38\ngithub.com/ory/kratos/x.glob..func1\n\t/project/x/clean_url.go:12\ngithub.com/urfave/negroni.HandlerFunc.ServeHTTP\n\t/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:29\ngithub.com/urfave/negroni.middleware.ServeHTTP\n\t/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:38\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2047\ngithub.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerResponseSize.func1\n\t/go/pkg/mod/github.com/prometheus/client_golang@v1.11.0/prometheus/promhttp/instrument_server.go:198\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2047\ngithub.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerCounter.func1\n\t/go/pkg/mod/github.com/prometheus/client_golang@v1.11.0/prometheus/promhttp/instrument_server.go:101\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2047\ngithub.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerDuration.func1\n\t/go/pkg/mod/github.com/prometheus/client_golang@v1.11.0/prometheus/promhttp/instrument_server.go:68\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2047\ngithub.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerDuration.func2\n\t/go/pkg/mod/github.com/prometheus/client_golang@v1.11.0/prometheus/promhttp/instrument_server.go:76\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2047\ngithub.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerRequestSize.func1\n\t/go/pkg/mod/github.com/prometheus/client_golang@v1.11.0/prometheus/promhttp/instrument_server.go:165\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2047\ngithub.com/ory/x/prometheusx.Metrics.instrumentHandlerStatusBucket.func1\n\t/go/pkg/mod/github.com/ory/x@v0.0.358/prometheusx/metrics.go:108\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2047\ngithub.com/ory/x/prometheusx.(*MetricsManager).ServeHTTP\n\t/go/pkg/mod/github.com/ory/x@v0.0.358/prometheusx/middleware.go:30\ngithub.com/urfave/negroni.middleware.ServeHTTP\n\t/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:38\ngithub.com/ory/x/tracing.(*Tracer).ServeHTTP\n\t/go/pkg/mod/github.com/ory/x@v0.0.358/tracing/middleware.go:36\ngithub.com/urfave/negroni.middleware.ServeHTTP\n\t/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:38\ngithub.com/ory/x/metricsx.(*Service).ServeHTTP\n\t/go/pkg/mod/github.com/ory/x@v0.0.358/metricsx/middleware.go:275\ngithub.com/urfave/negroni.middleware.ServeHTTP\n\t/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:38","message":"The requested resource could not be found"}}
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).
