### PR TITLE
feat: add certificate based authentication for smtp client

### DIFF
--- a/courier/smtp.go
+++ b/courier/smtp.go
@@ -28,6 +28,20 @@ type smtpClient struct {
 
 func newSMTP(ctx context.Context, deps Dependencies) *smtpClient {
 	uri := deps.CourierConfig(ctx).CourierSMTPURL()
+	var tlsCertificates []tls.Certificate
+	clientCertPath := deps.CourierConfig(ctx).CourierSMTPClientCertPath()
+	clientKeyPath := deps.CourierConfig(ctx).CourierSMTPClientKeyPath()
+
+	if clientCertPath != "" && clientKeyPath != "" {
+		clientCert, err := tls.LoadX509KeyPair(clientCertPath, clientKeyPath)
+		if err == nil {
+			tlsCertificates = append(tlsCertificates, clientCert)
+		} else {
+			deps.Logger().
+				WithError(err).
+				Error("Unable to load tls certificate and private key for smtp client.")
+		}
+	}
 
 	password, _ := uri.User.Password()
 	port, _ := strconv.ParseInt(uri.Port(), 10, 0)
@@ -44,6 +58,11 @@ func newSMTP(ctx context.Context, deps Dependencies) *smtpClient {
 
 	sslSkipVerify, _ := strconv.ParseBool(uri.Query().Get("skip_ssl_verify"))
 
+	serverName := uri.Query().Get("server_name")
+	if serverName == "" {
+		serverName = uri.Hostname()
+	}
+
 	// SMTP schemes
 	// smtp: smtp clear text (with uri parameter) or with StartTLS (enforced by default)
 	// smtps: smtp with implicit TLS (recommended way in 2021 to avoid StartTLS downgrade attacks
@@ -54,13 +73,13 @@ func newSMTP(ctx context.Context, deps Dependencies) *smtpClient {
 		skipStartTLS, _ := strconv.ParseBool(uri.Query().Get("disable_starttls"))
 		if !skipStartTLS {
 			// #nosec G402 This is ok (and required!) because it is configurable and disabled by default.
-			dialer.TLSConfig = &tls.Config{InsecureSkipVerify: sslSkipVerify, ServerName: uri.Hostname()}
+			dialer.TLSConfig = &tls.Config{InsecureSkipVerify: sslSkipVerify, Certificates: tlsCertificates, ServerName: serverName}
 			// Enforcing StartTLS
 			dialer.StartTLSPolicy = gomail.MandatoryStartTLS
 		}
 	case "smtps":
 		// #nosec G402 This is ok (and required!) because it is configurable and disabled by default.
-		dialer.TLSConfig = &tls.Config{InsecureSkipVerify: sslSkipVerify, ServerName: uri.Hostname()}
+		dialer.TLSConfig = &tls.Config{InsecureSkipVerify: sslSkipVerify, Certificates: tlsCertificates, ServerName: serverName}
 		dialer.SSL = true
 	}
 

--- a/driver/config/config.go
+++ b/driver/config/config.go
@@ -61,6 +61,8 @@ const (
 	UnknownVersion                                           = "unknown version"
 	ViperKeyDSN                                              = "dsn"
 	ViperKeyCourierSMTPURL                                   = "courier.smtp.connection_uri"
+	ViperKeyCourierSMTPClientCertPath                        = "courier.smtp.client_cert_path"
+	ViperKeyCourierSMTPClientKeyPath                         = "courier.smtp.client_key_path"
 	ViperKeyCourierTemplatesPath                             = "courier.template_override_path"
 	ViperKeyCourierTemplatesRecoveryInvalidEmail             = "courier.templates.recovery.invalid.email"
 	ViperKeyCourierTemplatesRecoveryValidEmail               = "courier.templates.recovery.valid.email"
@@ -239,6 +241,8 @@ type (
 	}
 	CourierConfigs interface {
 		CourierSMTPURL() *url.URL
+		CourierSMTPClientCertPath() string
+		CourierSMTPClientKeyPath() string
 		CourierSMTPFrom() string
 		CourierSMTPFromName() string
 		CourierSMTPHeaders() map[string]string
@@ -869,6 +873,14 @@ func (p *Config) SelfServiceFlowRegistrationRequestLifespan() time.Duration {
 
 func (p *Config) SelfServiceFlowLogoutRedirectURL() *url.URL {
 	return p.p.RequestURIF(ViperKeySelfServiceLogoutBrowserDefaultReturnTo, p.SelfServiceBrowserDefaultReturnTo())
+}
+
+func (p *Config) CourierSMTPClientCertPath() string {
+	return p.p.StringF(ViperKeyCourierSMTPClientCertPath, "")
+}
+
+func (p *Config) CourierSMTPClientKeyPath() string {
+	return p.p.StringF(ViperKeyCourierSMTPClientKeyPath, "")
 }
 
 func (p *Config) CourierSMTPFrom() string {

--- a/embedx/config.schema.json
+++ b/embedx/config.schema.json
@@ -1494,10 +1494,23 @@
                 "smtp://foo:bar@my-mailserver:1234/ (Explicit StartTLS with certificate trust verification)",
                 "smtp://foo:bar@my-mailserver:1234/?skip_ssl_verify=true (NOT RECOMMENDED: Explicit StartTLS without certificate trust verification)",
                 "smtps://foo:bar@my-mailserver:1234/ (Implicit TLS with certificate trust verification)",
-                "smtps://foo:bar@my-mailserver:1234/?skip_ssl_verify=true (NOT RECOMMENDED: Implicit TLS without certificate trust verification)"
+                "smtps://foo:bar@my-mailserver:1234/?skip_ssl_verify=true (NOT RECOMMENDED: Implicit TLS without certificate trust verification)",
+                "smtps://subdomain.my-mailserver:1234/?server_name=my-mailserver (allows TLS to work if the server is hosted on a sudomain that uses a non-wildcard domain certificate)"
               ],
               "type": "string",
               "pattern": "^smtps?:\\/\\/.*"
+            },
+            "client_cert_path": {
+              "title": "SMTP Client certificate path",
+              "description": "Path of the client X.509 certificate, in case of certificate based client authentication to the SMTP server.",
+              "type": "string",
+              "default": ""
+            },
+            "client_key_path": {
+              "title": "SMTP Client private key path",
+              "description": "Path of the client certificate private key, in case of certificate based client authentication to the SMTP server",
+              "type": "string",
+              "default": ""
             },
             "from_address": {
               "title": "SMTP Sender Address",


### PR DESCRIPTION
This is an implementation of certificate based authentication for the smtp client, as described in design document [#2350](https://github.com/ory/kratos/issues/2350)

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).
