### PR TITLE
docs: schema fixes

### DIFF
--- a/.schema/openapi/patches/schema.yaml
+++ b/.schema/openapi/patches/schema.yaml
@@ -8,8 +8,8 @@
     mapping:
       input: "#/components/schemas/uiNodeInputAttributes"
       text: "#/components/schemas/uiNodeTextAttributes"
-      image: "#/components/schemas/uiNodeImageAttributes"
-      anchor: "#/components/schemas/uiNodeAnchorAttributes"
+      img: "#/components/schemas/uiNodeImageAttributes"
+      a: "#/components/schemas/uiNodeAnchorAttributes"
       script: "#/components/schemas/uiNodeScriptAttributes"
 - op: add
   path: /components/schemas/uiNodeAttributes/oneOf

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,14 @@ $(call make-lint-dependency)
 docs/cli:
 		go run ./cmd/clidoc/. .
 
+.PHONY: docs/api
+docs/api:
+		npx @redocly/openapi-cli preview-docs spec/api.json
+
+.PHONY: docs/swagger
+docs/swagger:
+		npx @redocly/openapi-cli preview-docs spec/swagger.json
+
 .bin/ory: Makefile
 		bash <(curl https://raw.githubusercontent.com/ory/meta/master/install.sh) -d -b .bin ory v0.1.14
 		touch -a -m .bin/ory

--- a/README.md
+++ b/README.md
@@ -578,3 +578,12 @@ To prepare documentation tests, run `npm i` to install
 
 - test all documentation: <code type="make/command">make test-docs</code>
 - test an individual file: <code type="npm/installed-executable">text-run</code>
+
+#### Preview API documentation
+
+- update the SDK including the OpenAPI specification:
+  <code type="make/command">make sdk</code>
+- run preview server for API documentation: <code type="make/command">make
+  docs/api</code>
+- run preview server for swagger documentation: <code type="make/command">make
+  docs/swagger</code>

--- a/internal/httpclient/api/openapi.yaml
+++ b/internal/httpclient/api/openapi.yaml
@@ -3461,8 +3461,8 @@ components:
               id: 0
               text: text
               type: type
-            type: ""
-            group: group
+            type: text
+            group: default
           - meta:
               label:
                 context: '{}'
@@ -3478,8 +3478,8 @@ components:
               id: 0
               text: text
               type: type
-            type: ""
-            group: group
+            type: text
+            group: default
           method: method
           action: action
           messages:
@@ -3593,8 +3593,8 @@ components:
               id: 0
               text: text
               type: type
-            type: ""
-            group: group
+            type: text
+            group: default
           - meta:
               label:
                 context: '{}'
@@ -3610,8 +3610,8 @@ components:
               id: 0
               text: text
               type: type
-            type: ""
-            group: group
+            type: text
+            group: default
           method: method
           action: action
           messages:
@@ -3727,8 +3727,8 @@ components:
               id: 0
               text: text
               type: type
-            type: ""
-            group: group
+            type: text
+            group: default
           - meta:
               label:
                 context: '{}'
@@ -3744,8 +3744,8 @@ components:
               id: 0
               text: text
               type: type
-            type: ""
-            group: group
+            type: text
+            group: default
           method: method
           action: action
           messages:
@@ -3824,8 +3824,8 @@ components:
               id: 0
               text: text
               type: type
-            type: ""
-            group: group
+            type: text
+            group: default
           - meta:
               label:
                 context: '{}'
@@ -3841,8 +3841,8 @@ components:
               id: 0
               text: text
               type: type
-            type: ""
-            group: group
+            type: text
+            group: default
           method: method
           action: action
           messages:
@@ -3988,8 +3988,8 @@ components:
               id: 0
               text: text
               type: type
-            type: ""
-            group: group
+            type: text
+            group: default
           - meta:
               label:
                 context: '{}'
@@ -4005,8 +4005,8 @@ components:
               id: 0
               text: text
               type: type
-            type: ""
-            group: group
+            type: text
+            group: default
           method: method
           action: action
           messages:
@@ -4964,8 +4964,8 @@ components:
             id: 0
             text: text
             type: type
-          type: ""
-          group: group
+          type: text
+          group: default
         - meta:
             label:
               context: '{}'
@@ -4981,8 +4981,8 @@ components:
             id: 0
             text: text
             type: type
-          type: ""
-          group: group
+          type: text
+          group: default
         method: method
         action: action
         messages:
@@ -5035,12 +5035,23 @@ components:
           id: 0
           text: text
           type: type
-        type: ""
-        group: group
+        type: text
+        group: default
       properties:
         attributes:
           $ref: '#/components/schemas/uiNodeAttributes'
         group:
+          description: Group specifies which group (e.g. password authenticator) this
+            node belongs to.
+          enum:
+          - default
+          - password
+          - oidc
+          - profile
+          - link
+          - totp
+          - lookup_secret
+          - webauthn
           type: string
         messages:
           items:
@@ -5053,6 +5064,13 @@ components:
             The node's type
 
             Can be one of: text, input, img, a, script
+          enum:
+          - text
+          - input
+          - img
+          - a
+          - script
+          type: string
       required:
       - attributes
       - group
@@ -5076,6 +5094,13 @@ components:
           description: |-
             NodeType represents this node's types. It is a mirror of `node.type` and
             is primarily used to allow compatibility with OpenAPI 3.0.
+          enum:
+          - text
+          - input
+          - img
+          - a
+          - script
+          type: string
         title:
           $ref: '#/components/schemas/uiText'
       required:
@@ -5101,8 +5126,6 @@ components:
       - $ref: '#/components/schemas/uiNodeAnchorAttributes'
       - $ref: '#/components/schemas/uiNodeScriptAttributes'
       title: Attributes represents a list of attributes (e.g. `href="foo"` for links).
-    uiNodeGroup:
-      type: string
     uiNodeImageAttributes:
       properties:
         height:
@@ -5116,6 +5139,13 @@ components:
           description: |-
             NodeType represents this node's types. It is a mirror of `node.type` and
             is primarily used to allow compatibility with OpenAPI 3.0.
+          enum:
+          - text
+          - input
+          - img
+          - a
+          - script
+          type: string
         src:
           description: |-
             The image's source URL.
@@ -5151,6 +5181,13 @@ components:
           description: |-
             NodeType represents this node's types. It is a mirror of `node.type` and
             is primarily used to allow compatibility with OpenAPI 3.0.
+          enum:
+          - text
+          - input
+          - img
+          - a
+          - script
+          type: string
         onclick:
           description: |-
             OnClick may contain javascript which should be executed on click. This is primarily
@@ -5206,6 +5243,13 @@ components:
           description: |-
             NodeType represents this node's types. It is a mirror of `node.type` and
             is primarily used to allow compatibility with OpenAPI 3.0.
+          enum:
+          - text
+          - input
+          - img
+          - a
+          - script
+          type: string
         nonce:
           description: |-
             Nonce for CSP
@@ -5244,6 +5288,13 @@ components:
           description: |-
             NodeType represents this node's types. It is a mirror of `node.type` and
             is primarily used to allow compatibility with OpenAPI 3.0.
+          enum:
+          - text
+          - input
+          - img
+          - a
+          - script
+          type: string
         text:
           $ref: '#/components/schemas/uiText'
       required:

--- a/internal/httpclient/api/openapi.yaml
+++ b/internal/httpclient/api/openapi.yaml
@@ -5063,10 +5063,7 @@ components:
         meta:
           $ref: '#/components/schemas/uiNodeMeta'
         type:
-          description: |-
-            The node's type
-
-            Can be one of: text, input, img, a, script
+          description: The node's type
           enum:
           - text
           - input

--- a/internal/httpclient/api/openapi.yaml
+++ b/internal/httpclient/api/openapi.yaml
@@ -3461,7 +3461,7 @@ components:
               id: 0
               text: text
               type: type
-            type: ""
+            type: text
             group: default
           - meta:
               label:
@@ -3478,7 +3478,7 @@ components:
               id: 0
               text: text
               type: type
-            type: ""
+            type: text
             group: default
           method: method
           action: action
@@ -3593,7 +3593,7 @@ components:
               id: 0
               text: text
               type: type
-            type: ""
+            type: text
             group: default
           - meta:
               label:
@@ -3610,7 +3610,7 @@ components:
               id: 0
               text: text
               type: type
-            type: ""
+            type: text
             group: default
           method: method
           action: action
@@ -3728,7 +3728,7 @@ components:
               id: 0
               text: text
               type: type
-            type: ""
+            type: text
             group: default
           - meta:
               label:
@@ -3745,7 +3745,7 @@ components:
               id: 0
               text: text
               type: type
-            type: ""
+            type: text
             group: default
           method: method
           action: action
@@ -3826,7 +3826,7 @@ components:
               id: 0
               text: text
               type: type
-            type: ""
+            type: text
             group: default
           - meta:
               label:
@@ -3843,7 +3843,7 @@ components:
               id: 0
               text: text
               type: type
-            type: ""
+            type: text
             group: default
           method: method
           action: action
@@ -3991,7 +3991,7 @@ components:
               id: 0
               text: text
               type: type
-            type: ""
+            type: text
             group: default
           - meta:
               label:
@@ -4008,7 +4008,7 @@ components:
               id: 0
               text: text
               type: type
-            type: ""
+            type: text
             group: default
           method: method
           action: action
@@ -4967,7 +4967,7 @@ components:
             id: 0
             text: text
             type: type
-          type: ""
+          type: text
           group: default
         - meta:
             label:
@@ -4984,7 +4984,7 @@ components:
             id: 0
             text: text
             type: type
-          type: ""
+          type: text
           group: default
         method: method
         action: action
@@ -5038,7 +5038,7 @@ components:
           id: 0
           text: text
           type: type
-        type: ""
+        type: text
         group: default
       properties:
         attributes:
@@ -5064,6 +5064,13 @@ components:
           $ref: '#/components/schemas/uiNodeMeta'
         type:
           description: The node's type
+          enum:
+          - text
+          - input
+          - img
+          - a
+          - script
+          type: string
       required:
       - attributes
       - group
@@ -5087,6 +5094,13 @@ components:
           description: |-
             NodeType represents this node's types. It is a mirror of `node.type` and
             is primarily used to allow compatibility with OpenAPI 3.0.
+          enum:
+          - text
+          - input
+          - img
+          - a
+          - script
+          type: string
         title:
           $ref: '#/components/schemas/uiText'
       required:
@@ -5125,6 +5139,13 @@ components:
           description: |-
             NodeType represents this node's types. It is a mirror of `node.type` and
             is primarily used to allow compatibility with OpenAPI 3.0.
+          enum:
+          - text
+          - input
+          - img
+          - a
+          - script
+          type: string
         src:
           description: |-
             The image's source URL.
@@ -5160,6 +5181,13 @@ components:
           description: |-
             NodeType represents this node's types. It is a mirror of `node.type` and
             is primarily used to allow compatibility with OpenAPI 3.0.
+          enum:
+          - text
+          - input
+          - img
+          - a
+          - script
+          type: string
         onclick:
           description: |-
             OnClick may contain javascript which should be executed on click. This is primarily
@@ -5215,6 +5243,13 @@ components:
           description: |-
             NodeType represents this node's types. It is a mirror of `node.type` and
             is primarily used to allow compatibility with OpenAPI 3.0.
+          enum:
+          - text
+          - input
+          - img
+          - a
+          - script
+          type: string
         nonce:
           description: |-
             Nonce for CSP
@@ -5253,6 +5288,13 @@ components:
           description: |-
             NodeType represents this node's types. It is a mirror of `node.type` and
             is primarily used to allow compatibility with OpenAPI 3.0.
+          enum:
+          - text
+          - input
+          - img
+          - a
+          - script
+          type: string
         text:
           $ref: '#/components/schemas/uiText'
       required:

--- a/internal/httpclient/api/openapi.yaml
+++ b/internal/httpclient/api/openapi.yaml
@@ -3461,7 +3461,7 @@ components:
               id: 0
               text: text
               type: type
-            type: type
+            type: ""
             group: group
           - meta:
               label:
@@ -3478,7 +3478,7 @@ components:
               id: 0
               text: text
               type: type
-            type: type
+            type: ""
             group: group
           method: method
           action: action
@@ -3593,7 +3593,7 @@ components:
               id: 0
               text: text
               type: type
-            type: type
+            type: ""
             group: group
           - meta:
               label:
@@ -3610,7 +3610,7 @@ components:
               id: 0
               text: text
               type: type
-            type: type
+            type: ""
             group: group
           method: method
           action: action
@@ -3727,7 +3727,7 @@ components:
               id: 0
               text: text
               type: type
-            type: type
+            type: ""
             group: group
           - meta:
               label:
@@ -3744,7 +3744,7 @@ components:
               id: 0
               text: text
               type: type
-            type: type
+            type: ""
             group: group
           method: method
           action: action
@@ -3824,7 +3824,7 @@ components:
               id: 0
               text: text
               type: type
-            type: type
+            type: ""
             group: group
           - meta:
               label:
@@ -3841,7 +3841,7 @@ components:
               id: 0
               text: text
               type: type
-            type: type
+            type: ""
             group: group
           method: method
           action: action
@@ -3988,7 +3988,7 @@ components:
               id: 0
               text: text
               type: type
-            type: type
+            type: ""
             group: group
           - meta:
               label:
@@ -4005,7 +4005,7 @@ components:
               id: 0
               text: text
               type: type
-            type: type
+            type: ""
             group: group
           method: method
           action: action
@@ -4964,7 +4964,7 @@ components:
             id: 0
             text: text
             type: type
-          type: type
+          type: ""
           group: group
         - meta:
             label:
@@ -4981,7 +4981,7 @@ components:
             id: 0
             text: text
             type: type
-          type: type
+          type: ""
           group: group
         method: method
         action: action
@@ -5035,7 +5035,7 @@ components:
           id: 0
           text: text
           type: type
-        type: type
+        type: ""
         group: group
       properties:
         attributes:
@@ -5049,7 +5049,10 @@ components:
         meta:
           $ref: '#/components/schemas/uiNodeMeta'
         type:
-          type: string
+          description: |-
+            The node's type
+
+            Can be one of: text, input, img, a
       required:
       - attributes
       - group
@@ -5070,7 +5073,9 @@ components:
           description: A unique identifier
           type: string
         node_type:
-          type: string
+          description: |-
+            NodeType represents this node's types. It is a mirror of `node.type` and
+            is primarily used to allow compatibility with OpenAPI 3.0.
         title:
           $ref: '#/components/schemas/uiText'
       required:
@@ -5108,7 +5113,9 @@ components:
           description: A unique identifier
           type: string
         node_type:
-          type: string
+          description: |-
+            NodeType represents this node's types. It is a mirror of `node.type` and
+            is primarily used to allow compatibility with OpenAPI 3.0.
         src:
           description: |-
             The image's source URL.
@@ -5141,7 +5148,9 @@ components:
           description: The input's element name.
           type: string
         node_type:
-          type: string
+          description: |-
+            NodeType represents this node's types. It is a mirror of `node.type` and
+            is primarily used to allow compatibility with OpenAPI 3.0.
         onclick:
           description: |-
             OnClick may contain javascript which should be executed on click. This is primarily
@@ -5194,7 +5203,9 @@ components:
           description: The script's integrity hash
           type: string
         node_type:
-          type: string
+          description: |-
+            NodeType represents this node's types. It is a mirror of `node.type` and
+            is primarily used to allow compatibility with OpenAPI 3.0.
         nonce:
           description: |-
             Nonce for CSP
@@ -5230,7 +5241,9 @@ components:
           description: A unique identifier
           type: string
         node_type:
-          type: string
+          description: |-
+            NodeType represents this node's types. It is a mirror of `node.type` and
+            is primarily used to allow compatibility with OpenAPI 3.0.
         text:
           $ref: '#/components/schemas/uiText'
       required:
@@ -5239,8 +5252,6 @@ components:
       - text
       title: TextAttributes represents the attributes of a text node.
       type: object
-    uiNodeType:
-      type: string
     uiNodes:
       items:
         $ref: '#/components/schemas/uiNode'

--- a/internal/httpclient/api/openapi.yaml
+++ b/internal/httpclient/api/openapi.yaml
@@ -5113,8 +5113,8 @@ components:
     uiNodeAttributes:
       discriminator:
         mapping:
-          anchor: '#/components/schemas/uiNodeAnchorAttributes'
-          image: '#/components/schemas/uiNodeImageAttributes'
+          a: '#/components/schemas/uiNodeAnchorAttributes'
+          img: '#/components/schemas/uiNodeImageAttributes'
           input: '#/components/schemas/uiNodeInputAttributes'
           script: '#/components/schemas/uiNodeScriptAttributes'
           text: '#/components/schemas/uiNodeTextAttributes'

--- a/internal/httpclient/api/openapi.yaml
+++ b/internal/httpclient/api/openapi.yaml
@@ -3670,6 +3670,7 @@ components:
       - issued_at
       - request_url
       - state
+      - type
       - ui
       title: A Recovery Flow
       type: object
@@ -3797,6 +3798,7 @@ components:
       - id
       - issued_at
       - request_url
+      - type
       - ui
       type: object
     selfServiceSettingsFlow:
@@ -3949,6 +3951,7 @@ components:
       - issued_at
       - request_url
       - state
+      - type
       - ui
       title: Flow represents a Settings Flow
       type: object

--- a/internal/httpclient/api/openapi.yaml
+++ b/internal/httpclient/api/openapi.yaml
@@ -3461,7 +3461,7 @@ components:
               id: 0
               text: text
               type: type
-            type: text
+            type: ""
             group: default
           - meta:
               label:
@@ -3478,7 +3478,7 @@ components:
               id: 0
               text: text
               type: type
-            type: text
+            type: ""
             group: default
           method: method
           action: action
@@ -3593,7 +3593,7 @@ components:
               id: 0
               text: text
               type: type
-            type: text
+            type: ""
             group: default
           - meta:
               label:
@@ -3610,7 +3610,7 @@ components:
               id: 0
               text: text
               type: type
-            type: text
+            type: ""
             group: default
           method: method
           action: action
@@ -3728,7 +3728,7 @@ components:
               id: 0
               text: text
               type: type
-            type: text
+            type: ""
             group: default
           - meta:
               label:
@@ -3745,7 +3745,7 @@ components:
               id: 0
               text: text
               type: type
-            type: text
+            type: ""
             group: default
           method: method
           action: action
@@ -3826,7 +3826,7 @@ components:
               id: 0
               text: text
               type: type
-            type: text
+            type: ""
             group: default
           - meta:
               label:
@@ -3843,7 +3843,7 @@ components:
               id: 0
               text: text
               type: type
-            type: text
+            type: ""
             group: default
           method: method
           action: action
@@ -3991,7 +3991,7 @@ components:
               id: 0
               text: text
               type: type
-            type: text
+            type: ""
             group: default
           - meta:
               label:
@@ -4008,7 +4008,7 @@ components:
               id: 0
               text: text
               type: type
-            type: text
+            type: ""
             group: default
           method: method
           action: action
@@ -4967,7 +4967,7 @@ components:
             id: 0
             text: text
             type: type
-          type: text
+          type: ""
           group: default
         - meta:
             label:
@@ -4984,7 +4984,7 @@ components:
             id: 0
             text: text
             type: type
-          type: text
+          type: ""
           group: default
         method: method
         action: action
@@ -5038,7 +5038,7 @@ components:
           id: 0
           text: text
           type: type
-        type: text
+        type: ""
         group: default
       properties:
         attributes:
@@ -5064,13 +5064,6 @@ components:
           $ref: '#/components/schemas/uiNodeMeta'
         type:
           description: The node's type
-          enum:
-          - text
-          - input
-          - img
-          - a
-          - script
-          type: string
       required:
       - attributes
       - group
@@ -5094,13 +5087,6 @@ components:
           description: |-
             NodeType represents this node's types. It is a mirror of `node.type` and
             is primarily used to allow compatibility with OpenAPI 3.0.
-          enum:
-          - text
-          - input
-          - img
-          - a
-          - script
-          type: string
         title:
           $ref: '#/components/schemas/uiText'
       required:
@@ -5139,13 +5125,6 @@ components:
           description: |-
             NodeType represents this node's types. It is a mirror of `node.type` and
             is primarily used to allow compatibility with OpenAPI 3.0.
-          enum:
-          - text
-          - input
-          - img
-          - a
-          - script
-          type: string
         src:
           description: |-
             The image's source URL.
@@ -5181,13 +5160,6 @@ components:
           description: |-
             NodeType represents this node's types. It is a mirror of `node.type` and
             is primarily used to allow compatibility with OpenAPI 3.0.
-          enum:
-          - text
-          - input
-          - img
-          - a
-          - script
-          type: string
         onclick:
           description: |-
             OnClick may contain javascript which should be executed on click. This is primarily
@@ -5243,13 +5215,6 @@ components:
           description: |-
             NodeType represents this node's types. It is a mirror of `node.type` and
             is primarily used to allow compatibility with OpenAPI 3.0.
-          enum:
-          - text
-          - input
-          - img
-          - a
-          - script
-          type: string
         nonce:
           description: |-
             Nonce for CSP
@@ -5288,13 +5253,6 @@ components:
           description: |-
             NodeType represents this node's types. It is a mirror of `node.type` and
             is primarily used to allow compatibility with OpenAPI 3.0.
-          enum:
-          - text
-          - input
-          - img
-          - a
-          - script
-          type: string
         text:
           $ref: '#/components/schemas/uiText'
       required:

--- a/internal/httpclient/api/openapi.yaml
+++ b/internal/httpclient/api/openapi.yaml
@@ -5052,7 +5052,7 @@ components:
           description: |-
             The node's type
 
-            Can be one of: text, input, img, a
+            Can be one of: text, input, img, a, script
       required:
       - attributes
       - group

--- a/internal/httpclient/docs/SelfServiceRecoveryFlow.md
+++ b/internal/httpclient/docs/SelfServiceRecoveryFlow.md
@@ -11,14 +11,14 @@ Name | Type | Description | Notes
 **RequestUrl** | **string** | RequestURL is the initial URL that was requested from Ory Kratos. It can be used to forward information contained in the URL&#39;s path or query for example. | 
 **ReturnTo** | Pointer to **string** | ReturnTo contains the requested return_to URL. | [optional] 
 **State** | [**SelfServiceRecoveryFlowState**](SelfServiceRecoveryFlowState.md) |  | 
-**Type** | Pointer to **string** | The flow type can either be &#x60;api&#x60; or &#x60;browser&#x60;. | [optional] 
+**Type** | **string** | The flow type can either be &#x60;api&#x60; or &#x60;browser&#x60;. | 
 **Ui** | [**UiContainer**](UiContainer.md) |  | 
 
 ## Methods
 
 ### NewSelfServiceRecoveryFlow
 
-`func NewSelfServiceRecoveryFlow(expiresAt time.Time, id string, issuedAt time.Time, requestUrl string, state SelfServiceRecoveryFlowState, ui UiContainer, ) *SelfServiceRecoveryFlow`
+`func NewSelfServiceRecoveryFlow(expiresAt time.Time, id string, issuedAt time.Time, requestUrl string, state SelfServiceRecoveryFlowState, type_ string, ui UiContainer, ) *SelfServiceRecoveryFlow`
 
 NewSelfServiceRecoveryFlow instantiates a new SelfServiceRecoveryFlow object
 This constructor will assign default values to properties that have it defined,
@@ -202,11 +202,6 @@ and a boolean to check if the value has been set.
 
 SetType sets Type field to given value.
 
-### HasType
-
-`func (o *SelfServiceRecoveryFlow) HasType() bool`
-
-HasType returns a boolean if a field has been set.
 
 ### GetUi
 

--- a/internal/httpclient/docs/SelfServiceRegistrationFlow.md
+++ b/internal/httpclient/docs/SelfServiceRegistrationFlow.md
@@ -10,14 +10,14 @@ Name | Type | Description | Notes
 **IssuedAt** | **time.Time** | IssuedAt is the time (UTC) when the flow occurred. | 
 **RequestUrl** | **string** | RequestURL is the initial URL that was requested from Ory Kratos. It can be used to forward information contained in the URL&#39;s path or query for example. | 
 **ReturnTo** | Pointer to **string** | ReturnTo contains the requested return_to URL. | [optional] 
-**Type** | Pointer to **string** | The flow type can either be &#x60;api&#x60; or &#x60;browser&#x60;. | [optional] 
+**Type** | **string** | The flow type can either be &#x60;api&#x60; or &#x60;browser&#x60;. | 
 **Ui** | [**UiContainer**](UiContainer.md) |  | 
 
 ## Methods
 
 ### NewSelfServiceRegistrationFlow
 
-`func NewSelfServiceRegistrationFlow(expiresAt time.Time, id string, issuedAt time.Time, requestUrl string, ui UiContainer, ) *SelfServiceRegistrationFlow`
+`func NewSelfServiceRegistrationFlow(expiresAt time.Time, id string, issuedAt time.Time, requestUrl string, type_ string, ui UiContainer, ) *SelfServiceRegistrationFlow`
 
 NewSelfServiceRegistrationFlow instantiates a new SelfServiceRegistrationFlow object
 This constructor will assign default values to properties that have it defined,
@@ -181,11 +181,6 @@ and a boolean to check if the value has been set.
 
 SetType sets Type field to given value.
 
-### HasType
-
-`func (o *SelfServiceRegistrationFlow) HasType() bool`
-
-HasType returns a boolean if a field has been set.
 
 ### GetUi
 

--- a/internal/httpclient/docs/SelfServiceSettingsFlow.md
+++ b/internal/httpclient/docs/SelfServiceSettingsFlow.md
@@ -12,14 +12,14 @@ Name | Type | Description | Notes
 **RequestUrl** | **string** | RequestURL is the initial URL that was requested from Ory Kratos. It can be used to forward information contained in the URL&#39;s path or query for example. | 
 **ReturnTo** | Pointer to **string** | ReturnTo contains the requested return_to URL. | [optional] 
 **State** | [**SelfServiceSettingsFlowState**](SelfServiceSettingsFlowState.md) |  | 
-**Type** | Pointer to **string** | The flow type can either be &#x60;api&#x60; or &#x60;browser&#x60;. | [optional] 
+**Type** | **string** | The flow type can either be &#x60;api&#x60; or &#x60;browser&#x60;. | 
 **Ui** | [**UiContainer**](UiContainer.md) |  | 
 
 ## Methods
 
 ### NewSelfServiceSettingsFlow
 
-`func NewSelfServiceSettingsFlow(expiresAt time.Time, id string, identity Identity, issuedAt time.Time, requestUrl string, state SelfServiceSettingsFlowState, ui UiContainer, ) *SelfServiceSettingsFlow`
+`func NewSelfServiceSettingsFlow(expiresAt time.Time, id string, identity Identity, issuedAt time.Time, requestUrl string, state SelfServiceSettingsFlowState, type_ string, ui UiContainer, ) *SelfServiceSettingsFlow`
 
 NewSelfServiceSettingsFlow instantiates a new SelfServiceSettingsFlow object
 This constructor will assign default values to properties that have it defined,
@@ -223,11 +223,6 @@ and a boolean to check if the value has been set.
 
 SetType sets Type field to given value.
 
-### HasType
-
-`func (o *SelfServiceSettingsFlow) HasType() bool`
-
-HasType returns a boolean if a field has been set.
 
 ### GetUi
 

--- a/internal/httpclient/docs/UiNode.md
+++ b/internal/httpclient/docs/UiNode.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **Group** | **string** | Group specifies which group (e.g. password authenticator) this node belongs to. | 
 **Messages** | [**[]UiText**](UiText.md) |  | 
 **Meta** | [**UiNodeMeta**](UiNodeMeta.md) |  | 
-**Type** | **string** | The node&#39;s type  Can be one of: text, input, img, a, script | 
+**Type** | **string** | The node&#39;s type | 
 
 ## Methods
 

--- a/internal/httpclient/docs/UiNode.md
+++ b/internal/httpclient/docs/UiNode.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **Group** | **string** |  | 
 **Messages** | [**[]UiText**](UiText.md) |  | 
 **Meta** | [**UiNodeMeta**](UiNodeMeta.md) |  | 
-**Type** | **interface{}** | The node&#39;s type  Can be one of: text, input, img, a | 
+**Type** | **interface{}** | The node&#39;s type  Can be one of: text, input, img, a, script | 
 
 ## Methods
 

--- a/internal/httpclient/docs/UiNode.md
+++ b/internal/httpclient/docs/UiNode.md
@@ -8,13 +8,13 @@ Name | Type | Description | Notes
 **Group** | **string** |  | 
 **Messages** | [**[]UiText**](UiText.md) |  | 
 **Meta** | [**UiNodeMeta**](UiNodeMeta.md) |  | 
-**Type** | **string** |  | 
+**Type** | **interface{}** | The node&#39;s type  Can be one of: text, input, img, a | 
 
 ## Methods
 
 ### NewUiNode
 
-`func NewUiNode(attributes UiNodeAttributes, group string, messages []UiText, meta UiNodeMeta, type_ string, ) *UiNode`
+`func NewUiNode(attributes UiNodeAttributes, group string, messages []UiText, meta UiNodeMeta, type_ interface{}, ) *UiNode`
 
 NewUiNode instantiates a new UiNode object
 This constructor will assign default values to properties that have it defined,
@@ -111,24 +111,34 @@ SetMeta sets Meta field to given value.
 
 ### GetType
 
-`func (o *UiNode) GetType() string`
+`func (o *UiNode) GetType() interface{}`
 
 GetType returns the Type field if non-nil, zero value otherwise.
 
 ### GetTypeOk
 
-`func (o *UiNode) GetTypeOk() (*string, bool)`
+`func (o *UiNode) GetTypeOk() (*interface{}, bool)`
 
 GetTypeOk returns a tuple with the Type field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetType
 
-`func (o *UiNode) SetType(v string)`
+`func (o *UiNode) SetType(v interface{})`
 
 SetType sets Type field to given value.
 
 
+### SetTypeNil
+
+`func (o *UiNode) SetTypeNil(b bool)`
+
+ SetTypeNil sets the value for Type to be an explicit nil
+
+### UnsetType
+`func (o *UiNode) UnsetType()`
+
+UnsetType ensures that no value is present for Type, not even an explicit nil
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/internal/httpclient/docs/UiNode.md
+++ b/internal/httpclient/docs/UiNode.md
@@ -5,16 +5,16 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Attributes** | [**UiNodeAttributes**](UiNodeAttributes.md) |  | 
-**Group** | **string** |  | 
+**Group** | **string** | Group specifies which group (e.g. password authenticator) this node belongs to. | 
 **Messages** | [**[]UiText**](UiText.md) |  | 
 **Meta** | [**UiNodeMeta**](UiNodeMeta.md) |  | 
-**Type** | **interface{}** | The node&#39;s type  Can be one of: text, input, img, a, script | 
+**Type** | **string** | The node&#39;s type  Can be one of: text, input, img, a, script | 
 
 ## Methods
 
 ### NewUiNode
 
-`func NewUiNode(attributes UiNodeAttributes, group string, messages []UiText, meta UiNodeMeta, type_ interface{}, ) *UiNode`
+`func NewUiNode(attributes UiNodeAttributes, group string, messages []UiText, meta UiNodeMeta, type_ string, ) *UiNode`
 
 NewUiNode instantiates a new UiNode object
 This constructor will assign default values to properties that have it defined,
@@ -111,34 +111,24 @@ SetMeta sets Meta field to given value.
 
 ### GetType
 
-`func (o *UiNode) GetType() interface{}`
+`func (o *UiNode) GetType() string`
 
 GetType returns the Type field if non-nil, zero value otherwise.
 
 ### GetTypeOk
 
-`func (o *UiNode) GetTypeOk() (*interface{}, bool)`
+`func (o *UiNode) GetTypeOk() (*string, bool)`
 
 GetTypeOk returns a tuple with the Type field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetType
 
-`func (o *UiNode) SetType(v interface{})`
+`func (o *UiNode) SetType(v string)`
 
 SetType sets Type field to given value.
 
 
-### SetTypeNil
-
-`func (o *UiNode) SetTypeNil(b bool)`
-
- SetTypeNil sets the value for Type to be an explicit nil
-
-### UnsetType
-`func (o *UiNode) UnsetType()`
-
-UnsetType ensures that no value is present for Type, not even an explicit nil
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/internal/httpclient/docs/UiNode.md
+++ b/internal/httpclient/docs/UiNode.md
@@ -8,13 +8,13 @@ Name | Type | Description | Notes
 **Group** | **string** | Group specifies which group (e.g. password authenticator) this node belongs to. | 
 **Messages** | [**[]UiText**](UiText.md) |  | 
 **Meta** | [**UiNodeMeta**](UiNodeMeta.md) |  | 
-**Type** | **string** | The node&#39;s type | 
+**Type** | **interface{}** | The node&#39;s type | 
 
 ## Methods
 
 ### NewUiNode
 
-`func NewUiNode(attributes UiNodeAttributes, group string, messages []UiText, meta UiNodeMeta, type_ string, ) *UiNode`
+`func NewUiNode(attributes UiNodeAttributes, group string, messages []UiText, meta UiNodeMeta, type_ interface{}, ) *UiNode`
 
 NewUiNode instantiates a new UiNode object
 This constructor will assign default values to properties that have it defined,
@@ -111,24 +111,34 @@ SetMeta sets Meta field to given value.
 
 ### GetType
 
-`func (o *UiNode) GetType() string`
+`func (o *UiNode) GetType() interface{}`
 
 GetType returns the Type field if non-nil, zero value otherwise.
 
 ### GetTypeOk
 
-`func (o *UiNode) GetTypeOk() (*string, bool)`
+`func (o *UiNode) GetTypeOk() (*interface{}, bool)`
 
 GetTypeOk returns a tuple with the Type field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetType
 
-`func (o *UiNode) SetType(v string)`
+`func (o *UiNode) SetType(v interface{})`
 
 SetType sets Type field to given value.
 
 
+### SetTypeNil
+
+`func (o *UiNode) SetTypeNil(b bool)`
+
+ SetTypeNil sets the value for Type to be an explicit nil
+
+### UnsetType
+`func (o *UiNode) UnsetType()`
+
+UnsetType ensures that no value is present for Type, not even an explicit nil
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/internal/httpclient/docs/UiNode.md
+++ b/internal/httpclient/docs/UiNode.md
@@ -8,13 +8,13 @@ Name | Type | Description | Notes
 **Group** | **string** | Group specifies which group (e.g. password authenticator) this node belongs to. | 
 **Messages** | [**[]UiText**](UiText.md) |  | 
 **Meta** | [**UiNodeMeta**](UiNodeMeta.md) |  | 
-**Type** | **interface{}** | The node&#39;s type | 
+**Type** | **string** | The node&#39;s type | 
 
 ## Methods
 
 ### NewUiNode
 
-`func NewUiNode(attributes UiNodeAttributes, group string, messages []UiText, meta UiNodeMeta, type_ interface{}, ) *UiNode`
+`func NewUiNode(attributes UiNodeAttributes, group string, messages []UiText, meta UiNodeMeta, type_ string, ) *UiNode`
 
 NewUiNode instantiates a new UiNode object
 This constructor will assign default values to properties that have it defined,
@@ -111,34 +111,24 @@ SetMeta sets Meta field to given value.
 
 ### GetType
 
-`func (o *UiNode) GetType() interface{}`
+`func (o *UiNode) GetType() string`
 
 GetType returns the Type field if non-nil, zero value otherwise.
 
 ### GetTypeOk
 
-`func (o *UiNode) GetTypeOk() (*interface{}, bool)`
+`func (o *UiNode) GetTypeOk() (*string, bool)`
 
 GetTypeOk returns a tuple with the Type field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetType
 
-`func (o *UiNode) SetType(v interface{})`
+`func (o *UiNode) SetType(v string)`
 
 SetType sets Type field to given value.
 
 
-### SetTypeNil
-
-`func (o *UiNode) SetTypeNil(b bool)`
-
- SetTypeNil sets the value for Type to be an explicit nil
-
-### UnsetType
-`func (o *UiNode) UnsetType()`
-
-UnsetType ensures that no value is present for Type, not even an explicit nil
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/internal/httpclient/docs/UiNodeAnchorAttributes.md
+++ b/internal/httpclient/docs/UiNodeAnchorAttributes.md
@@ -6,14 +6,14 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Href** | **string** | The link&#39;s href (destination) URL.  format: uri | 
 **Id** | **string** | A unique identifier | 
-**NodeType** | **string** | NodeType represents this node&#39;s types. It is a mirror of &#x60;node.type&#x60; and is primarily used to allow compatibility with OpenAPI 3.0. | 
+**NodeType** | **interface{}** | NodeType represents this node&#39;s types. It is a mirror of &#x60;node.type&#x60; and is primarily used to allow compatibility with OpenAPI 3.0. | 
 **Title** | [**UiText**](UiText.md) |  | 
 
 ## Methods
 
 ### NewUiNodeAnchorAttributes
 
-`func NewUiNodeAnchorAttributes(href string, id string, nodeType string, title UiText, ) *UiNodeAnchorAttributes`
+`func NewUiNodeAnchorAttributes(href string, id string, nodeType interface{}, title UiText, ) *UiNodeAnchorAttributes`
 
 NewUiNodeAnchorAttributes instantiates a new UiNodeAnchorAttributes object
 This constructor will assign default values to properties that have it defined,
@@ -70,24 +70,34 @@ SetId sets Id field to given value.
 
 ### GetNodeType
 
-`func (o *UiNodeAnchorAttributes) GetNodeType() string`
+`func (o *UiNodeAnchorAttributes) GetNodeType() interface{}`
 
 GetNodeType returns the NodeType field if non-nil, zero value otherwise.
 
 ### GetNodeTypeOk
 
-`func (o *UiNodeAnchorAttributes) GetNodeTypeOk() (*string, bool)`
+`func (o *UiNodeAnchorAttributes) GetNodeTypeOk() (*interface{}, bool)`
 
 GetNodeTypeOk returns a tuple with the NodeType field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetNodeType
 
-`func (o *UiNodeAnchorAttributes) SetNodeType(v string)`
+`func (o *UiNodeAnchorAttributes) SetNodeType(v interface{})`
 
 SetNodeType sets NodeType field to given value.
 
 
+### SetNodeTypeNil
+
+`func (o *UiNodeAnchorAttributes) SetNodeTypeNil(b bool)`
+
+ SetNodeTypeNil sets the value for NodeType to be an explicit nil
+
+### UnsetNodeType
+`func (o *UiNodeAnchorAttributes) UnsetNodeType()`
+
+UnsetNodeType ensures that no value is present for NodeType, not even an explicit nil
 ### GetTitle
 
 `func (o *UiNodeAnchorAttributes) GetTitle() UiText`

--- a/internal/httpclient/docs/UiNodeAnchorAttributes.md
+++ b/internal/httpclient/docs/UiNodeAnchorAttributes.md
@@ -6,14 +6,14 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Href** | **string** | The link&#39;s href (destination) URL.  format: uri | 
 **Id** | **string** | A unique identifier | 
-**NodeType** | **string** |  | 
+**NodeType** | **interface{}** | NodeType represents this node&#39;s types. It is a mirror of &#x60;node.type&#x60; and is primarily used to allow compatibility with OpenAPI 3.0. | 
 **Title** | [**UiText**](UiText.md) |  | 
 
 ## Methods
 
 ### NewUiNodeAnchorAttributes
 
-`func NewUiNodeAnchorAttributes(href string, id string, nodeType string, title UiText, ) *UiNodeAnchorAttributes`
+`func NewUiNodeAnchorAttributes(href string, id string, nodeType interface{}, title UiText, ) *UiNodeAnchorAttributes`
 
 NewUiNodeAnchorAttributes instantiates a new UiNodeAnchorAttributes object
 This constructor will assign default values to properties that have it defined,
@@ -70,24 +70,34 @@ SetId sets Id field to given value.
 
 ### GetNodeType
 
-`func (o *UiNodeAnchorAttributes) GetNodeType() string`
+`func (o *UiNodeAnchorAttributes) GetNodeType() interface{}`
 
 GetNodeType returns the NodeType field if non-nil, zero value otherwise.
 
 ### GetNodeTypeOk
 
-`func (o *UiNodeAnchorAttributes) GetNodeTypeOk() (*string, bool)`
+`func (o *UiNodeAnchorAttributes) GetNodeTypeOk() (*interface{}, bool)`
 
 GetNodeTypeOk returns a tuple with the NodeType field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetNodeType
 
-`func (o *UiNodeAnchorAttributes) SetNodeType(v string)`
+`func (o *UiNodeAnchorAttributes) SetNodeType(v interface{})`
 
 SetNodeType sets NodeType field to given value.
 
 
+### SetNodeTypeNil
+
+`func (o *UiNodeAnchorAttributes) SetNodeTypeNil(b bool)`
+
+ SetNodeTypeNil sets the value for NodeType to be an explicit nil
+
+### UnsetNodeType
+`func (o *UiNodeAnchorAttributes) UnsetNodeType()`
+
+UnsetNodeType ensures that no value is present for NodeType, not even an explicit nil
 ### GetTitle
 
 `func (o *UiNodeAnchorAttributes) GetTitle() UiText`

--- a/internal/httpclient/docs/UiNodeAnchorAttributes.md
+++ b/internal/httpclient/docs/UiNodeAnchorAttributes.md
@@ -6,14 +6,14 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Href** | **string** | The link&#39;s href (destination) URL.  format: uri | 
 **Id** | **string** | A unique identifier | 
-**NodeType** | **interface{}** | NodeType represents this node&#39;s types. It is a mirror of &#x60;node.type&#x60; and is primarily used to allow compatibility with OpenAPI 3.0. | 
+**NodeType** | **string** | NodeType represents this node&#39;s types. It is a mirror of &#x60;node.type&#x60; and is primarily used to allow compatibility with OpenAPI 3.0. | 
 **Title** | [**UiText**](UiText.md) |  | 
 
 ## Methods
 
 ### NewUiNodeAnchorAttributes
 
-`func NewUiNodeAnchorAttributes(href string, id string, nodeType interface{}, title UiText, ) *UiNodeAnchorAttributes`
+`func NewUiNodeAnchorAttributes(href string, id string, nodeType string, title UiText, ) *UiNodeAnchorAttributes`
 
 NewUiNodeAnchorAttributes instantiates a new UiNodeAnchorAttributes object
 This constructor will assign default values to properties that have it defined,
@@ -70,34 +70,24 @@ SetId sets Id field to given value.
 
 ### GetNodeType
 
-`func (o *UiNodeAnchorAttributes) GetNodeType() interface{}`
+`func (o *UiNodeAnchorAttributes) GetNodeType() string`
 
 GetNodeType returns the NodeType field if non-nil, zero value otherwise.
 
 ### GetNodeTypeOk
 
-`func (o *UiNodeAnchorAttributes) GetNodeTypeOk() (*interface{}, bool)`
+`func (o *UiNodeAnchorAttributes) GetNodeTypeOk() (*string, bool)`
 
 GetNodeTypeOk returns a tuple with the NodeType field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetNodeType
 
-`func (o *UiNodeAnchorAttributes) SetNodeType(v interface{})`
+`func (o *UiNodeAnchorAttributes) SetNodeType(v string)`
 
 SetNodeType sets NodeType field to given value.
 
 
-### SetNodeTypeNil
-
-`func (o *UiNodeAnchorAttributes) SetNodeTypeNil(b bool)`
-
- SetNodeTypeNil sets the value for NodeType to be an explicit nil
-
-### UnsetNodeType
-`func (o *UiNodeAnchorAttributes) UnsetNodeType()`
-
-UnsetNodeType ensures that no value is present for NodeType, not even an explicit nil
 ### GetTitle
 
 `func (o *UiNodeAnchorAttributes) GetTitle() UiText`

--- a/internal/httpclient/docs/UiNodeAttributes.md
+++ b/internal/httpclient/docs/UiNodeAttributes.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 **Disabled** | **bool** | Sets the input&#39;s disabled field to true or false. | 
 **Label** | Pointer to [**UiText**](UiText.md) |  | [optional] 
 **Name** | **string** | The input&#39;s element name. | 
-**NodeType** | **string** | NodeType represents this node&#39;s types. It is a mirror of &#x60;node.type&#x60; and is primarily used to allow compatibility with OpenAPI 3.0. | 
+**NodeType** | **interface{}** | NodeType represents this node&#39;s types. It is a mirror of &#x60;node.type&#x60; and is primarily used to allow compatibility with OpenAPI 3.0. | 
 **Onclick** | Pointer to **string** | OnClick may contain javascript which should be executed on click. This is primarily used for WebAuthn. | [optional] 
 **Pattern** | Pointer to **string** | The input&#39;s pattern. | [optional] 
 **Required** | Pointer to **bool** | Mark this input field as required. | [optional] 
@@ -30,7 +30,7 @@ Name | Type | Description | Notes
 
 ### NewUiNodeAttributes
 
-`func NewUiNodeAttributes(disabled bool, name string, nodeType string, type_ string, id string, text UiText, height int64, src string, width int64, href string, title UiText, async bool, crossorigin string, integrity string, nonce string, referrerpolicy string, ) *UiNodeAttributes`
+`func NewUiNodeAttributes(disabled bool, name string, nodeType interface{}, type_ string, id string, text UiText, height int64, src string, width int64, href string, title UiText, async bool, crossorigin string, integrity string, nonce string, referrerpolicy string, ) *UiNodeAttributes`
 
 NewUiNodeAttributes instantiates a new UiNodeAttributes object
 This constructor will assign default values to properties that have it defined,
@@ -112,24 +112,34 @@ SetName sets Name field to given value.
 
 ### GetNodeType
 
-`func (o *UiNodeAttributes) GetNodeType() string`
+`func (o *UiNodeAttributes) GetNodeType() interface{}`
 
 GetNodeType returns the NodeType field if non-nil, zero value otherwise.
 
 ### GetNodeTypeOk
 
-`func (o *UiNodeAttributes) GetNodeTypeOk() (*string, bool)`
+`func (o *UiNodeAttributes) GetNodeTypeOk() (*interface{}, bool)`
 
 GetNodeTypeOk returns a tuple with the NodeType field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetNodeType
 
-`func (o *UiNodeAttributes) SetNodeType(v string)`
+`func (o *UiNodeAttributes) SetNodeType(v interface{})`
 
 SetNodeType sets NodeType field to given value.
 
 
+### SetNodeTypeNil
+
+`func (o *UiNodeAttributes) SetNodeTypeNil(b bool)`
+
+ SetNodeTypeNil sets the value for NodeType to be an explicit nil
+
+### UnsetNodeType
+`func (o *UiNodeAttributes) UnsetNodeType()`
+
+UnsetNodeType ensures that no value is present for NodeType, not even an explicit nil
 ### GetOnclick
 
 `func (o *UiNodeAttributes) GetOnclick() string`

--- a/internal/httpclient/docs/UiNodeAttributes.md
+++ b/internal/httpclient/docs/UiNodeAttributes.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 **Disabled** | **bool** | Sets the input&#39;s disabled field to true or false. | 
 **Label** | Pointer to [**UiText**](UiText.md) |  | [optional] 
 **Name** | **string** | The input&#39;s element name. | 
-**NodeType** | **interface{}** | NodeType represents this node&#39;s types. It is a mirror of &#x60;node.type&#x60; and is primarily used to allow compatibility with OpenAPI 3.0. | 
+**NodeType** | **string** | NodeType represents this node&#39;s types. It is a mirror of &#x60;node.type&#x60; and is primarily used to allow compatibility with OpenAPI 3.0. | 
 **Onclick** | Pointer to **string** | OnClick may contain javascript which should be executed on click. This is primarily used for WebAuthn. | [optional] 
 **Pattern** | Pointer to **string** | The input&#39;s pattern. | [optional] 
 **Required** | Pointer to **bool** | Mark this input field as required. | [optional] 
@@ -30,7 +30,7 @@ Name | Type | Description | Notes
 
 ### NewUiNodeAttributes
 
-`func NewUiNodeAttributes(disabled bool, name string, nodeType interface{}, type_ string, id string, text UiText, height int64, src string, width int64, href string, title UiText, async bool, crossorigin string, integrity string, nonce string, referrerpolicy string, ) *UiNodeAttributes`
+`func NewUiNodeAttributes(disabled bool, name string, nodeType string, type_ string, id string, text UiText, height int64, src string, width int64, href string, title UiText, async bool, crossorigin string, integrity string, nonce string, referrerpolicy string, ) *UiNodeAttributes`
 
 NewUiNodeAttributes instantiates a new UiNodeAttributes object
 This constructor will assign default values to properties that have it defined,
@@ -112,34 +112,24 @@ SetName sets Name field to given value.
 
 ### GetNodeType
 
-`func (o *UiNodeAttributes) GetNodeType() interface{}`
+`func (o *UiNodeAttributes) GetNodeType() string`
 
 GetNodeType returns the NodeType field if non-nil, zero value otherwise.
 
 ### GetNodeTypeOk
 
-`func (o *UiNodeAttributes) GetNodeTypeOk() (*interface{}, bool)`
+`func (o *UiNodeAttributes) GetNodeTypeOk() (*string, bool)`
 
 GetNodeTypeOk returns a tuple with the NodeType field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetNodeType
 
-`func (o *UiNodeAttributes) SetNodeType(v interface{})`
+`func (o *UiNodeAttributes) SetNodeType(v string)`
 
 SetNodeType sets NodeType field to given value.
 
 
-### SetNodeTypeNil
-
-`func (o *UiNodeAttributes) SetNodeTypeNil(b bool)`
-
- SetNodeTypeNil sets the value for NodeType to be an explicit nil
-
-### UnsetNodeType
-`func (o *UiNodeAttributes) UnsetNodeType()`
-
-UnsetNodeType ensures that no value is present for NodeType, not even an explicit nil
 ### GetOnclick
 
 `func (o *UiNodeAttributes) GetOnclick() string`

--- a/internal/httpclient/docs/UiNodeAttributes.md
+++ b/internal/httpclient/docs/UiNodeAttributes.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 **Disabled** | **bool** | Sets the input&#39;s disabled field to true or false. | 
 **Label** | Pointer to [**UiText**](UiText.md) |  | [optional] 
 **Name** | **string** | The input&#39;s element name. | 
-**NodeType** | **string** |  | 
+**NodeType** | **interface{}** | NodeType represents this node&#39;s types. It is a mirror of &#x60;node.type&#x60; and is primarily used to allow compatibility with OpenAPI 3.0. | 
 **Onclick** | Pointer to **string** | OnClick may contain javascript which should be executed on click. This is primarily used for WebAuthn. | [optional] 
 **Pattern** | Pointer to **string** | The input&#39;s pattern. | [optional] 
 **Required** | Pointer to **bool** | Mark this input field as required. | [optional] 
@@ -30,7 +30,7 @@ Name | Type | Description | Notes
 
 ### NewUiNodeAttributes
 
-`func NewUiNodeAttributes(disabled bool, name string, nodeType string, type_ string, id string, text UiText, height int64, src string, width int64, href string, title UiText, async bool, crossorigin string, integrity string, nonce string, referrerpolicy string, ) *UiNodeAttributes`
+`func NewUiNodeAttributes(disabled bool, name string, nodeType interface{}, type_ string, id string, text UiText, height int64, src string, width int64, href string, title UiText, async bool, crossorigin string, integrity string, nonce string, referrerpolicy string, ) *UiNodeAttributes`
 
 NewUiNodeAttributes instantiates a new UiNodeAttributes object
 This constructor will assign default values to properties that have it defined,
@@ -112,24 +112,34 @@ SetName sets Name field to given value.
 
 ### GetNodeType
 
-`func (o *UiNodeAttributes) GetNodeType() string`
+`func (o *UiNodeAttributes) GetNodeType() interface{}`
 
 GetNodeType returns the NodeType field if non-nil, zero value otherwise.
 
 ### GetNodeTypeOk
 
-`func (o *UiNodeAttributes) GetNodeTypeOk() (*string, bool)`
+`func (o *UiNodeAttributes) GetNodeTypeOk() (*interface{}, bool)`
 
 GetNodeTypeOk returns a tuple with the NodeType field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetNodeType
 
-`func (o *UiNodeAttributes) SetNodeType(v string)`
+`func (o *UiNodeAttributes) SetNodeType(v interface{})`
 
 SetNodeType sets NodeType field to given value.
 
 
+### SetNodeTypeNil
+
+`func (o *UiNodeAttributes) SetNodeTypeNil(b bool)`
+
+ SetNodeTypeNil sets the value for NodeType to be an explicit nil
+
+### UnsetNodeType
+`func (o *UiNodeAttributes) UnsetNodeType()`
+
+UnsetNodeType ensures that no value is present for NodeType, not even an explicit nil
 ### GetOnclick
 
 `func (o *UiNodeAttributes) GetOnclick() string`

--- a/internal/httpclient/docs/UiNodeImageAttributes.md
+++ b/internal/httpclient/docs/UiNodeImageAttributes.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Height** | **int64** | Height of the image | 
 **Id** | **string** | A unique identifier | 
-**NodeType** | **interface{}** | NodeType represents this node&#39;s types. It is a mirror of &#x60;node.type&#x60; and is primarily used to allow compatibility with OpenAPI 3.0. | 
+**NodeType** | **string** | NodeType represents this node&#39;s types. It is a mirror of &#x60;node.type&#x60; and is primarily used to allow compatibility with OpenAPI 3.0. | 
 **Src** | **string** | The image&#39;s source URL.  format: uri | 
 **Width** | **int64** | Width of the image | 
 
@@ -14,7 +14,7 @@ Name | Type | Description | Notes
 
 ### NewUiNodeImageAttributes
 
-`func NewUiNodeImageAttributes(height int64, id string, nodeType interface{}, src string, width int64, ) *UiNodeImageAttributes`
+`func NewUiNodeImageAttributes(height int64, id string, nodeType string, src string, width int64, ) *UiNodeImageAttributes`
 
 NewUiNodeImageAttributes instantiates a new UiNodeImageAttributes object
 This constructor will assign default values to properties that have it defined,
@@ -71,34 +71,24 @@ SetId sets Id field to given value.
 
 ### GetNodeType
 
-`func (o *UiNodeImageAttributes) GetNodeType() interface{}`
+`func (o *UiNodeImageAttributes) GetNodeType() string`
 
 GetNodeType returns the NodeType field if non-nil, zero value otherwise.
 
 ### GetNodeTypeOk
 
-`func (o *UiNodeImageAttributes) GetNodeTypeOk() (*interface{}, bool)`
+`func (o *UiNodeImageAttributes) GetNodeTypeOk() (*string, bool)`
 
 GetNodeTypeOk returns a tuple with the NodeType field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetNodeType
 
-`func (o *UiNodeImageAttributes) SetNodeType(v interface{})`
+`func (o *UiNodeImageAttributes) SetNodeType(v string)`
 
 SetNodeType sets NodeType field to given value.
 
 
-### SetNodeTypeNil
-
-`func (o *UiNodeImageAttributes) SetNodeTypeNil(b bool)`
-
- SetNodeTypeNil sets the value for NodeType to be an explicit nil
-
-### UnsetNodeType
-`func (o *UiNodeImageAttributes) UnsetNodeType()`
-
-UnsetNodeType ensures that no value is present for NodeType, not even an explicit nil
 ### GetSrc
 
 `func (o *UiNodeImageAttributes) GetSrc() string`

--- a/internal/httpclient/docs/UiNodeImageAttributes.md
+++ b/internal/httpclient/docs/UiNodeImageAttributes.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Height** | **int64** | Height of the image | 
 **Id** | **string** | A unique identifier | 
-**NodeType** | **string** | NodeType represents this node&#39;s types. It is a mirror of &#x60;node.type&#x60; and is primarily used to allow compatibility with OpenAPI 3.0. | 
+**NodeType** | **interface{}** | NodeType represents this node&#39;s types. It is a mirror of &#x60;node.type&#x60; and is primarily used to allow compatibility with OpenAPI 3.0. | 
 **Src** | **string** | The image&#39;s source URL.  format: uri | 
 **Width** | **int64** | Width of the image | 
 
@@ -14,7 +14,7 @@ Name | Type | Description | Notes
 
 ### NewUiNodeImageAttributes
 
-`func NewUiNodeImageAttributes(height int64, id string, nodeType string, src string, width int64, ) *UiNodeImageAttributes`
+`func NewUiNodeImageAttributes(height int64, id string, nodeType interface{}, src string, width int64, ) *UiNodeImageAttributes`
 
 NewUiNodeImageAttributes instantiates a new UiNodeImageAttributes object
 This constructor will assign default values to properties that have it defined,
@@ -71,24 +71,34 @@ SetId sets Id field to given value.
 
 ### GetNodeType
 
-`func (o *UiNodeImageAttributes) GetNodeType() string`
+`func (o *UiNodeImageAttributes) GetNodeType() interface{}`
 
 GetNodeType returns the NodeType field if non-nil, zero value otherwise.
 
 ### GetNodeTypeOk
 
-`func (o *UiNodeImageAttributes) GetNodeTypeOk() (*string, bool)`
+`func (o *UiNodeImageAttributes) GetNodeTypeOk() (*interface{}, bool)`
 
 GetNodeTypeOk returns a tuple with the NodeType field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetNodeType
 
-`func (o *UiNodeImageAttributes) SetNodeType(v string)`
+`func (o *UiNodeImageAttributes) SetNodeType(v interface{})`
 
 SetNodeType sets NodeType field to given value.
 
 
+### SetNodeTypeNil
+
+`func (o *UiNodeImageAttributes) SetNodeTypeNil(b bool)`
+
+ SetNodeTypeNil sets the value for NodeType to be an explicit nil
+
+### UnsetNodeType
+`func (o *UiNodeImageAttributes) UnsetNodeType()`
+
+UnsetNodeType ensures that no value is present for NodeType, not even an explicit nil
 ### GetSrc
 
 `func (o *UiNodeImageAttributes) GetSrc() string`

--- a/internal/httpclient/docs/UiNodeImageAttributes.md
+++ b/internal/httpclient/docs/UiNodeImageAttributes.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Height** | **int64** | Height of the image | 
 **Id** | **string** | A unique identifier | 
-**NodeType** | **string** |  | 
+**NodeType** | **interface{}** | NodeType represents this node&#39;s types. It is a mirror of &#x60;node.type&#x60; and is primarily used to allow compatibility with OpenAPI 3.0. | 
 **Src** | **string** | The image&#39;s source URL.  format: uri | 
 **Width** | **int64** | Width of the image | 
 
@@ -14,7 +14,7 @@ Name | Type | Description | Notes
 
 ### NewUiNodeImageAttributes
 
-`func NewUiNodeImageAttributes(height int64, id string, nodeType string, src string, width int64, ) *UiNodeImageAttributes`
+`func NewUiNodeImageAttributes(height int64, id string, nodeType interface{}, src string, width int64, ) *UiNodeImageAttributes`
 
 NewUiNodeImageAttributes instantiates a new UiNodeImageAttributes object
 This constructor will assign default values to properties that have it defined,
@@ -71,24 +71,34 @@ SetId sets Id field to given value.
 
 ### GetNodeType
 
-`func (o *UiNodeImageAttributes) GetNodeType() string`
+`func (o *UiNodeImageAttributes) GetNodeType() interface{}`
 
 GetNodeType returns the NodeType field if non-nil, zero value otherwise.
 
 ### GetNodeTypeOk
 
-`func (o *UiNodeImageAttributes) GetNodeTypeOk() (*string, bool)`
+`func (o *UiNodeImageAttributes) GetNodeTypeOk() (*interface{}, bool)`
 
 GetNodeTypeOk returns a tuple with the NodeType field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetNodeType
 
-`func (o *UiNodeImageAttributes) SetNodeType(v string)`
+`func (o *UiNodeImageAttributes) SetNodeType(v interface{})`
 
 SetNodeType sets NodeType field to given value.
 
 
+### SetNodeTypeNil
+
+`func (o *UiNodeImageAttributes) SetNodeTypeNil(b bool)`
+
+ SetNodeTypeNil sets the value for NodeType to be an explicit nil
+
+### UnsetNodeType
+`func (o *UiNodeImageAttributes) UnsetNodeType()`
+
+UnsetNodeType ensures that no value is present for NodeType, not even an explicit nil
 ### GetSrc
 
 `func (o *UiNodeImageAttributes) GetSrc() string`

--- a/internal/httpclient/docs/UiNodeInputAttributes.md
+++ b/internal/httpclient/docs/UiNodeInputAttributes.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 **Disabled** | **bool** | Sets the input&#39;s disabled field to true or false. | 
 **Label** | Pointer to [**UiText**](UiText.md) |  | [optional] 
 **Name** | **string** | The input&#39;s element name. | 
-**NodeType** | **string** | NodeType represents this node&#39;s types. It is a mirror of &#x60;node.type&#x60; and is primarily used to allow compatibility with OpenAPI 3.0. | 
+**NodeType** | **interface{}** | NodeType represents this node&#39;s types. It is a mirror of &#x60;node.type&#x60; and is primarily used to allow compatibility with OpenAPI 3.0. | 
 **Onclick** | Pointer to **string** | OnClick may contain javascript which should be executed on click. This is primarily used for WebAuthn. | [optional] 
 **Pattern** | Pointer to **string** | The input&#39;s pattern. | [optional] 
 **Required** | Pointer to **bool** | Mark this input field as required. | [optional] 
@@ -18,7 +18,7 @@ Name | Type | Description | Notes
 
 ### NewUiNodeInputAttributes
 
-`func NewUiNodeInputAttributes(disabled bool, name string, nodeType string, type_ string, ) *UiNodeInputAttributes`
+`func NewUiNodeInputAttributes(disabled bool, name string, nodeType interface{}, type_ string, ) *UiNodeInputAttributes`
 
 NewUiNodeInputAttributes instantiates a new UiNodeInputAttributes object
 This constructor will assign default values to properties that have it defined,
@@ -100,24 +100,34 @@ SetName sets Name field to given value.
 
 ### GetNodeType
 
-`func (o *UiNodeInputAttributes) GetNodeType() string`
+`func (o *UiNodeInputAttributes) GetNodeType() interface{}`
 
 GetNodeType returns the NodeType field if non-nil, zero value otherwise.
 
 ### GetNodeTypeOk
 
-`func (o *UiNodeInputAttributes) GetNodeTypeOk() (*string, bool)`
+`func (o *UiNodeInputAttributes) GetNodeTypeOk() (*interface{}, bool)`
 
 GetNodeTypeOk returns a tuple with the NodeType field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetNodeType
 
-`func (o *UiNodeInputAttributes) SetNodeType(v string)`
+`func (o *UiNodeInputAttributes) SetNodeType(v interface{})`
 
 SetNodeType sets NodeType field to given value.
 
 
+### SetNodeTypeNil
+
+`func (o *UiNodeInputAttributes) SetNodeTypeNil(b bool)`
+
+ SetNodeTypeNil sets the value for NodeType to be an explicit nil
+
+### UnsetNodeType
+`func (o *UiNodeInputAttributes) UnsetNodeType()`
+
+UnsetNodeType ensures that no value is present for NodeType, not even an explicit nil
 ### GetOnclick
 
 `func (o *UiNodeInputAttributes) GetOnclick() string`

--- a/internal/httpclient/docs/UiNodeInputAttributes.md
+++ b/internal/httpclient/docs/UiNodeInputAttributes.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 **Disabled** | **bool** | Sets the input&#39;s disabled field to true or false. | 
 **Label** | Pointer to [**UiText**](UiText.md) |  | [optional] 
 **Name** | **string** | The input&#39;s element name. | 
-**NodeType** | **string** |  | 
+**NodeType** | **interface{}** | NodeType represents this node&#39;s types. It is a mirror of &#x60;node.type&#x60; and is primarily used to allow compatibility with OpenAPI 3.0. | 
 **Onclick** | Pointer to **string** | OnClick may contain javascript which should be executed on click. This is primarily used for WebAuthn. | [optional] 
 **Pattern** | Pointer to **string** | The input&#39;s pattern. | [optional] 
 **Required** | Pointer to **bool** | Mark this input field as required. | [optional] 
@@ -18,7 +18,7 @@ Name | Type | Description | Notes
 
 ### NewUiNodeInputAttributes
 
-`func NewUiNodeInputAttributes(disabled bool, name string, nodeType string, type_ string, ) *UiNodeInputAttributes`
+`func NewUiNodeInputAttributes(disabled bool, name string, nodeType interface{}, type_ string, ) *UiNodeInputAttributes`
 
 NewUiNodeInputAttributes instantiates a new UiNodeInputAttributes object
 This constructor will assign default values to properties that have it defined,
@@ -100,24 +100,34 @@ SetName sets Name field to given value.
 
 ### GetNodeType
 
-`func (o *UiNodeInputAttributes) GetNodeType() string`
+`func (o *UiNodeInputAttributes) GetNodeType() interface{}`
 
 GetNodeType returns the NodeType field if non-nil, zero value otherwise.
 
 ### GetNodeTypeOk
 
-`func (o *UiNodeInputAttributes) GetNodeTypeOk() (*string, bool)`
+`func (o *UiNodeInputAttributes) GetNodeTypeOk() (*interface{}, bool)`
 
 GetNodeTypeOk returns a tuple with the NodeType field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetNodeType
 
-`func (o *UiNodeInputAttributes) SetNodeType(v string)`
+`func (o *UiNodeInputAttributes) SetNodeType(v interface{})`
 
 SetNodeType sets NodeType field to given value.
 
 
+### SetNodeTypeNil
+
+`func (o *UiNodeInputAttributes) SetNodeTypeNil(b bool)`
+
+ SetNodeTypeNil sets the value for NodeType to be an explicit nil
+
+### UnsetNodeType
+`func (o *UiNodeInputAttributes) UnsetNodeType()`
+
+UnsetNodeType ensures that no value is present for NodeType, not even an explicit nil
 ### GetOnclick
 
 `func (o *UiNodeInputAttributes) GetOnclick() string`

--- a/internal/httpclient/docs/UiNodeInputAttributes.md
+++ b/internal/httpclient/docs/UiNodeInputAttributes.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 **Disabled** | **bool** | Sets the input&#39;s disabled field to true or false. | 
 **Label** | Pointer to [**UiText**](UiText.md) |  | [optional] 
 **Name** | **string** | The input&#39;s element name. | 
-**NodeType** | **interface{}** | NodeType represents this node&#39;s types. It is a mirror of &#x60;node.type&#x60; and is primarily used to allow compatibility with OpenAPI 3.0. | 
+**NodeType** | **string** | NodeType represents this node&#39;s types. It is a mirror of &#x60;node.type&#x60; and is primarily used to allow compatibility with OpenAPI 3.0. | 
 **Onclick** | Pointer to **string** | OnClick may contain javascript which should be executed on click. This is primarily used for WebAuthn. | [optional] 
 **Pattern** | Pointer to **string** | The input&#39;s pattern. | [optional] 
 **Required** | Pointer to **bool** | Mark this input field as required. | [optional] 
@@ -18,7 +18,7 @@ Name | Type | Description | Notes
 
 ### NewUiNodeInputAttributes
 
-`func NewUiNodeInputAttributes(disabled bool, name string, nodeType interface{}, type_ string, ) *UiNodeInputAttributes`
+`func NewUiNodeInputAttributes(disabled bool, name string, nodeType string, type_ string, ) *UiNodeInputAttributes`
 
 NewUiNodeInputAttributes instantiates a new UiNodeInputAttributes object
 This constructor will assign default values to properties that have it defined,
@@ -100,34 +100,24 @@ SetName sets Name field to given value.
 
 ### GetNodeType
 
-`func (o *UiNodeInputAttributes) GetNodeType() interface{}`
+`func (o *UiNodeInputAttributes) GetNodeType() string`
 
 GetNodeType returns the NodeType field if non-nil, zero value otherwise.
 
 ### GetNodeTypeOk
 
-`func (o *UiNodeInputAttributes) GetNodeTypeOk() (*interface{}, bool)`
+`func (o *UiNodeInputAttributes) GetNodeTypeOk() (*string, bool)`
 
 GetNodeTypeOk returns a tuple with the NodeType field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetNodeType
 
-`func (o *UiNodeInputAttributes) SetNodeType(v interface{})`
+`func (o *UiNodeInputAttributes) SetNodeType(v string)`
 
 SetNodeType sets NodeType field to given value.
 
 
-### SetNodeTypeNil
-
-`func (o *UiNodeInputAttributes) SetNodeTypeNil(b bool)`
-
- SetNodeTypeNil sets the value for NodeType to be an explicit nil
-
-### UnsetNodeType
-`func (o *UiNodeInputAttributes) UnsetNodeType()`
-
-UnsetNodeType ensures that no value is present for NodeType, not even an explicit nil
 ### GetOnclick
 
 `func (o *UiNodeInputAttributes) GetOnclick() string`

--- a/internal/httpclient/docs/UiNodeScriptAttributes.md
+++ b/internal/httpclient/docs/UiNodeScriptAttributes.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **Crossorigin** | **string** | The script cross origin policy | 
 **Id** | **string** | A unique identifier | 
 **Integrity** | **string** | The script&#39;s integrity hash | 
-**NodeType** | **string** |  | 
+**NodeType** | **interface{}** | NodeType represents this node&#39;s types. It is a mirror of &#x60;node.type&#x60; and is primarily used to allow compatibility with OpenAPI 3.0. | 
 **Nonce** | **string** | Nonce for CSP  A nonce you may want to use to improve your Content Security Policy. You do not have to use this value but if you want to improve your CSP policies you may use it. You can also choose to use your own nonce value! | 
 **Referrerpolicy** | **string** | The script referrer policy | 
 **Src** | **string** | The script source | 
@@ -18,7 +18,7 @@ Name | Type | Description | Notes
 
 ### NewUiNodeScriptAttributes
 
-`func NewUiNodeScriptAttributes(async bool, crossorigin string, id string, integrity string, nodeType string, nonce string, referrerpolicy string, src string, type_ string, ) *UiNodeScriptAttributes`
+`func NewUiNodeScriptAttributes(async bool, crossorigin string, id string, integrity string, nodeType interface{}, nonce string, referrerpolicy string, src string, type_ string, ) *UiNodeScriptAttributes`
 
 NewUiNodeScriptAttributes instantiates a new UiNodeScriptAttributes object
 This constructor will assign default values to properties that have it defined,
@@ -115,24 +115,34 @@ SetIntegrity sets Integrity field to given value.
 
 ### GetNodeType
 
-`func (o *UiNodeScriptAttributes) GetNodeType() string`
+`func (o *UiNodeScriptAttributes) GetNodeType() interface{}`
 
 GetNodeType returns the NodeType field if non-nil, zero value otherwise.
 
 ### GetNodeTypeOk
 
-`func (o *UiNodeScriptAttributes) GetNodeTypeOk() (*string, bool)`
+`func (o *UiNodeScriptAttributes) GetNodeTypeOk() (*interface{}, bool)`
 
 GetNodeTypeOk returns a tuple with the NodeType field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetNodeType
 
-`func (o *UiNodeScriptAttributes) SetNodeType(v string)`
+`func (o *UiNodeScriptAttributes) SetNodeType(v interface{})`
 
 SetNodeType sets NodeType field to given value.
 
 
+### SetNodeTypeNil
+
+`func (o *UiNodeScriptAttributes) SetNodeTypeNil(b bool)`
+
+ SetNodeTypeNil sets the value for NodeType to be an explicit nil
+
+### UnsetNodeType
+`func (o *UiNodeScriptAttributes) UnsetNodeType()`
+
+UnsetNodeType ensures that no value is present for NodeType, not even an explicit nil
 ### GetNonce
 
 `func (o *UiNodeScriptAttributes) GetNonce() string`

--- a/internal/httpclient/docs/UiNodeScriptAttributes.md
+++ b/internal/httpclient/docs/UiNodeScriptAttributes.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **Crossorigin** | **string** | The script cross origin policy | 
 **Id** | **string** | A unique identifier | 
 **Integrity** | **string** | The script&#39;s integrity hash | 
-**NodeType** | **interface{}** | NodeType represents this node&#39;s types. It is a mirror of &#x60;node.type&#x60; and is primarily used to allow compatibility with OpenAPI 3.0. | 
+**NodeType** | **string** | NodeType represents this node&#39;s types. It is a mirror of &#x60;node.type&#x60; and is primarily used to allow compatibility with OpenAPI 3.0. | 
 **Nonce** | **string** | Nonce for CSP  A nonce you may want to use to improve your Content Security Policy. You do not have to use this value but if you want to improve your CSP policies you may use it. You can also choose to use your own nonce value! | 
 **Referrerpolicy** | **string** | The script referrer policy | 
 **Src** | **string** | The script source | 
@@ -18,7 +18,7 @@ Name | Type | Description | Notes
 
 ### NewUiNodeScriptAttributes
 
-`func NewUiNodeScriptAttributes(async bool, crossorigin string, id string, integrity string, nodeType interface{}, nonce string, referrerpolicy string, src string, type_ string, ) *UiNodeScriptAttributes`
+`func NewUiNodeScriptAttributes(async bool, crossorigin string, id string, integrity string, nodeType string, nonce string, referrerpolicy string, src string, type_ string, ) *UiNodeScriptAttributes`
 
 NewUiNodeScriptAttributes instantiates a new UiNodeScriptAttributes object
 This constructor will assign default values to properties that have it defined,
@@ -115,34 +115,24 @@ SetIntegrity sets Integrity field to given value.
 
 ### GetNodeType
 
-`func (o *UiNodeScriptAttributes) GetNodeType() interface{}`
+`func (o *UiNodeScriptAttributes) GetNodeType() string`
 
 GetNodeType returns the NodeType field if non-nil, zero value otherwise.
 
 ### GetNodeTypeOk
 
-`func (o *UiNodeScriptAttributes) GetNodeTypeOk() (*interface{}, bool)`
+`func (o *UiNodeScriptAttributes) GetNodeTypeOk() (*string, bool)`
 
 GetNodeTypeOk returns a tuple with the NodeType field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetNodeType
 
-`func (o *UiNodeScriptAttributes) SetNodeType(v interface{})`
+`func (o *UiNodeScriptAttributes) SetNodeType(v string)`
 
 SetNodeType sets NodeType field to given value.
 
 
-### SetNodeTypeNil
-
-`func (o *UiNodeScriptAttributes) SetNodeTypeNil(b bool)`
-
- SetNodeTypeNil sets the value for NodeType to be an explicit nil
-
-### UnsetNodeType
-`func (o *UiNodeScriptAttributes) UnsetNodeType()`
-
-UnsetNodeType ensures that no value is present for NodeType, not even an explicit nil
 ### GetNonce
 
 `func (o *UiNodeScriptAttributes) GetNonce() string`

--- a/internal/httpclient/docs/UiNodeScriptAttributes.md
+++ b/internal/httpclient/docs/UiNodeScriptAttributes.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **Crossorigin** | **string** | The script cross origin policy | 
 **Id** | **string** | A unique identifier | 
 **Integrity** | **string** | The script&#39;s integrity hash | 
-**NodeType** | **string** | NodeType represents this node&#39;s types. It is a mirror of &#x60;node.type&#x60; and is primarily used to allow compatibility with OpenAPI 3.0. | 
+**NodeType** | **interface{}** | NodeType represents this node&#39;s types. It is a mirror of &#x60;node.type&#x60; and is primarily used to allow compatibility with OpenAPI 3.0. | 
 **Nonce** | **string** | Nonce for CSP  A nonce you may want to use to improve your Content Security Policy. You do not have to use this value but if you want to improve your CSP policies you may use it. You can also choose to use your own nonce value! | 
 **Referrerpolicy** | **string** | The script referrer policy | 
 **Src** | **string** | The script source | 
@@ -18,7 +18,7 @@ Name | Type | Description | Notes
 
 ### NewUiNodeScriptAttributes
 
-`func NewUiNodeScriptAttributes(async bool, crossorigin string, id string, integrity string, nodeType string, nonce string, referrerpolicy string, src string, type_ string, ) *UiNodeScriptAttributes`
+`func NewUiNodeScriptAttributes(async bool, crossorigin string, id string, integrity string, nodeType interface{}, nonce string, referrerpolicy string, src string, type_ string, ) *UiNodeScriptAttributes`
 
 NewUiNodeScriptAttributes instantiates a new UiNodeScriptAttributes object
 This constructor will assign default values to properties that have it defined,
@@ -115,24 +115,34 @@ SetIntegrity sets Integrity field to given value.
 
 ### GetNodeType
 
-`func (o *UiNodeScriptAttributes) GetNodeType() string`
+`func (o *UiNodeScriptAttributes) GetNodeType() interface{}`
 
 GetNodeType returns the NodeType field if non-nil, zero value otherwise.
 
 ### GetNodeTypeOk
 
-`func (o *UiNodeScriptAttributes) GetNodeTypeOk() (*string, bool)`
+`func (o *UiNodeScriptAttributes) GetNodeTypeOk() (*interface{}, bool)`
 
 GetNodeTypeOk returns a tuple with the NodeType field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetNodeType
 
-`func (o *UiNodeScriptAttributes) SetNodeType(v string)`
+`func (o *UiNodeScriptAttributes) SetNodeType(v interface{})`
 
 SetNodeType sets NodeType field to given value.
 
 
+### SetNodeTypeNil
+
+`func (o *UiNodeScriptAttributes) SetNodeTypeNil(b bool)`
+
+ SetNodeTypeNil sets the value for NodeType to be an explicit nil
+
+### UnsetNodeType
+`func (o *UiNodeScriptAttributes) UnsetNodeType()`
+
+UnsetNodeType ensures that no value is present for NodeType, not even an explicit nil
 ### GetNonce
 
 `func (o *UiNodeScriptAttributes) GetNonce() string`

--- a/internal/httpclient/docs/UiNodeTextAttributes.md
+++ b/internal/httpclient/docs/UiNodeTextAttributes.md
@@ -5,14 +5,14 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Id** | **string** | A unique identifier | 
-**NodeType** | **string** |  | 
+**NodeType** | **interface{}** | NodeType represents this node&#39;s types. It is a mirror of &#x60;node.type&#x60; and is primarily used to allow compatibility with OpenAPI 3.0. | 
 **Text** | [**UiText**](UiText.md) |  | 
 
 ## Methods
 
 ### NewUiNodeTextAttributes
 
-`func NewUiNodeTextAttributes(id string, nodeType string, text UiText, ) *UiNodeTextAttributes`
+`func NewUiNodeTextAttributes(id string, nodeType interface{}, text UiText, ) *UiNodeTextAttributes`
 
 NewUiNodeTextAttributes instantiates a new UiNodeTextAttributes object
 This constructor will assign default values to properties that have it defined,
@@ -49,24 +49,34 @@ SetId sets Id field to given value.
 
 ### GetNodeType
 
-`func (o *UiNodeTextAttributes) GetNodeType() string`
+`func (o *UiNodeTextAttributes) GetNodeType() interface{}`
 
 GetNodeType returns the NodeType field if non-nil, zero value otherwise.
 
 ### GetNodeTypeOk
 
-`func (o *UiNodeTextAttributes) GetNodeTypeOk() (*string, bool)`
+`func (o *UiNodeTextAttributes) GetNodeTypeOk() (*interface{}, bool)`
 
 GetNodeTypeOk returns a tuple with the NodeType field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetNodeType
 
-`func (o *UiNodeTextAttributes) SetNodeType(v string)`
+`func (o *UiNodeTextAttributes) SetNodeType(v interface{})`
 
 SetNodeType sets NodeType field to given value.
 
 
+### SetNodeTypeNil
+
+`func (o *UiNodeTextAttributes) SetNodeTypeNil(b bool)`
+
+ SetNodeTypeNil sets the value for NodeType to be an explicit nil
+
+### UnsetNodeType
+`func (o *UiNodeTextAttributes) UnsetNodeType()`
+
+UnsetNodeType ensures that no value is present for NodeType, not even an explicit nil
 ### GetText
 
 `func (o *UiNodeTextAttributes) GetText() UiText`

--- a/internal/httpclient/docs/UiNodeTextAttributes.md
+++ b/internal/httpclient/docs/UiNodeTextAttributes.md
@@ -5,14 +5,14 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Id** | **string** | A unique identifier | 
-**NodeType** | **string** | NodeType represents this node&#39;s types. It is a mirror of &#x60;node.type&#x60; and is primarily used to allow compatibility with OpenAPI 3.0. | 
+**NodeType** | **interface{}** | NodeType represents this node&#39;s types. It is a mirror of &#x60;node.type&#x60; and is primarily used to allow compatibility with OpenAPI 3.0. | 
 **Text** | [**UiText**](UiText.md) |  | 
 
 ## Methods
 
 ### NewUiNodeTextAttributes
 
-`func NewUiNodeTextAttributes(id string, nodeType string, text UiText, ) *UiNodeTextAttributes`
+`func NewUiNodeTextAttributes(id string, nodeType interface{}, text UiText, ) *UiNodeTextAttributes`
 
 NewUiNodeTextAttributes instantiates a new UiNodeTextAttributes object
 This constructor will assign default values to properties that have it defined,
@@ -49,24 +49,34 @@ SetId sets Id field to given value.
 
 ### GetNodeType
 
-`func (o *UiNodeTextAttributes) GetNodeType() string`
+`func (o *UiNodeTextAttributes) GetNodeType() interface{}`
 
 GetNodeType returns the NodeType field if non-nil, zero value otherwise.
 
 ### GetNodeTypeOk
 
-`func (o *UiNodeTextAttributes) GetNodeTypeOk() (*string, bool)`
+`func (o *UiNodeTextAttributes) GetNodeTypeOk() (*interface{}, bool)`
 
 GetNodeTypeOk returns a tuple with the NodeType field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetNodeType
 
-`func (o *UiNodeTextAttributes) SetNodeType(v string)`
+`func (o *UiNodeTextAttributes) SetNodeType(v interface{})`
 
 SetNodeType sets NodeType field to given value.
 
 
+### SetNodeTypeNil
+
+`func (o *UiNodeTextAttributes) SetNodeTypeNil(b bool)`
+
+ SetNodeTypeNil sets the value for NodeType to be an explicit nil
+
+### UnsetNodeType
+`func (o *UiNodeTextAttributes) UnsetNodeType()`
+
+UnsetNodeType ensures that no value is present for NodeType, not even an explicit nil
 ### GetText
 
 `func (o *UiNodeTextAttributes) GetText() UiText`

--- a/internal/httpclient/docs/UiNodeTextAttributes.md
+++ b/internal/httpclient/docs/UiNodeTextAttributes.md
@@ -5,14 +5,14 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Id** | **string** | A unique identifier | 
-**NodeType** | **interface{}** | NodeType represents this node&#39;s types. It is a mirror of &#x60;node.type&#x60; and is primarily used to allow compatibility with OpenAPI 3.0. | 
+**NodeType** | **string** | NodeType represents this node&#39;s types. It is a mirror of &#x60;node.type&#x60; and is primarily used to allow compatibility with OpenAPI 3.0. | 
 **Text** | [**UiText**](UiText.md) |  | 
 
 ## Methods
 
 ### NewUiNodeTextAttributes
 
-`func NewUiNodeTextAttributes(id string, nodeType interface{}, text UiText, ) *UiNodeTextAttributes`
+`func NewUiNodeTextAttributes(id string, nodeType string, text UiText, ) *UiNodeTextAttributes`
 
 NewUiNodeTextAttributes instantiates a new UiNodeTextAttributes object
 This constructor will assign default values to properties that have it defined,
@@ -49,34 +49,24 @@ SetId sets Id field to given value.
 
 ### GetNodeType
 
-`func (o *UiNodeTextAttributes) GetNodeType() interface{}`
+`func (o *UiNodeTextAttributes) GetNodeType() string`
 
 GetNodeType returns the NodeType field if non-nil, zero value otherwise.
 
 ### GetNodeTypeOk
 
-`func (o *UiNodeTextAttributes) GetNodeTypeOk() (*interface{}, bool)`
+`func (o *UiNodeTextAttributes) GetNodeTypeOk() (*string, bool)`
 
 GetNodeTypeOk returns a tuple with the NodeType field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetNodeType
 
-`func (o *UiNodeTextAttributes) SetNodeType(v interface{})`
+`func (o *UiNodeTextAttributes) SetNodeType(v string)`
 
 SetNodeType sets NodeType field to given value.
 
 
-### SetNodeTypeNil
-
-`func (o *UiNodeTextAttributes) SetNodeTypeNil(b bool)`
-
- SetNodeTypeNil sets the value for NodeType to be an explicit nil
-
-### UnsetNodeType
-`func (o *UiNodeTextAttributes) UnsetNodeType()`
-
-UnsetNodeType ensures that no value is present for NodeType, not even an explicit nil
 ### GetText
 
 `func (o *UiNodeTextAttributes) GetText() UiText`

--- a/internal/httpclient/model_self_service_recovery_flow.go
+++ b/internal/httpclient/model_self_service_recovery_flow.go
@@ -31,7 +31,7 @@ type SelfServiceRecoveryFlow struct {
 	ReturnTo *string                      `json:"return_to,omitempty"`
 	State    SelfServiceRecoveryFlowState `json:"state"`
 	// The flow type can either be `api` or `browser`.
-	Type *string     `json:"type,omitempty"`
+	Type string      `json:"type"`
 	Ui   UiContainer `json:"ui"`
 }
 
@@ -39,13 +39,14 @@ type SelfServiceRecoveryFlow struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewSelfServiceRecoveryFlow(expiresAt time.Time, id string, issuedAt time.Time, requestUrl string, state SelfServiceRecoveryFlowState, ui UiContainer) *SelfServiceRecoveryFlow {
+func NewSelfServiceRecoveryFlow(expiresAt time.Time, id string, issuedAt time.Time, requestUrl string, state SelfServiceRecoveryFlowState, type_ string, ui UiContainer) *SelfServiceRecoveryFlow {
 	this := SelfServiceRecoveryFlow{}
 	this.ExpiresAt = expiresAt
 	this.Id = id
 	this.IssuedAt = issuedAt
 	this.RequestUrl = requestUrl
 	this.State = state
+	this.Type = type_
 	this.Ui = ui
 	return &this
 }
@@ -242,36 +243,28 @@ func (o *SelfServiceRecoveryFlow) SetState(v SelfServiceRecoveryFlowState) {
 	o.State = v
 }
 
-// GetType returns the Type field value if set, zero value otherwise.
+// GetType returns the Type field value
 func (o *SelfServiceRecoveryFlow) GetType() string {
-	if o == nil || o.Type == nil {
+	if o == nil {
 		var ret string
 		return ret
 	}
-	return *o.Type
+
+	return o.Type
 }
 
-// GetTypeOk returns a tuple with the Type field value if set, nil otherwise
+// GetTypeOk returns a tuple with the Type field value
 // and a boolean to check if the value has been set.
 func (o *SelfServiceRecoveryFlow) GetTypeOk() (*string, bool) {
-	if o == nil || o.Type == nil {
+	if o == nil {
 		return nil, false
 	}
-	return o.Type, true
+	return &o.Type, true
 }
 
-// HasType returns a boolean if a field has been set.
-func (o *SelfServiceRecoveryFlow) HasType() bool {
-	if o != nil && o.Type != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetType gets a reference to the given string and assigns it to the Type field.
+// SetType sets field value
 func (o *SelfServiceRecoveryFlow) SetType(v string) {
-	o.Type = &v
+	o.Type = v
 }
 
 // GetUi returns the Ui field value
@@ -321,7 +314,7 @@ func (o SelfServiceRecoveryFlow) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["state"] = o.State
 	}
-	if o.Type != nil {
+	if true {
 		toSerialize["type"] = o.Type
 	}
 	if true {

--- a/internal/httpclient/model_self_service_registration_flow.go
+++ b/internal/httpclient/model_self_service_registration_flow.go
@@ -29,7 +29,7 @@ type SelfServiceRegistrationFlow struct {
 	// ReturnTo contains the requested return_to URL.
 	ReturnTo *string `json:"return_to,omitempty"`
 	// The flow type can either be `api` or `browser`.
-	Type *string     `json:"type,omitempty"`
+	Type string      `json:"type"`
 	Ui   UiContainer `json:"ui"`
 }
 
@@ -37,12 +37,13 @@ type SelfServiceRegistrationFlow struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewSelfServiceRegistrationFlow(expiresAt time.Time, id string, issuedAt time.Time, requestUrl string, ui UiContainer) *SelfServiceRegistrationFlow {
+func NewSelfServiceRegistrationFlow(expiresAt time.Time, id string, issuedAt time.Time, requestUrl string, type_ string, ui UiContainer) *SelfServiceRegistrationFlow {
 	this := SelfServiceRegistrationFlow{}
 	this.ExpiresAt = expiresAt
 	this.Id = id
 	this.IssuedAt = issuedAt
 	this.RequestUrl = requestUrl
+	this.Type = type_
 	this.Ui = ui
 	return &this
 }
@@ -215,36 +216,28 @@ func (o *SelfServiceRegistrationFlow) SetReturnTo(v string) {
 	o.ReturnTo = &v
 }
 
-// GetType returns the Type field value if set, zero value otherwise.
+// GetType returns the Type field value
 func (o *SelfServiceRegistrationFlow) GetType() string {
-	if o == nil || o.Type == nil {
+	if o == nil {
 		var ret string
 		return ret
 	}
-	return *o.Type
+
+	return o.Type
 }
 
-// GetTypeOk returns a tuple with the Type field value if set, nil otherwise
+// GetTypeOk returns a tuple with the Type field value
 // and a boolean to check if the value has been set.
 func (o *SelfServiceRegistrationFlow) GetTypeOk() (*string, bool) {
-	if o == nil || o.Type == nil {
+	if o == nil {
 		return nil, false
 	}
-	return o.Type, true
+	return &o.Type, true
 }
 
-// HasType returns a boolean if a field has been set.
-func (o *SelfServiceRegistrationFlow) HasType() bool {
-	if o != nil && o.Type != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetType gets a reference to the given string and assigns it to the Type field.
+// SetType sets field value
 func (o *SelfServiceRegistrationFlow) SetType(v string) {
-	o.Type = &v
+	o.Type = v
 }
 
 // GetUi returns the Ui field value
@@ -291,7 +284,7 @@ func (o SelfServiceRegistrationFlow) MarshalJSON() ([]byte, error) {
 	if o.ReturnTo != nil {
 		toSerialize["return_to"] = o.ReturnTo
 	}
-	if o.Type != nil {
+	if true {
 		toSerialize["type"] = o.Type
 	}
 	if true {

--- a/internal/httpclient/model_self_service_settings_flow.go
+++ b/internal/httpclient/model_self_service_settings_flow.go
@@ -32,7 +32,7 @@ type SelfServiceSettingsFlow struct {
 	ReturnTo *string                      `json:"return_to,omitempty"`
 	State    SelfServiceSettingsFlowState `json:"state"`
 	// The flow type can either be `api` or `browser`.
-	Type *string     `json:"type,omitempty"`
+	Type string      `json:"type"`
 	Ui   UiContainer `json:"ui"`
 }
 
@@ -40,7 +40,7 @@ type SelfServiceSettingsFlow struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewSelfServiceSettingsFlow(expiresAt time.Time, id string, identity Identity, issuedAt time.Time, requestUrl string, state SelfServiceSettingsFlowState, ui UiContainer) *SelfServiceSettingsFlow {
+func NewSelfServiceSettingsFlow(expiresAt time.Time, id string, identity Identity, issuedAt time.Time, requestUrl string, state SelfServiceSettingsFlowState, type_ string, ui UiContainer) *SelfServiceSettingsFlow {
 	this := SelfServiceSettingsFlow{}
 	this.ExpiresAt = expiresAt
 	this.Id = id
@@ -48,6 +48,7 @@ func NewSelfServiceSettingsFlow(expiresAt time.Time, id string, identity Identit
 	this.IssuedAt = issuedAt
 	this.RequestUrl = requestUrl
 	this.State = state
+	this.Type = type_
 	this.Ui = ui
 	return &this
 }
@@ -268,36 +269,28 @@ func (o *SelfServiceSettingsFlow) SetState(v SelfServiceSettingsFlowState) {
 	o.State = v
 }
 
-// GetType returns the Type field value if set, zero value otherwise.
+// GetType returns the Type field value
 func (o *SelfServiceSettingsFlow) GetType() string {
-	if o == nil || o.Type == nil {
+	if o == nil {
 		var ret string
 		return ret
 	}
-	return *o.Type
+
+	return o.Type
 }
 
-// GetTypeOk returns a tuple with the Type field value if set, nil otherwise
+// GetTypeOk returns a tuple with the Type field value
 // and a boolean to check if the value has been set.
 func (o *SelfServiceSettingsFlow) GetTypeOk() (*string, bool) {
-	if o == nil || o.Type == nil {
+	if o == nil {
 		return nil, false
 	}
-	return o.Type, true
+	return &o.Type, true
 }
 
-// HasType returns a boolean if a field has been set.
-func (o *SelfServiceSettingsFlow) HasType() bool {
-	if o != nil && o.Type != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetType gets a reference to the given string and assigns it to the Type field.
+// SetType sets field value
 func (o *SelfServiceSettingsFlow) SetType(v string) {
-	o.Type = &v
+	o.Type = v
 }
 
 // GetUi returns the Ui field value
@@ -350,7 +343,7 @@ func (o SelfServiceSettingsFlow) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["state"] = o.State
 	}
-	if o.Type != nil {
+	if true {
 		toSerialize["type"] = o.Type
 	}
 	if true {

--- a/internal/httpclient/model_ui_node.go
+++ b/internal/httpclient/model_ui_node.go
@@ -22,7 +22,7 @@ type UiNode struct {
 	Group    string     `json:"group"`
 	Messages []UiText   `json:"messages"`
 	Meta     UiNodeMeta `json:"meta"`
-	// The node's type  Can be one of: text, input, img, a, script
+	// The node's type
 	Type string `json:"type"`
 }
 

--- a/internal/httpclient/model_ui_node.go
+++ b/internal/httpclient/model_ui_node.go
@@ -18,18 +18,19 @@ import (
 // UiNode Nodes are represented as HTML elements or their native UI equivalents. For example, a node can be an `<img>` tag, or an `<input element>` but also `some plain text`.
 type UiNode struct {
 	Attributes UiNodeAttributes `json:"attributes"`
-	Group      string           `json:"group"`
-	Messages   []UiText         `json:"messages"`
-	Meta       UiNodeMeta       `json:"meta"`
+	// Group specifies which group (e.g. password authenticator) this node belongs to.
+	Group    string     `json:"group"`
+	Messages []UiText   `json:"messages"`
+	Meta     UiNodeMeta `json:"meta"`
 	// The node's type  Can be one of: text, input, img, a, script
-	Type interface{} `json:"type"`
+	Type string `json:"type"`
 }
 
 // NewUiNode instantiates a new UiNode object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewUiNode(attributes UiNodeAttributes, group string, messages []UiText, meta UiNodeMeta, type_ interface{}) *UiNode {
+func NewUiNode(attributes UiNodeAttributes, group string, messages []UiText, meta UiNodeMeta, type_ string) *UiNode {
 	this := UiNode{}
 	this.Attributes = attributes
 	this.Group = group
@@ -144,10 +145,9 @@ func (o *UiNode) SetMeta(v UiNodeMeta) {
 }
 
 // GetType returns the Type field value
-// If the value is explicit nil, the zero value for interface{} will be returned
-func (o *UiNode) GetType() interface{} {
+func (o *UiNode) GetType() string {
 	if o == nil {
-		var ret interface{}
+		var ret string
 		return ret
 	}
 
@@ -156,16 +156,15 @@ func (o *UiNode) GetType() interface{} {
 
 // GetTypeOk returns a tuple with the Type field value
 // and a boolean to check if the value has been set.
-// NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *UiNode) GetTypeOk() (*interface{}, bool) {
-	if o == nil || o.Type == nil {
+func (o *UiNode) GetTypeOk() (*string, bool) {
+	if o == nil {
 		return nil, false
 	}
 	return &o.Type, true
 }
 
 // SetType sets field value
-func (o *UiNode) SetType(v interface{}) {
+func (o *UiNode) SetType(v string) {
 	o.Type = v
 }
 
@@ -183,7 +182,7 @@ func (o UiNode) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["meta"] = o.Meta
 	}
-	if o.Type != nil {
+	if true {
 		toSerialize["type"] = o.Type
 	}
 	return json.Marshal(toSerialize)

--- a/internal/httpclient/model_ui_node.go
+++ b/internal/httpclient/model_ui_node.go
@@ -23,14 +23,14 @@ type UiNode struct {
 	Messages []UiText   `json:"messages"`
 	Meta     UiNodeMeta `json:"meta"`
 	// The node's type
-	Type interface{} `json:"type"`
+	Type string `json:"type"`
 }
 
 // NewUiNode instantiates a new UiNode object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewUiNode(attributes UiNodeAttributes, group string, messages []UiText, meta UiNodeMeta, type_ interface{}) *UiNode {
+func NewUiNode(attributes UiNodeAttributes, group string, messages []UiText, meta UiNodeMeta, type_ string) *UiNode {
 	this := UiNode{}
 	this.Attributes = attributes
 	this.Group = group
@@ -145,10 +145,9 @@ func (o *UiNode) SetMeta(v UiNodeMeta) {
 }
 
 // GetType returns the Type field value
-// If the value is explicit nil, the zero value for interface{} will be returned
-func (o *UiNode) GetType() interface{} {
+func (o *UiNode) GetType() string {
 	if o == nil {
-		var ret interface{}
+		var ret string
 		return ret
 	}
 
@@ -157,16 +156,15 @@ func (o *UiNode) GetType() interface{} {
 
 // GetTypeOk returns a tuple with the Type field value
 // and a boolean to check if the value has been set.
-// NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *UiNode) GetTypeOk() (*interface{}, bool) {
-	if o == nil || o.Type == nil {
+func (o *UiNode) GetTypeOk() (*string, bool) {
+	if o == nil {
 		return nil, false
 	}
 	return &o.Type, true
 }
 
 // SetType sets field value
-func (o *UiNode) SetType(v interface{}) {
+func (o *UiNode) SetType(v string) {
 	o.Type = v
 }
 
@@ -184,7 +182,7 @@ func (o UiNode) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["meta"] = o.Meta
 	}
-	if o.Type != nil {
+	if true {
 		toSerialize["type"] = o.Type
 	}
 	return json.Marshal(toSerialize)

--- a/internal/httpclient/model_ui_node.go
+++ b/internal/httpclient/model_ui_node.go
@@ -21,14 +21,15 @@ type UiNode struct {
 	Group      string           `json:"group"`
 	Messages   []UiText         `json:"messages"`
 	Meta       UiNodeMeta       `json:"meta"`
-	Type       string           `json:"type"`
+	// The node's type  Can be one of: text, input, img, a
+	Type interface{} `json:"type"`
 }
 
 // NewUiNode instantiates a new UiNode object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewUiNode(attributes UiNodeAttributes, group string, messages []UiText, meta UiNodeMeta, type_ string) *UiNode {
+func NewUiNode(attributes UiNodeAttributes, group string, messages []UiText, meta UiNodeMeta, type_ interface{}) *UiNode {
 	this := UiNode{}
 	this.Attributes = attributes
 	this.Group = group
@@ -143,9 +144,10 @@ func (o *UiNode) SetMeta(v UiNodeMeta) {
 }
 
 // GetType returns the Type field value
-func (o *UiNode) GetType() string {
+// If the value is explicit nil, the zero value for interface{} will be returned
+func (o *UiNode) GetType() interface{} {
 	if o == nil {
-		var ret string
+		var ret interface{}
 		return ret
 	}
 
@@ -154,15 +156,16 @@ func (o *UiNode) GetType() string {
 
 // GetTypeOk returns a tuple with the Type field value
 // and a boolean to check if the value has been set.
-func (o *UiNode) GetTypeOk() (*string, bool) {
-	if o == nil {
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *UiNode) GetTypeOk() (*interface{}, bool) {
+	if o == nil || o.Type == nil {
 		return nil, false
 	}
 	return &o.Type, true
 }
 
 // SetType sets field value
-func (o *UiNode) SetType(v string) {
+func (o *UiNode) SetType(v interface{}) {
 	o.Type = v
 }
 
@@ -180,7 +183,7 @@ func (o UiNode) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["meta"] = o.Meta
 	}
-	if true {
+	if o.Type != nil {
 		toSerialize["type"] = o.Type
 	}
 	return json.Marshal(toSerialize)

--- a/internal/httpclient/model_ui_node.go
+++ b/internal/httpclient/model_ui_node.go
@@ -21,7 +21,7 @@ type UiNode struct {
 	Group      string           `json:"group"`
 	Messages   []UiText         `json:"messages"`
 	Meta       UiNodeMeta       `json:"meta"`
-	// The node's type  Can be one of: text, input, img, a
+	// The node's type  Can be one of: text, input, img, a, script
 	Type interface{} `json:"type"`
 }
 

--- a/internal/httpclient/model_ui_node.go
+++ b/internal/httpclient/model_ui_node.go
@@ -23,14 +23,14 @@ type UiNode struct {
 	Messages []UiText   `json:"messages"`
 	Meta     UiNodeMeta `json:"meta"`
 	// The node's type
-	Type string `json:"type"`
+	Type interface{} `json:"type"`
 }
 
 // NewUiNode instantiates a new UiNode object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewUiNode(attributes UiNodeAttributes, group string, messages []UiText, meta UiNodeMeta, type_ string) *UiNode {
+func NewUiNode(attributes UiNodeAttributes, group string, messages []UiText, meta UiNodeMeta, type_ interface{}) *UiNode {
 	this := UiNode{}
 	this.Attributes = attributes
 	this.Group = group
@@ -145,9 +145,10 @@ func (o *UiNode) SetMeta(v UiNodeMeta) {
 }
 
 // GetType returns the Type field value
-func (o *UiNode) GetType() string {
+// If the value is explicit nil, the zero value for interface{} will be returned
+func (o *UiNode) GetType() interface{} {
 	if o == nil {
-		var ret string
+		var ret interface{}
 		return ret
 	}
 
@@ -156,15 +157,16 @@ func (o *UiNode) GetType() string {
 
 // GetTypeOk returns a tuple with the Type field value
 // and a boolean to check if the value has been set.
-func (o *UiNode) GetTypeOk() (*string, bool) {
-	if o == nil {
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *UiNode) GetTypeOk() (*interface{}, bool) {
+	if o == nil || o.Type == nil {
 		return nil, false
 	}
 	return &o.Type, true
 }
 
 // SetType sets field value
-func (o *UiNode) SetType(v string) {
+func (o *UiNode) SetType(v interface{}) {
 	o.Type = v
 }
 
@@ -182,7 +184,7 @@ func (o UiNode) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["meta"] = o.Meta
 	}
-	if true {
+	if o.Type != nil {
 		toSerialize["type"] = o.Type
 	}
 	return json.Marshal(toSerialize)

--- a/internal/httpclient/model_ui_node_anchor_attributes.go
+++ b/internal/httpclient/model_ui_node_anchor_attributes.go
@@ -20,16 +20,17 @@ type UiNodeAnchorAttributes struct {
 	// The link's href (destination) URL.  format: uri
 	Href string `json:"href"`
 	// A unique identifier
-	Id       string `json:"id"`
-	NodeType string `json:"node_type"`
-	Title    UiText `json:"title"`
+	Id string `json:"id"`
+	// NodeType represents this node's types. It is a mirror of `node.type` and is primarily used to allow compatibility with OpenAPI 3.0.
+	NodeType interface{} `json:"node_type"`
+	Title    UiText      `json:"title"`
 }
 
 // NewUiNodeAnchorAttributes instantiates a new UiNodeAnchorAttributes object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewUiNodeAnchorAttributes(href string, id string, nodeType string, title UiText) *UiNodeAnchorAttributes {
+func NewUiNodeAnchorAttributes(href string, id string, nodeType interface{}, title UiText) *UiNodeAnchorAttributes {
 	this := UiNodeAnchorAttributes{}
 	this.Href = href
 	this.Id = id
@@ -95,9 +96,10 @@ func (o *UiNodeAnchorAttributes) SetId(v string) {
 }
 
 // GetNodeType returns the NodeType field value
-func (o *UiNodeAnchorAttributes) GetNodeType() string {
+// If the value is explicit nil, the zero value for interface{} will be returned
+func (o *UiNodeAnchorAttributes) GetNodeType() interface{} {
 	if o == nil {
-		var ret string
+		var ret interface{}
 		return ret
 	}
 
@@ -106,15 +108,16 @@ func (o *UiNodeAnchorAttributes) GetNodeType() string {
 
 // GetNodeTypeOk returns a tuple with the NodeType field value
 // and a boolean to check if the value has been set.
-func (o *UiNodeAnchorAttributes) GetNodeTypeOk() (*string, bool) {
-	if o == nil {
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *UiNodeAnchorAttributes) GetNodeTypeOk() (*interface{}, bool) {
+	if o == nil || o.NodeType == nil {
 		return nil, false
 	}
 	return &o.NodeType, true
 }
 
 // SetNodeType sets field value
-func (o *UiNodeAnchorAttributes) SetNodeType(v string) {
+func (o *UiNodeAnchorAttributes) SetNodeType(v interface{}) {
 	o.NodeType = v
 }
 
@@ -150,7 +153,7 @@ func (o UiNodeAnchorAttributes) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["id"] = o.Id
 	}
-	if true {
+	if o.NodeType != nil {
 		toSerialize["node_type"] = o.NodeType
 	}
 	if true {

--- a/internal/httpclient/model_ui_node_anchor_attributes.go
+++ b/internal/httpclient/model_ui_node_anchor_attributes.go
@@ -22,15 +22,15 @@ type UiNodeAnchorAttributes struct {
 	// A unique identifier
 	Id string `json:"id"`
 	// NodeType represents this node's types. It is a mirror of `node.type` and is primarily used to allow compatibility with OpenAPI 3.0.
-	NodeType string `json:"node_type"`
-	Title    UiText `json:"title"`
+	NodeType interface{} `json:"node_type"`
+	Title    UiText      `json:"title"`
 }
 
 // NewUiNodeAnchorAttributes instantiates a new UiNodeAnchorAttributes object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewUiNodeAnchorAttributes(href string, id string, nodeType string, title UiText) *UiNodeAnchorAttributes {
+func NewUiNodeAnchorAttributes(href string, id string, nodeType interface{}, title UiText) *UiNodeAnchorAttributes {
 	this := UiNodeAnchorAttributes{}
 	this.Href = href
 	this.Id = id
@@ -96,9 +96,10 @@ func (o *UiNodeAnchorAttributes) SetId(v string) {
 }
 
 // GetNodeType returns the NodeType field value
-func (o *UiNodeAnchorAttributes) GetNodeType() string {
+// If the value is explicit nil, the zero value for interface{} will be returned
+func (o *UiNodeAnchorAttributes) GetNodeType() interface{} {
 	if o == nil {
-		var ret string
+		var ret interface{}
 		return ret
 	}
 
@@ -107,15 +108,16 @@ func (o *UiNodeAnchorAttributes) GetNodeType() string {
 
 // GetNodeTypeOk returns a tuple with the NodeType field value
 // and a boolean to check if the value has been set.
-func (o *UiNodeAnchorAttributes) GetNodeTypeOk() (*string, bool) {
-	if o == nil {
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *UiNodeAnchorAttributes) GetNodeTypeOk() (*interface{}, bool) {
+	if o == nil || o.NodeType == nil {
 		return nil, false
 	}
 	return &o.NodeType, true
 }
 
 // SetNodeType sets field value
-func (o *UiNodeAnchorAttributes) SetNodeType(v string) {
+func (o *UiNodeAnchorAttributes) SetNodeType(v interface{}) {
 	o.NodeType = v
 }
 
@@ -151,7 +153,7 @@ func (o UiNodeAnchorAttributes) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["id"] = o.Id
 	}
-	if true {
+	if o.NodeType != nil {
 		toSerialize["node_type"] = o.NodeType
 	}
 	if true {

--- a/internal/httpclient/model_ui_node_anchor_attributes.go
+++ b/internal/httpclient/model_ui_node_anchor_attributes.go
@@ -22,15 +22,15 @@ type UiNodeAnchorAttributes struct {
 	// A unique identifier
 	Id string `json:"id"`
 	// NodeType represents this node's types. It is a mirror of `node.type` and is primarily used to allow compatibility with OpenAPI 3.0.
-	NodeType interface{} `json:"node_type"`
-	Title    UiText      `json:"title"`
+	NodeType string `json:"node_type"`
+	Title    UiText `json:"title"`
 }
 
 // NewUiNodeAnchorAttributes instantiates a new UiNodeAnchorAttributes object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewUiNodeAnchorAttributes(href string, id string, nodeType interface{}, title UiText) *UiNodeAnchorAttributes {
+func NewUiNodeAnchorAttributes(href string, id string, nodeType string, title UiText) *UiNodeAnchorAttributes {
 	this := UiNodeAnchorAttributes{}
 	this.Href = href
 	this.Id = id
@@ -96,10 +96,9 @@ func (o *UiNodeAnchorAttributes) SetId(v string) {
 }
 
 // GetNodeType returns the NodeType field value
-// If the value is explicit nil, the zero value for interface{} will be returned
-func (o *UiNodeAnchorAttributes) GetNodeType() interface{} {
+func (o *UiNodeAnchorAttributes) GetNodeType() string {
 	if o == nil {
-		var ret interface{}
+		var ret string
 		return ret
 	}
 
@@ -108,16 +107,15 @@ func (o *UiNodeAnchorAttributes) GetNodeType() interface{} {
 
 // GetNodeTypeOk returns a tuple with the NodeType field value
 // and a boolean to check if the value has been set.
-// NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *UiNodeAnchorAttributes) GetNodeTypeOk() (*interface{}, bool) {
-	if o == nil || o.NodeType == nil {
+func (o *UiNodeAnchorAttributes) GetNodeTypeOk() (*string, bool) {
+	if o == nil {
 		return nil, false
 	}
 	return &o.NodeType, true
 }
 
 // SetNodeType sets field value
-func (o *UiNodeAnchorAttributes) SetNodeType(v interface{}) {
+func (o *UiNodeAnchorAttributes) SetNodeType(v string) {
 	o.NodeType = v
 }
 
@@ -153,7 +151,7 @@ func (o UiNodeAnchorAttributes) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["id"] = o.Id
 	}
-	if o.NodeType != nil {
+	if true {
 		toSerialize["node_type"] = o.NodeType
 	}
 	if true {

--- a/internal/httpclient/model_ui_node_image_attributes.go
+++ b/internal/httpclient/model_ui_node_image_attributes.go
@@ -22,7 +22,7 @@ type UiNodeImageAttributes struct {
 	// A unique identifier
 	Id string `json:"id"`
 	// NodeType represents this node's types. It is a mirror of `node.type` and is primarily used to allow compatibility with OpenAPI 3.0.
-	NodeType string `json:"node_type"`
+	NodeType interface{} `json:"node_type"`
 	// The image's source URL.  format: uri
 	Src string `json:"src"`
 	// Width of the image
@@ -33,7 +33,7 @@ type UiNodeImageAttributes struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewUiNodeImageAttributes(height int64, id string, nodeType string, src string, width int64) *UiNodeImageAttributes {
+func NewUiNodeImageAttributes(height int64, id string, nodeType interface{}, src string, width int64) *UiNodeImageAttributes {
 	this := UiNodeImageAttributes{}
 	this.Height = height
 	this.Id = id
@@ -100,9 +100,10 @@ func (o *UiNodeImageAttributes) SetId(v string) {
 }
 
 // GetNodeType returns the NodeType field value
-func (o *UiNodeImageAttributes) GetNodeType() string {
+// If the value is explicit nil, the zero value for interface{} will be returned
+func (o *UiNodeImageAttributes) GetNodeType() interface{} {
 	if o == nil {
-		var ret string
+		var ret interface{}
 		return ret
 	}
 
@@ -111,15 +112,16 @@ func (o *UiNodeImageAttributes) GetNodeType() string {
 
 // GetNodeTypeOk returns a tuple with the NodeType field value
 // and a boolean to check if the value has been set.
-func (o *UiNodeImageAttributes) GetNodeTypeOk() (*string, bool) {
-	if o == nil {
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *UiNodeImageAttributes) GetNodeTypeOk() (*interface{}, bool) {
+	if o == nil || o.NodeType == nil {
 		return nil, false
 	}
 	return &o.NodeType, true
 }
 
 // SetNodeType sets field value
-func (o *UiNodeImageAttributes) SetNodeType(v string) {
+func (o *UiNodeImageAttributes) SetNodeType(v interface{}) {
 	o.NodeType = v
 }
 
@@ -179,7 +181,7 @@ func (o UiNodeImageAttributes) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["id"] = o.Id
 	}
-	if true {
+	if o.NodeType != nil {
 		toSerialize["node_type"] = o.NodeType
 	}
 	if true {

--- a/internal/httpclient/model_ui_node_image_attributes.go
+++ b/internal/httpclient/model_ui_node_image_attributes.go
@@ -20,8 +20,9 @@ type UiNodeImageAttributes struct {
 	// Height of the image
 	Height int64 `json:"height"`
 	// A unique identifier
-	Id       string `json:"id"`
-	NodeType string `json:"node_type"`
+	Id string `json:"id"`
+	// NodeType represents this node's types. It is a mirror of `node.type` and is primarily used to allow compatibility with OpenAPI 3.0.
+	NodeType interface{} `json:"node_type"`
 	// The image's source URL.  format: uri
 	Src string `json:"src"`
 	// Width of the image
@@ -32,7 +33,7 @@ type UiNodeImageAttributes struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewUiNodeImageAttributes(height int64, id string, nodeType string, src string, width int64) *UiNodeImageAttributes {
+func NewUiNodeImageAttributes(height int64, id string, nodeType interface{}, src string, width int64) *UiNodeImageAttributes {
 	this := UiNodeImageAttributes{}
 	this.Height = height
 	this.Id = id
@@ -99,9 +100,10 @@ func (o *UiNodeImageAttributes) SetId(v string) {
 }
 
 // GetNodeType returns the NodeType field value
-func (o *UiNodeImageAttributes) GetNodeType() string {
+// If the value is explicit nil, the zero value for interface{} will be returned
+func (o *UiNodeImageAttributes) GetNodeType() interface{} {
 	if o == nil {
-		var ret string
+		var ret interface{}
 		return ret
 	}
 
@@ -110,15 +112,16 @@ func (o *UiNodeImageAttributes) GetNodeType() string {
 
 // GetNodeTypeOk returns a tuple with the NodeType field value
 // and a boolean to check if the value has been set.
-func (o *UiNodeImageAttributes) GetNodeTypeOk() (*string, bool) {
-	if o == nil {
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *UiNodeImageAttributes) GetNodeTypeOk() (*interface{}, bool) {
+	if o == nil || o.NodeType == nil {
 		return nil, false
 	}
 	return &o.NodeType, true
 }
 
 // SetNodeType sets field value
-func (o *UiNodeImageAttributes) SetNodeType(v string) {
+func (o *UiNodeImageAttributes) SetNodeType(v interface{}) {
 	o.NodeType = v
 }
 
@@ -178,7 +181,7 @@ func (o UiNodeImageAttributes) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["id"] = o.Id
 	}
-	if true {
+	if o.NodeType != nil {
 		toSerialize["node_type"] = o.NodeType
 	}
 	if true {

--- a/internal/httpclient/model_ui_node_image_attributes.go
+++ b/internal/httpclient/model_ui_node_image_attributes.go
@@ -22,7 +22,7 @@ type UiNodeImageAttributes struct {
 	// A unique identifier
 	Id string `json:"id"`
 	// NodeType represents this node's types. It is a mirror of `node.type` and is primarily used to allow compatibility with OpenAPI 3.0.
-	NodeType interface{} `json:"node_type"`
+	NodeType string `json:"node_type"`
 	// The image's source URL.  format: uri
 	Src string `json:"src"`
 	// Width of the image
@@ -33,7 +33,7 @@ type UiNodeImageAttributes struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewUiNodeImageAttributes(height int64, id string, nodeType interface{}, src string, width int64) *UiNodeImageAttributes {
+func NewUiNodeImageAttributes(height int64, id string, nodeType string, src string, width int64) *UiNodeImageAttributes {
 	this := UiNodeImageAttributes{}
 	this.Height = height
 	this.Id = id
@@ -100,10 +100,9 @@ func (o *UiNodeImageAttributes) SetId(v string) {
 }
 
 // GetNodeType returns the NodeType field value
-// If the value is explicit nil, the zero value for interface{} will be returned
-func (o *UiNodeImageAttributes) GetNodeType() interface{} {
+func (o *UiNodeImageAttributes) GetNodeType() string {
 	if o == nil {
-		var ret interface{}
+		var ret string
 		return ret
 	}
 
@@ -112,16 +111,15 @@ func (o *UiNodeImageAttributes) GetNodeType() interface{} {
 
 // GetNodeTypeOk returns a tuple with the NodeType field value
 // and a boolean to check if the value has been set.
-// NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *UiNodeImageAttributes) GetNodeTypeOk() (*interface{}, bool) {
-	if o == nil || o.NodeType == nil {
+func (o *UiNodeImageAttributes) GetNodeTypeOk() (*string, bool) {
+	if o == nil {
 		return nil, false
 	}
 	return &o.NodeType, true
 }
 
 // SetNodeType sets field value
-func (o *UiNodeImageAttributes) SetNodeType(v interface{}) {
+func (o *UiNodeImageAttributes) SetNodeType(v string) {
 	o.NodeType = v
 }
 
@@ -181,7 +179,7 @@ func (o UiNodeImageAttributes) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["id"] = o.Id
 	}
-	if o.NodeType != nil {
+	if true {
 		toSerialize["node_type"] = o.NodeType
 	}
 	if true {

--- a/internal/httpclient/model_ui_node_input_attributes.go
+++ b/internal/httpclient/model_ui_node_input_attributes.go
@@ -23,7 +23,7 @@ type UiNodeInputAttributes struct {
 	// The input's element name.
 	Name string `json:"name"`
 	// NodeType represents this node's types. It is a mirror of `node.type` and is primarily used to allow compatibility with OpenAPI 3.0.
-	NodeType interface{} `json:"node_type"`
+	NodeType string `json:"node_type"`
 	// OnClick may contain javascript which should be executed on click. This is primarily used for WebAuthn.
 	Onclick *string `json:"onclick,omitempty"`
 	// The input's pattern.
@@ -39,7 +39,7 @@ type UiNodeInputAttributes struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewUiNodeInputAttributes(disabled bool, name string, nodeType interface{}, type_ string) *UiNodeInputAttributes {
+func NewUiNodeInputAttributes(disabled bool, name string, nodeType string, type_ string) *UiNodeInputAttributes {
 	this := UiNodeInputAttributes{}
 	this.Disabled = disabled
 	this.Name = name
@@ -137,10 +137,9 @@ func (o *UiNodeInputAttributes) SetName(v string) {
 }
 
 // GetNodeType returns the NodeType field value
-// If the value is explicit nil, the zero value for interface{} will be returned
-func (o *UiNodeInputAttributes) GetNodeType() interface{} {
+func (o *UiNodeInputAttributes) GetNodeType() string {
 	if o == nil {
-		var ret interface{}
+		var ret string
 		return ret
 	}
 
@@ -149,16 +148,15 @@ func (o *UiNodeInputAttributes) GetNodeType() interface{} {
 
 // GetNodeTypeOk returns a tuple with the NodeType field value
 // and a boolean to check if the value has been set.
-// NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *UiNodeInputAttributes) GetNodeTypeOk() (*interface{}, bool) {
-	if o == nil || o.NodeType == nil {
+func (o *UiNodeInputAttributes) GetNodeTypeOk() (*string, bool) {
+	if o == nil {
 		return nil, false
 	}
 	return &o.NodeType, true
 }
 
 // SetNodeType sets field value
-func (o *UiNodeInputAttributes) SetNodeType(v interface{}) {
+func (o *UiNodeInputAttributes) SetNodeType(v string) {
 	o.NodeType = v
 }
 
@@ -326,7 +324,7 @@ func (o UiNodeInputAttributes) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["name"] = o.Name
 	}
-	if o.NodeType != nil {
+	if true {
 		toSerialize["node_type"] = o.NodeType
 	}
 	if o.Onclick != nil {

--- a/internal/httpclient/model_ui_node_input_attributes.go
+++ b/internal/httpclient/model_ui_node_input_attributes.go
@@ -23,7 +23,7 @@ type UiNodeInputAttributes struct {
 	// The input's element name.
 	Name string `json:"name"`
 	// NodeType represents this node's types. It is a mirror of `node.type` and is primarily used to allow compatibility with OpenAPI 3.0.
-	NodeType string `json:"node_type"`
+	NodeType interface{} `json:"node_type"`
 	// OnClick may contain javascript which should be executed on click. This is primarily used for WebAuthn.
 	Onclick *string `json:"onclick,omitempty"`
 	// The input's pattern.
@@ -39,7 +39,7 @@ type UiNodeInputAttributes struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewUiNodeInputAttributes(disabled bool, name string, nodeType string, type_ string) *UiNodeInputAttributes {
+func NewUiNodeInputAttributes(disabled bool, name string, nodeType interface{}, type_ string) *UiNodeInputAttributes {
 	this := UiNodeInputAttributes{}
 	this.Disabled = disabled
 	this.Name = name
@@ -137,9 +137,10 @@ func (o *UiNodeInputAttributes) SetName(v string) {
 }
 
 // GetNodeType returns the NodeType field value
-func (o *UiNodeInputAttributes) GetNodeType() string {
+// If the value is explicit nil, the zero value for interface{} will be returned
+func (o *UiNodeInputAttributes) GetNodeType() interface{} {
 	if o == nil {
-		var ret string
+		var ret interface{}
 		return ret
 	}
 
@@ -148,15 +149,16 @@ func (o *UiNodeInputAttributes) GetNodeType() string {
 
 // GetNodeTypeOk returns a tuple with the NodeType field value
 // and a boolean to check if the value has been set.
-func (o *UiNodeInputAttributes) GetNodeTypeOk() (*string, bool) {
-	if o == nil {
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *UiNodeInputAttributes) GetNodeTypeOk() (*interface{}, bool) {
+	if o == nil || o.NodeType == nil {
 		return nil, false
 	}
 	return &o.NodeType, true
 }
 
 // SetNodeType sets field value
-func (o *UiNodeInputAttributes) SetNodeType(v string) {
+func (o *UiNodeInputAttributes) SetNodeType(v interface{}) {
 	o.NodeType = v
 }
 
@@ -324,7 +326,7 @@ func (o UiNodeInputAttributes) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["name"] = o.Name
 	}
-	if true {
+	if o.NodeType != nil {
 		toSerialize["node_type"] = o.NodeType
 	}
 	if o.Onclick != nil {

--- a/internal/httpclient/model_ui_node_input_attributes.go
+++ b/internal/httpclient/model_ui_node_input_attributes.go
@@ -21,8 +21,9 @@ type UiNodeInputAttributes struct {
 	Disabled bool    `json:"disabled"`
 	Label    *UiText `json:"label,omitempty"`
 	// The input's element name.
-	Name     string `json:"name"`
-	NodeType string `json:"node_type"`
+	Name string `json:"name"`
+	// NodeType represents this node's types. It is a mirror of `node.type` and is primarily used to allow compatibility with OpenAPI 3.0.
+	NodeType interface{} `json:"node_type"`
 	// OnClick may contain javascript which should be executed on click. This is primarily used for WebAuthn.
 	Onclick *string `json:"onclick,omitempty"`
 	// The input's pattern.
@@ -38,7 +39,7 @@ type UiNodeInputAttributes struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewUiNodeInputAttributes(disabled bool, name string, nodeType string, type_ string) *UiNodeInputAttributes {
+func NewUiNodeInputAttributes(disabled bool, name string, nodeType interface{}, type_ string) *UiNodeInputAttributes {
 	this := UiNodeInputAttributes{}
 	this.Disabled = disabled
 	this.Name = name
@@ -136,9 +137,10 @@ func (o *UiNodeInputAttributes) SetName(v string) {
 }
 
 // GetNodeType returns the NodeType field value
-func (o *UiNodeInputAttributes) GetNodeType() string {
+// If the value is explicit nil, the zero value for interface{} will be returned
+func (o *UiNodeInputAttributes) GetNodeType() interface{} {
 	if o == nil {
-		var ret string
+		var ret interface{}
 		return ret
 	}
 
@@ -147,15 +149,16 @@ func (o *UiNodeInputAttributes) GetNodeType() string {
 
 // GetNodeTypeOk returns a tuple with the NodeType field value
 // and a boolean to check if the value has been set.
-func (o *UiNodeInputAttributes) GetNodeTypeOk() (*string, bool) {
-	if o == nil {
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *UiNodeInputAttributes) GetNodeTypeOk() (*interface{}, bool) {
+	if o == nil || o.NodeType == nil {
 		return nil, false
 	}
 	return &o.NodeType, true
 }
 
 // SetNodeType sets field value
-func (o *UiNodeInputAttributes) SetNodeType(v string) {
+func (o *UiNodeInputAttributes) SetNodeType(v interface{}) {
 	o.NodeType = v
 }
 
@@ -323,7 +326,7 @@ func (o UiNodeInputAttributes) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["name"] = o.Name
 	}
-	if true {
+	if o.NodeType != nil {
 		toSerialize["node_type"] = o.NodeType
 	}
 	if o.Onclick != nil {

--- a/internal/httpclient/model_ui_node_script_attributes.go
+++ b/internal/httpclient/model_ui_node_script_attributes.go
@@ -25,7 +25,8 @@ type UiNodeScriptAttributes struct {
 	Id string `json:"id"`
 	// The script's integrity hash
 	Integrity string `json:"integrity"`
-	NodeType  string `json:"node_type"`
+	// NodeType represents this node's types. It is a mirror of `node.type` and is primarily used to allow compatibility with OpenAPI 3.0.
+	NodeType interface{} `json:"node_type"`
 	// Nonce for CSP  A nonce you may want to use to improve your Content Security Policy. You do not have to use this value but if you want to improve your CSP policies you may use it. You can also choose to use your own nonce value!
 	Nonce string `json:"nonce"`
 	// The script referrer policy
@@ -40,7 +41,7 @@ type UiNodeScriptAttributes struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewUiNodeScriptAttributes(async bool, crossorigin string, id string, integrity string, nodeType string, nonce string, referrerpolicy string, src string, type_ string) *UiNodeScriptAttributes {
+func NewUiNodeScriptAttributes(async bool, crossorigin string, id string, integrity string, nodeType interface{}, nonce string, referrerpolicy string, src string, type_ string) *UiNodeScriptAttributes {
 	this := UiNodeScriptAttributes{}
 	this.Async = async
 	this.Crossorigin = crossorigin
@@ -159,9 +160,10 @@ func (o *UiNodeScriptAttributes) SetIntegrity(v string) {
 }
 
 // GetNodeType returns the NodeType field value
-func (o *UiNodeScriptAttributes) GetNodeType() string {
+// If the value is explicit nil, the zero value for interface{} will be returned
+func (o *UiNodeScriptAttributes) GetNodeType() interface{} {
 	if o == nil {
-		var ret string
+		var ret interface{}
 		return ret
 	}
 
@@ -170,15 +172,16 @@ func (o *UiNodeScriptAttributes) GetNodeType() string {
 
 // GetNodeTypeOk returns a tuple with the NodeType field value
 // and a boolean to check if the value has been set.
-func (o *UiNodeScriptAttributes) GetNodeTypeOk() (*string, bool) {
-	if o == nil {
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *UiNodeScriptAttributes) GetNodeTypeOk() (*interface{}, bool) {
+	if o == nil || o.NodeType == nil {
 		return nil, false
 	}
 	return &o.NodeType, true
 }
 
 // SetNodeType sets field value
-func (o *UiNodeScriptAttributes) SetNodeType(v string) {
+func (o *UiNodeScriptAttributes) SetNodeType(v interface{}) {
 	o.NodeType = v
 }
 
@@ -292,7 +295,7 @@ func (o UiNodeScriptAttributes) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["integrity"] = o.Integrity
 	}
-	if true {
+	if o.NodeType != nil {
 		toSerialize["node_type"] = o.NodeType
 	}
 	if true {

--- a/internal/httpclient/model_ui_node_script_attributes.go
+++ b/internal/httpclient/model_ui_node_script_attributes.go
@@ -26,7 +26,7 @@ type UiNodeScriptAttributes struct {
 	// The script's integrity hash
 	Integrity string `json:"integrity"`
 	// NodeType represents this node's types. It is a mirror of `node.type` and is primarily used to allow compatibility with OpenAPI 3.0.
-	NodeType string `json:"node_type"`
+	NodeType interface{} `json:"node_type"`
 	// Nonce for CSP  A nonce you may want to use to improve your Content Security Policy. You do not have to use this value but if you want to improve your CSP policies you may use it. You can also choose to use your own nonce value!
 	Nonce string `json:"nonce"`
 	// The script referrer policy
@@ -41,7 +41,7 @@ type UiNodeScriptAttributes struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewUiNodeScriptAttributes(async bool, crossorigin string, id string, integrity string, nodeType string, nonce string, referrerpolicy string, src string, type_ string) *UiNodeScriptAttributes {
+func NewUiNodeScriptAttributes(async bool, crossorigin string, id string, integrity string, nodeType interface{}, nonce string, referrerpolicy string, src string, type_ string) *UiNodeScriptAttributes {
 	this := UiNodeScriptAttributes{}
 	this.Async = async
 	this.Crossorigin = crossorigin
@@ -160,9 +160,10 @@ func (o *UiNodeScriptAttributes) SetIntegrity(v string) {
 }
 
 // GetNodeType returns the NodeType field value
-func (o *UiNodeScriptAttributes) GetNodeType() string {
+// If the value is explicit nil, the zero value for interface{} will be returned
+func (o *UiNodeScriptAttributes) GetNodeType() interface{} {
 	if o == nil {
-		var ret string
+		var ret interface{}
 		return ret
 	}
 
@@ -171,15 +172,16 @@ func (o *UiNodeScriptAttributes) GetNodeType() string {
 
 // GetNodeTypeOk returns a tuple with the NodeType field value
 // and a boolean to check if the value has been set.
-func (o *UiNodeScriptAttributes) GetNodeTypeOk() (*string, bool) {
-	if o == nil {
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *UiNodeScriptAttributes) GetNodeTypeOk() (*interface{}, bool) {
+	if o == nil || o.NodeType == nil {
 		return nil, false
 	}
 	return &o.NodeType, true
 }
 
 // SetNodeType sets field value
-func (o *UiNodeScriptAttributes) SetNodeType(v string) {
+func (o *UiNodeScriptAttributes) SetNodeType(v interface{}) {
 	o.NodeType = v
 }
 
@@ -293,7 +295,7 @@ func (o UiNodeScriptAttributes) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["integrity"] = o.Integrity
 	}
-	if true {
+	if o.NodeType != nil {
 		toSerialize["node_type"] = o.NodeType
 	}
 	if true {

--- a/internal/httpclient/model_ui_node_script_attributes.go
+++ b/internal/httpclient/model_ui_node_script_attributes.go
@@ -26,7 +26,7 @@ type UiNodeScriptAttributes struct {
 	// The script's integrity hash
 	Integrity string `json:"integrity"`
 	// NodeType represents this node's types. It is a mirror of `node.type` and is primarily used to allow compatibility with OpenAPI 3.0.
-	NodeType interface{} `json:"node_type"`
+	NodeType string `json:"node_type"`
 	// Nonce for CSP  A nonce you may want to use to improve your Content Security Policy. You do not have to use this value but if you want to improve your CSP policies you may use it. You can also choose to use your own nonce value!
 	Nonce string `json:"nonce"`
 	// The script referrer policy
@@ -41,7 +41,7 @@ type UiNodeScriptAttributes struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewUiNodeScriptAttributes(async bool, crossorigin string, id string, integrity string, nodeType interface{}, nonce string, referrerpolicy string, src string, type_ string) *UiNodeScriptAttributes {
+func NewUiNodeScriptAttributes(async bool, crossorigin string, id string, integrity string, nodeType string, nonce string, referrerpolicy string, src string, type_ string) *UiNodeScriptAttributes {
 	this := UiNodeScriptAttributes{}
 	this.Async = async
 	this.Crossorigin = crossorigin
@@ -160,10 +160,9 @@ func (o *UiNodeScriptAttributes) SetIntegrity(v string) {
 }
 
 // GetNodeType returns the NodeType field value
-// If the value is explicit nil, the zero value for interface{} will be returned
-func (o *UiNodeScriptAttributes) GetNodeType() interface{} {
+func (o *UiNodeScriptAttributes) GetNodeType() string {
 	if o == nil {
-		var ret interface{}
+		var ret string
 		return ret
 	}
 
@@ -172,16 +171,15 @@ func (o *UiNodeScriptAttributes) GetNodeType() interface{} {
 
 // GetNodeTypeOk returns a tuple with the NodeType field value
 // and a boolean to check if the value has been set.
-// NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *UiNodeScriptAttributes) GetNodeTypeOk() (*interface{}, bool) {
-	if o == nil || o.NodeType == nil {
+func (o *UiNodeScriptAttributes) GetNodeTypeOk() (*string, bool) {
+	if o == nil {
 		return nil, false
 	}
 	return &o.NodeType, true
 }
 
 // SetNodeType sets field value
-func (o *UiNodeScriptAttributes) SetNodeType(v interface{}) {
+func (o *UiNodeScriptAttributes) SetNodeType(v string) {
 	o.NodeType = v
 }
 
@@ -295,7 +293,7 @@ func (o UiNodeScriptAttributes) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["integrity"] = o.Integrity
 	}
-	if o.NodeType != nil {
+	if true {
 		toSerialize["node_type"] = o.NodeType
 	}
 	if true {

--- a/internal/httpclient/model_ui_node_text_attributes.go
+++ b/internal/httpclient/model_ui_node_text_attributes.go
@@ -20,15 +20,15 @@ type UiNodeTextAttributes struct {
 	// A unique identifier
 	Id string `json:"id"`
 	// NodeType represents this node's types. It is a mirror of `node.type` and is primarily used to allow compatibility with OpenAPI 3.0.
-	NodeType string `json:"node_type"`
-	Text     UiText `json:"text"`
+	NodeType interface{} `json:"node_type"`
+	Text     UiText      `json:"text"`
 }
 
 // NewUiNodeTextAttributes instantiates a new UiNodeTextAttributes object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewUiNodeTextAttributes(id string, nodeType string, text UiText) *UiNodeTextAttributes {
+func NewUiNodeTextAttributes(id string, nodeType interface{}, text UiText) *UiNodeTextAttributes {
 	this := UiNodeTextAttributes{}
 	this.Id = id
 	this.NodeType = nodeType
@@ -69,9 +69,10 @@ func (o *UiNodeTextAttributes) SetId(v string) {
 }
 
 // GetNodeType returns the NodeType field value
-func (o *UiNodeTextAttributes) GetNodeType() string {
+// If the value is explicit nil, the zero value for interface{} will be returned
+func (o *UiNodeTextAttributes) GetNodeType() interface{} {
 	if o == nil {
-		var ret string
+		var ret interface{}
 		return ret
 	}
 
@@ -80,15 +81,16 @@ func (o *UiNodeTextAttributes) GetNodeType() string {
 
 // GetNodeTypeOk returns a tuple with the NodeType field value
 // and a boolean to check if the value has been set.
-func (o *UiNodeTextAttributes) GetNodeTypeOk() (*string, bool) {
-	if o == nil {
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *UiNodeTextAttributes) GetNodeTypeOk() (*interface{}, bool) {
+	if o == nil || o.NodeType == nil {
 		return nil, false
 	}
 	return &o.NodeType, true
 }
 
 // SetNodeType sets field value
-func (o *UiNodeTextAttributes) SetNodeType(v string) {
+func (o *UiNodeTextAttributes) SetNodeType(v interface{}) {
 	o.NodeType = v
 }
 
@@ -121,7 +123,7 @@ func (o UiNodeTextAttributes) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["id"] = o.Id
 	}
-	if true {
+	if o.NodeType != nil {
 		toSerialize["node_type"] = o.NodeType
 	}
 	if true {

--- a/internal/httpclient/model_ui_node_text_attributes.go
+++ b/internal/httpclient/model_ui_node_text_attributes.go
@@ -20,15 +20,15 @@ type UiNodeTextAttributes struct {
 	// A unique identifier
 	Id string `json:"id"`
 	// NodeType represents this node's types. It is a mirror of `node.type` and is primarily used to allow compatibility with OpenAPI 3.0.
-	NodeType interface{} `json:"node_type"`
-	Text     UiText      `json:"text"`
+	NodeType string `json:"node_type"`
+	Text     UiText `json:"text"`
 }
 
 // NewUiNodeTextAttributes instantiates a new UiNodeTextAttributes object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewUiNodeTextAttributes(id string, nodeType interface{}, text UiText) *UiNodeTextAttributes {
+func NewUiNodeTextAttributes(id string, nodeType string, text UiText) *UiNodeTextAttributes {
 	this := UiNodeTextAttributes{}
 	this.Id = id
 	this.NodeType = nodeType
@@ -69,10 +69,9 @@ func (o *UiNodeTextAttributes) SetId(v string) {
 }
 
 // GetNodeType returns the NodeType field value
-// If the value is explicit nil, the zero value for interface{} will be returned
-func (o *UiNodeTextAttributes) GetNodeType() interface{} {
+func (o *UiNodeTextAttributes) GetNodeType() string {
 	if o == nil {
-		var ret interface{}
+		var ret string
 		return ret
 	}
 
@@ -81,16 +80,15 @@ func (o *UiNodeTextAttributes) GetNodeType() interface{} {
 
 // GetNodeTypeOk returns a tuple with the NodeType field value
 // and a boolean to check if the value has been set.
-// NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *UiNodeTextAttributes) GetNodeTypeOk() (*interface{}, bool) {
-	if o == nil || o.NodeType == nil {
+func (o *UiNodeTextAttributes) GetNodeTypeOk() (*string, bool) {
+	if o == nil {
 		return nil, false
 	}
 	return &o.NodeType, true
 }
 
 // SetNodeType sets field value
-func (o *UiNodeTextAttributes) SetNodeType(v interface{}) {
+func (o *UiNodeTextAttributes) SetNodeType(v string) {
 	o.NodeType = v
 }
 
@@ -123,7 +121,7 @@ func (o UiNodeTextAttributes) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["id"] = o.Id
 	}
-	if o.NodeType != nil {
+	if true {
 		toSerialize["node_type"] = o.NodeType
 	}
 	if true {

--- a/internal/httpclient/model_ui_node_text_attributes.go
+++ b/internal/httpclient/model_ui_node_text_attributes.go
@@ -18,16 +18,17 @@ import (
 // UiNodeTextAttributes struct for UiNodeTextAttributes
 type UiNodeTextAttributes struct {
 	// A unique identifier
-	Id       string `json:"id"`
-	NodeType string `json:"node_type"`
-	Text     UiText `json:"text"`
+	Id string `json:"id"`
+	// NodeType represents this node's types. It is a mirror of `node.type` and is primarily used to allow compatibility with OpenAPI 3.0.
+	NodeType interface{} `json:"node_type"`
+	Text     UiText      `json:"text"`
 }
 
 // NewUiNodeTextAttributes instantiates a new UiNodeTextAttributes object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewUiNodeTextAttributes(id string, nodeType string, text UiText) *UiNodeTextAttributes {
+func NewUiNodeTextAttributes(id string, nodeType interface{}, text UiText) *UiNodeTextAttributes {
 	this := UiNodeTextAttributes{}
 	this.Id = id
 	this.NodeType = nodeType
@@ -68,9 +69,10 @@ func (o *UiNodeTextAttributes) SetId(v string) {
 }
 
 // GetNodeType returns the NodeType field value
-func (o *UiNodeTextAttributes) GetNodeType() string {
+// If the value is explicit nil, the zero value for interface{} will be returned
+func (o *UiNodeTextAttributes) GetNodeType() interface{} {
 	if o == nil {
-		var ret string
+		var ret interface{}
 		return ret
 	}
 
@@ -79,15 +81,16 @@ func (o *UiNodeTextAttributes) GetNodeType() string {
 
 // GetNodeTypeOk returns a tuple with the NodeType field value
 // and a boolean to check if the value has been set.
-func (o *UiNodeTextAttributes) GetNodeTypeOk() (*string, bool) {
-	if o == nil {
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *UiNodeTextAttributes) GetNodeTypeOk() (*interface{}, bool) {
+	if o == nil || o.NodeType == nil {
 		return nil, false
 	}
 	return &o.NodeType, true
 }
 
 // SetNodeType sets field value
-func (o *UiNodeTextAttributes) SetNodeType(v string) {
+func (o *UiNodeTextAttributes) SetNodeType(v interface{}) {
 	o.NodeType = v
 }
 
@@ -120,7 +123,7 @@ func (o UiNodeTextAttributes) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["id"] = o.Id
 	}
-	if true {
+	if o.NodeType != nil {
 		toSerialize["node_type"] = o.NodeType
 	}
 	if true {

--- a/selfservice/flow/login/error.go
+++ b/selfservice/flow/login/error.go
@@ -70,7 +70,7 @@ func (s *ErrorHandler) PrepareReplacementForExpiredFlow(w http.ResponseWriter, r
 	return e.WithFlow(a), nil
 }
 
-func (s *ErrorHandler) WriteFlowError(w http.ResponseWriter, r *http.Request, f *Flow, group node.Group, err error) {
+func (s *ErrorHandler) WriteFlowError(w http.ResponseWriter, r *http.Request, f *Flow, group node.UiNodeGroup, err error) {
 	s.d.Audit().
 		WithError(err).
 		WithRequest(r).

--- a/selfservice/flow/login/error_test.go
+++ b/selfservice/flow/login/error_test.go
@@ -51,7 +51,7 @@ func TestHandleError(t *testing.T) {
 
 	var loginFlow *login.Flow
 	var flowError error
-	var ct node.Group
+	var ct node.UiNodeGroup
 	router.GET("/error", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		h.WriteFlowError(w, r, loginFlow, ct, flowError)
 	})

--- a/selfservice/flow/login/sort.go
+++ b/selfservice/flow/login/sort.go
@@ -8,7 +8,7 @@ import (
 
 func sortNodes(ctx context.Context, n node.Nodes) error {
 	return n.SortBySchema(ctx,
-		node.SortByGroups([]node.Group{
+		node.SortByGroups([]node.UiNodeGroup{
 			node.OpenIDConnectGroup,
 			node.DefaultGroup,
 			node.WebAuthnGroup,

--- a/selfservice/flow/login/strategy.go
+++ b/selfservice/flow/login/strategy.go
@@ -15,7 +15,7 @@ import (
 
 type Strategy interface {
 	ID() identity.CredentialsType
-	NodeGroup() node.Group
+	NodeGroup() node.UiNodeGroup
 	RegisterLoginRoutes(*x.RouterPublic)
 	PopulateLoginMethod(r *http.Request, requestedAAL identity.AuthenticatorAssuranceLevel, sr *Flow) error
 	Login(w http.ResponseWriter, r *http.Request, f *Flow, ss *session.Session) (i *identity.Identity, err error)

--- a/selfservice/flow/recovery/error.go
+++ b/selfservice/flow/recovery/error.go
@@ -54,7 +54,7 @@ func (s *ErrorHandler) WriteFlowError(
 	w http.ResponseWriter,
 	r *http.Request,
 	f *Flow,
-	group node.Group,
+	group node.UiNodeGroup,
 	err error,
 ) {
 	s.d.Audit().

--- a/selfservice/flow/recovery/error_test.go
+++ b/selfservice/flow/recovery/error_test.go
@@ -52,7 +52,7 @@ func TestHandleError(t *testing.T) {
 
 	var recoveryFlow *recovery.Flow
 	var flowError error
-	var methodName node.Group
+	var methodName node.UiNodeGroup
 	router.GET("/error", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		h.WriteFlowError(w, r, recoveryFlow, methodName, flowError)
 	})

--- a/selfservice/flow/recovery/error_test.go
+++ b/selfservice/flow/recovery/error_test.go
@@ -195,7 +195,7 @@ func TestHandleError(t *testing.T) {
 
 			recoveryFlow = &recovery.Flow{Type: flow.TypeBrowser}
 			flowError = flow.NewFlowExpiredError(anHourAgo)
-			methodName = node.RecoveryLinkGroup
+			methodName = node.LinkGroup
 
 			lf, _ := expectRecoveryUI(t)
 			require.Len(t, lf.UI.Messages, 1, "%s", jsonx.TestMarshalJSONString(t, lf))
@@ -207,7 +207,7 @@ func TestHandleError(t *testing.T) {
 
 			recoveryFlow = newFlow(t, time.Minute, flow.TypeBrowser)
 			flowError = schema.NewInvalidCredentialsError()
-			methodName = node.RecoveryLinkGroup
+			methodName = node.LinkGroup
 
 			lf, _ := expectRecoveryUI(t)
 			require.NotEmpty(t, lf.UI, x.MustEncodeJSON(t, lf))
@@ -220,7 +220,7 @@ func TestHandleError(t *testing.T) {
 
 			recoveryFlow = newFlow(t, time.Minute, flow.TypeBrowser)
 			flowError = herodot.ErrInternalServerError.WithReason("system error")
-			methodName = node.RecoveryLinkGroup
+			methodName = node.LinkGroup
 
 			sse, _ := expectErrorUI(t)
 			assertx.EqualAsJSON(t, flowError, sse)

--- a/selfservice/flow/recovery/flow.go
+++ b/selfservice/flow/recovery/flow.go
@@ -38,6 +38,8 @@ type Flow struct {
 	ID uuid.UUID `json:"id" db:"id" faker:"-"`
 
 	// Type represents the flow's type which can be either "api" or "browser", depending on the flow interaction.
+	//
+	// required: true
 	Type flow.Type `json:"type" db:"type" faker:"flow_type"`
 
 	// ExpiresAt is the time (UTC) when the request expires. If the user still wishes to update the setting,

--- a/selfservice/flow/recovery/handler.go
+++ b/selfservice/flow/recovery/handler.go
@@ -370,7 +370,7 @@ func (h *Handler) submitFlow(w http.ResponseWriter, r *http.Request, ps httprout
 		return
 	}
 
-	var g node.Group
+	var g node.UiNodeGroup
 	var found bool
 	for _, ss := range h.d.AllRecoveryStrategies() {
 		err := ss.Recover(w, r, f)

--- a/selfservice/flow/recovery/strategy.go
+++ b/selfservice/flow/recovery/strategy.go
@@ -18,7 +18,7 @@ const (
 type (
 	Strategy interface {
 		RecoveryStrategyID() string
-		RecoveryNodeGroup() node.Group
+		RecoveryNodeGroup() node.UiNodeGroup
 		PopulateRecoveryMethod(*http.Request, *Flow) error
 		Recover(w http.ResponseWriter, r *http.Request, f *Flow) (err error)
 	}

--- a/selfservice/flow/registration/error.go
+++ b/selfservice/flow/registration/error.go
@@ -66,7 +66,7 @@ func (s *ErrorHandler) WriteFlowError(
 	w http.ResponseWriter,
 	r *http.Request,
 	f *Flow,
-	group node.Group,
+	group node.UiNodeGroup,
 	err error,
 ) {
 	s.d.Audit().

--- a/selfservice/flow/registration/error_test.go
+++ b/selfservice/flow/registration/error_test.go
@@ -54,7 +54,7 @@ func TestHandleError(t *testing.T) {
 
 	var registrationFlow *registration.Flow
 	var flowError error
-	var group node.Group
+	var group node.UiNodeGroup
 	router.GET("/error", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		h.WriteFlowError(w, r, registrationFlow, group, flowError)
 	})

--- a/selfservice/flow/registration/flow.go
+++ b/selfservice/flow/registration/flow.go
@@ -37,6 +37,8 @@ type Flow struct {
 	ID uuid.UUID `json:"id" faker:"-" db:"id"`
 
 	// Type represents the flow's type which can be either "api" or "browser", depending on the flow interaction.
+	//
+	// required: true
 	Type flow.Type `json:"type" db:"type" faker:"flow_type"`
 
 	// ExpiresAt is the time (UTC) when the flow expires. If the user still wishes to log in,

--- a/selfservice/flow/registration/sort.go
+++ b/selfservice/flow/registration/sort.go
@@ -9,7 +9,7 @@ import (
 func SortNodes(ctx context.Context, n node.Nodes, schemaRef string) error {
 	return n.SortBySchema(ctx,
 		node.SortBySchema(schemaRef),
-		node.SortByGroups([]node.Group{
+		node.SortByGroups([]node.UiNodeGroup{
 			node.DefaultGroup,
 			node.OpenIDConnectGroup,
 			node.WebAuthnGroup,

--- a/selfservice/flow/registration/strategy.go
+++ b/selfservice/flow/registration/strategy.go
@@ -14,7 +14,7 @@ import (
 
 type Strategy interface {
 	ID() identity.CredentialsType
-	NodeGroup() node.Group
+	NodeGroup() node.UiNodeGroup
 	RegisterRegistrationRoutes(*x.RouterPublic)
 	PopulateRegistrationMethod(r *http.Request, sr *Flow) error
 	Register(w http.ResponseWriter, r *http.Request, f *Flow, i *identity.Identity) (err error)

--- a/selfservice/flow/settings/error.go
+++ b/selfservice/flow/settings/error.go
@@ -115,7 +115,7 @@ func (s *ErrorHandler) PrepareReplacementForExpiredFlow(w http.ResponseWriter, r
 func (s *ErrorHandler) WriteFlowError(
 	w http.ResponseWriter,
 	r *http.Request,
-	group node.Group,
+	group node.UiNodeGroup,
 	f *Flow,
 	id *identity.Identity,
 	err error,

--- a/selfservice/flow/settings/error_test.go
+++ b/selfservice/flow/settings/error_test.go
@@ -57,7 +57,7 @@ func TestHandleError(t *testing.T) {
 
 	var settingsFlow *settings.Flow
 	var flowError error
-	var flowMethod node.Group
+	var flowMethod node.UiNodeGroup
 	var id identity.Identity
 	require.NoError(t, faker.FakeData(&id))
 	id.SchemaID = "default"

--- a/selfservice/flow/settings/flow.go
+++ b/selfservice/flow/settings/flow.go
@@ -50,6 +50,8 @@ type Flow struct {
 	ID uuid.UUID `json:"id" db:"id" faker:"-"`
 
 	// Type represents the flow's type which can be either "api" or "browser", depending on the flow interaction.
+	//
+	// required: true
 	Type flow.Type `json:"type" db:"type" faker:"flow_type"`
 
 	// ExpiresAt is the time (UTC) when the flow expires. If the user still wishes to update the setting,

--- a/selfservice/flow/settings/sort.go
+++ b/selfservice/flow/settings/sort.go
@@ -9,7 +9,7 @@ import (
 func sortNodes(ctx context.Context, n node.Nodes, schemaRef string) error {
 	return n.SortBySchema(ctx,
 		node.SortBySchema(schemaRef),
-		node.SortByGroups([]node.Group{
+		node.SortByGroups([]node.UiNodeGroup{
 			node.DefaultGroup,
 			node.ProfileGroup,
 			node.PasswordGroup,

--- a/selfservice/flow/settings/strategy.go
+++ b/selfservice/flow/settings/strategy.go
@@ -23,7 +23,7 @@ var pkgName = reflect.TypeOf(Strategies{}).PkgPath()
 
 type Strategy interface {
 	SettingsStrategyID() string
-	NodeGroup() node.Group
+	NodeGroup() node.UiNodeGroup
 	RegisterSettingsRoutes(*x.RouterPublic)
 	PopulateSettingsMethod(*http.Request, *identity.Identity, *Flow) error
 	Settings(w http.ResponseWriter, r *http.Request, f *Flow, s *session.Session) (*UpdateContext, error)

--- a/selfservice/flow/verification/error.go
+++ b/selfservice/flow/verification/error.go
@@ -51,7 +51,7 @@ func (s *ErrorHandler) WriteFlowError(
 	w http.ResponseWriter,
 	r *http.Request,
 	f *Flow,
-	group node.Group,
+	group node.UiNodeGroup,
 	err error,
 ) {
 	s.d.Audit().

--- a/selfservice/flow/verification/error_test.go
+++ b/selfservice/flow/verification/error_test.go
@@ -52,7 +52,7 @@ func TestHandleError(t *testing.T) {
 
 	var verificationFlow *verification.Flow
 	var flowError error
-	var methodName node.Group
+	var methodName node.UiNodeGroup
 	router.GET("/error", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		h.WriteFlowError(w, r, verificationFlow, methodName, flowError)
 	})

--- a/selfservice/flow/verification/error_test.go
+++ b/selfservice/flow/verification/error_test.go
@@ -195,7 +195,7 @@ func TestHandleError(t *testing.T) {
 
 			verificationFlow = &verification.Flow{Type: flow.TypeBrowser}
 			flowError = flow.NewFlowExpiredError(anHourAgo)
-			methodName = node.VerificationLinkGroup
+			methodName = node.LinkGroup
 
 			lf, _ := expectVerificationUI(t)
 			require.Len(t, lf.UI.Messages, 1, "%s", jsonx.TestMarshalJSONString(t, lf))
@@ -207,7 +207,7 @@ func TestHandleError(t *testing.T) {
 
 			verificationFlow = newFlow(t, time.Minute, flow.TypeBrowser)
 			flowError = schema.NewInvalidCredentialsError()
-			methodName = node.VerificationLinkGroup
+			methodName = node.LinkGroup
 
 			lf, _ := expectVerificationUI(t)
 			require.NotEmpty(t, lf.UI, x.MustEncodeJSON(t, lf))
@@ -220,7 +220,7 @@ func TestHandleError(t *testing.T) {
 
 			verificationFlow = newFlow(t, time.Minute, flow.TypeBrowser)
 			flowError = herodot.ErrInternalServerError.WithReason("system error")
-			methodName = node.VerificationLinkGroup
+			methodName = node.LinkGroup
 
 			sse, _ := expectErrorUI(t)
 			assertx.EqualAsJSON(t, flowError, sse)

--- a/selfservice/flow/verification/flow.go
+++ b/selfservice/flow/verification/flow.go
@@ -39,6 +39,7 @@ type Flow struct {
 	ID uuid.UUID `json:"id" db:"id" faker:"-"`
 
 	// Type represents the flow's type which can be either "api" or "browser", depending on the flow interaction.
+	//
 	// required: true
 	Type flow.Type `json:"type" db:"type" faker:"flow_type"`
 

--- a/selfservice/flow/verification/handler.go
+++ b/selfservice/flow/verification/handler.go
@@ -352,7 +352,7 @@ func (h *Handler) submitFlow(w http.ResponseWriter, r *http.Request, ps httprout
 		return
 	}
 
-	var g node.Group
+	var g node.UiNodeGroup
 	var found bool
 	for _, ss := range h.d.AllVerificationStrategies() {
 		err := ss.Verify(w, r, f)

--- a/selfservice/flow/verification/strategy.go
+++ b/selfservice/flow/verification/strategy.go
@@ -18,7 +18,7 @@ const (
 type (
 	Strategy interface {
 		VerificationStrategyID() string
-		VerificationNodeGroup() node.Group
+		VerificationNodeGroup() node.UiNodeGroup
 		PopulateVerificationMethod(*http.Request, *Flow) error
 		Verify(w http.ResponseWriter, r *http.Request, f *Flow) (err error)
 	}

--- a/selfservice/strategy/link/strategy.go
+++ b/selfservice/strategy/link/strategy.go
@@ -79,10 +79,10 @@ func NewStrategy(d strategyDependencies) *Strategy {
 	return &Strategy{d: d, dx: decoderx.NewHTTP()}
 }
 
-func (s *Strategy) RecoveryNodeGroup() node.Group {
+func (s *Strategy) RecoveryNodeGroup() node.UiNodeGroup {
 	return node.LinkGroup
 }
 
-func (s *Strategy) VerificationNodeGroup() node.Group {
+func (s *Strategy) VerificationNodeGroup() node.UiNodeGroup {
 	return node.LinkGroup
 }

--- a/selfservice/strategy/link/strategy.go
+++ b/selfservice/strategy/link/strategy.go
@@ -80,9 +80,9 @@ func NewStrategy(d strategyDependencies) *Strategy {
 }
 
 func (s *Strategy) RecoveryNodeGroup() node.Group {
-	return node.RecoveryLinkGroup
+	return node.LinkGroup
 }
 
 func (s *Strategy) VerificationNodeGroup() node.Group {
-	return node.VerificationLinkGroup
+	return node.LinkGroup
 }

--- a/selfservice/strategy/link/strategy_recovery.go
+++ b/selfservice/strategy/link/strategy_recovery.go
@@ -49,9 +49,9 @@ func (s *Strategy) PopulateRecoveryMethod(r *http.Request, f *recovery.Flow) err
 	f.UI.SetCSRF(s.d.GenerateCSRFToken(r))
 	f.UI.GetNodes().Upsert(
 		// v0.5: form.Field{Name: "email", Type: "email", Required: true},
-		node.NewInputField("email", nil, node.RecoveryLinkGroup, node.InputAttributeTypeEmail, node.WithRequiredInputAttribute).WithMetaLabel(text.NewInfoNodeInputEmail()),
+		node.NewInputField("email", nil, node.LinkGroup, node.InputAttributeTypeEmail, node.WithRequiredInputAttribute).WithMetaLabel(text.NewInfoNodeInputEmail()),
 	)
-	f.UI.GetNodes().Append(node.NewInputField("method", s.RecoveryStrategyID(), node.RecoveryLinkGroup, node.InputAttributeTypeSubmit).WithMetaLabel(text.NewInfoNodeLabelSubmit()))
+	f.UI.GetNodes().Append(node.NewInputField("method", s.RecoveryStrategyID(), node.LinkGroup, node.InputAttributeTypeSubmit).WithMetaLabel(text.NewInfoNodeLabelSubmit()))
 
 	return nil
 }
@@ -394,7 +394,7 @@ func (s *Strategy) retryRecoveryFlowWithError(w http.ResponseWriter, r *http.Req
 	if expired := new(flow.ExpiredError); errors.As(recErr, &expired) {
 		return s.retryRecoveryFlowWithMessage(w, r, ft, text.NewErrorValidationRecoveryFlowExpired(expired.Ago))
 	} else {
-		if err := req.UI.ParseError(node.RecoveryLinkGroup, recErr); err != nil {
+		if err := req.UI.ParseError(node.LinkGroup, recErr); err != nil {
 			return err
 		}
 	}
@@ -437,7 +437,7 @@ func (s *Strategy) recoveryHandleFormSubmission(w http.ResponseWriter, r *http.R
 	f.UI.SetCSRF(s.d.GenerateCSRFToken(r))
 	f.UI.GetNodes().Upsert(
 		// v0.5: form.Field{Name: "email", Type: "email", Required: true, Value: body.Body.Email}
-		node.NewInputField("email", body.Email, node.RecoveryLinkGroup, node.InputAttributeTypeEmail, node.WithRequiredInputAttribute),
+		node.NewInputField("email", body.Email, node.LinkGroup, node.InputAttributeTypeEmail, node.WithRequiredInputAttribute),
 	)
 
 	f.Active = sqlxx.NullString(s.RecoveryNodeGroup())
@@ -483,7 +483,7 @@ func (s *Strategy) HandleRecoveryError(w http.ResponseWriter, r *http.Request, r
 		req.UI.SetCSRF(s.d.GenerateCSRFToken(r))
 		req.UI.GetNodes().Upsert(
 			// v0.5: form.Field{Name: "email", Type: "email", Required: true, Value: body.Body.Email}
-			node.NewInputField("email", email, node.RecoveryLinkGroup, node.InputAttributeTypeEmail, node.WithRequiredInputAttribute),
+			node.NewInputField("email", email, node.LinkGroup, node.InputAttributeTypeEmail, node.WithRequiredInputAttribute),
 		)
 	}
 

--- a/selfservice/strategy/link/strategy_recovery_test.go
+++ b/selfservice/strategy/link/strategy_recovery_test.go
@@ -251,7 +251,7 @@ func TestRecovery(t *testing.T) {
 
 	t.Run("description=should require an email to be sent", func(t *testing.T) {
 		var check = func(t *testing.T, actual string) {
-			assert.EqualValues(t, node.RecoveryLinkGroup, gjson.Get(actual, "active").String(), "%s", actual)
+			assert.EqualValues(t, node.LinkGroup, gjson.Get(actual, "active").String(), "%s", actual)
 			assert.EqualValues(t, "Property email is missing.",
 				gjson.Get(actual, "ui.nodes.#(attributes.name==email).messages.0.text").String(),
 				"%s", actual)
@@ -276,7 +276,7 @@ func TestRecovery(t *testing.T) {
 
 	t.Run("description=should require a valid email to be sent", func(t *testing.T) {
 		var check = func(t *testing.T, actual string, value string) {
-			assert.EqualValues(t, node.RecoveryLinkGroup, gjson.Get(actual, "active").String(), "%s", actual)
+			assert.EqualValues(t, node.LinkGroup, gjson.Get(actual, "active").String(), "%s", actual)
 			assert.EqualValues(t, fmt.Sprintf("%q is not valid \"email\"", value),
 				gjson.Get(actual, "ui.nodes.#(attributes.name==email).messages.0.text").String(),
 				"%s", actual)
@@ -356,7 +356,7 @@ func TestRecovery(t *testing.T) {
 	t.Run("description=should try to recover an email that does not exist", func(t *testing.T) {
 		var email string
 		var check = func(t *testing.T, actual string) {
-			assert.EqualValues(t, node.RecoveryLinkGroup, gjson.Get(actual, "active").String(), "%s", actual)
+			assert.EqualValues(t, node.LinkGroup, gjson.Get(actual, "active").String(), "%s", actual)
 			assert.EqualValues(t, email, gjson.Get(actual, "ui.nodes.#(attributes.name==email).attributes.value").String(), "%s", actual)
 			assertx.EqualAsJSON(t, text.NewRecoveryEmailSent(), json.RawMessage(gjson.Get(actual, "ui.messages.0").Raw))
 
@@ -443,7 +443,7 @@ func TestRecovery(t *testing.T) {
 			assert.Nil(t, addr.VerifiedAt)
 			assert.Equal(t, identity.VerifiableAddressStatusPending, addr.Status)
 
-			assert.EqualValues(t, node.RecoveryLinkGroup, gjson.Get(recoverySubmissionResponse, "active").String(), "%s", recoverySubmissionResponse)
+			assert.EqualValues(t, node.LinkGroup, gjson.Get(recoverySubmissionResponse, "active").String(), "%s", recoverySubmissionResponse)
 			assert.EqualValues(t, recoveryEmail, gjson.Get(recoverySubmissionResponse, "ui.nodes.#(attributes.name==email).attributes.value").String(), "%s", recoverySubmissionResponse)
 			require.Len(t, gjson.Get(recoverySubmissionResponse, "ui.messages").Array(), 1, "%s", recoverySubmissionResponse)
 			assertx.EqualAsJSON(t, text.NewRecoveryEmailSent(), json.RawMessage(gjson.Get(recoverySubmissionResponse, "ui.messages.0").Raw))

--- a/selfservice/strategy/link/strategy_verification.go
+++ b/selfservice/strategy/link/strategy_verification.go
@@ -34,9 +34,9 @@ func (s *Strategy) PopulateVerificationMethod(r *http.Request, f *verification.F
 	f.UI.SetCSRF(s.d.GenerateCSRFToken(r))
 	f.UI.GetNodes().Upsert(
 		// v0.5: form.Field{Name: "email", Type: "email", Required: true}
-		node.NewInputField("email", nil, node.VerificationLinkGroup, node.InputAttributeTypeEmail, node.WithRequiredInputAttribute).WithMetaLabel(text.NewInfoNodeInputEmail()),
+		node.NewInputField("email", nil, node.LinkGroup, node.InputAttributeTypeEmail, node.WithRequiredInputAttribute).WithMetaLabel(text.NewInfoNodeInputEmail()),
 	)
-	f.UI.GetNodes().Append(node.NewInputField("method", s.VerificationStrategyID(), node.VerificationLinkGroup, node.InputAttributeTypeSubmit).WithMetaLabel(text.NewInfoNodeLabelSubmit()))
+	f.UI.GetNodes().Append(node.NewInputField("method", s.VerificationStrategyID(), node.LinkGroup, node.InputAttributeTypeSubmit).WithMetaLabel(text.NewInfoNodeLabelSubmit()))
 	return nil
 }
 
@@ -75,7 +75,7 @@ func (s *Strategy) handleVerificationError(w http.ResponseWriter, r *http.Reques
 		f.UI.SetCSRF(s.d.GenerateCSRFToken(r))
 		f.UI.GetNodes().Upsert(
 			// v0.5: form.Field{Name: "email", Type: "email", Required: true, Value: body.Body.Email}
-			node.NewInputField("email", body.Email, node.VerificationLinkGroup, node.InputAttributeTypeEmail, node.WithRequiredInputAttribute),
+			node.NewInputField("email", body.Email, node.LinkGroup, node.InputAttributeTypeEmail, node.WithRequiredInputAttribute),
 		)
 	}
 
@@ -166,7 +166,7 @@ func (s *Strategy) verificationHandleFormSubmission(w http.ResponseWriter, r *ht
 	f.UI.SetCSRF(s.d.GenerateCSRFToken(r))
 	f.UI.GetNodes().Upsert(
 		// v0.5: form.Field{Name: "email", Type: "email", Required: true, Value: body.Body.Email}
-		node.NewInputField("email", body.Email, node.VerificationLinkGroup, node.InputAttributeTypeEmail, node.WithRequiredInputAttribute),
+		node.NewInputField("email", body.Email, node.LinkGroup, node.InputAttributeTypeEmail, node.WithRequiredInputAttribute),
 	)
 
 	f.Active = sqlxx.NullString(s.VerificationNodeGroup())
@@ -305,7 +305,7 @@ func (s *Strategy) retryVerificationFlowWithError(w http.ResponseWriter, r *http
 	if expired := new(flow.ExpiredError); errors.As(verErr, &expired) {
 		return s.retryVerificationFlowWithMessage(w, r, ft, text.NewErrorValidationVerificationFlowExpired(expired.Ago))
 	} else {
-		if err := f.UI.ParseError(node.RecoveryLinkGroup, verErr); err != nil {
+		if err := f.UI.ParseError(node.LinkGroup, verErr); err != nil {
 			return err
 		}
 	}

--- a/selfservice/strategy/link/strategy_verification_test.go
+++ b/selfservice/strategy/link/strategy_verification_test.go
@@ -112,7 +112,7 @@ func TestVerification(t *testing.T) {
 
 	t.Run("description=should require an email to be sent", func(t *testing.T) {
 		var check = func(t *testing.T, actual string) {
-			assert.EqualValues(t, string(node.VerificationLinkGroup), gjson.Get(actual, "active").String(), "%s", actual)
+			assert.EqualValues(t, string(node.LinkGroup), gjson.Get(actual, "active").String(), "%s", actual)
 			assert.EqualValues(t, "Property email is missing.",
 				gjson.Get(actual, "ui.nodes.#(attributes.name==email).messages.0.text").String(),
 				"%s", actual)
@@ -137,7 +137,7 @@ func TestVerification(t *testing.T) {
 
 	t.Run("description=should require a valid email to be sent", func(t *testing.T) {
 		var check = func(t *testing.T, actual string, value string) {
-			assert.EqualValues(t, string(node.VerificationLinkGroup), gjson.Get(actual, "active").String(), "%s", actual)
+			assert.EqualValues(t, string(node.LinkGroup), gjson.Get(actual, "active").String(), "%s", actual)
 			assert.EqualValues(t, fmt.Sprintf("%q is not valid \"email\"", value),
 				gjson.Get(actual, "ui.nodes.#(attributes.name==email).messages.0.text").String(),
 				"%s", actual)
@@ -165,7 +165,7 @@ func TestVerification(t *testing.T) {
 	t.Run("description=should try to verify an email that does not exist", func(t *testing.T) {
 		var email string
 		var check = func(t *testing.T, actual string) {
-			assert.EqualValues(t, string(node.VerificationLinkGroup), gjson.Get(actual, "active").String(), "%s", actual)
+			assert.EqualValues(t, string(node.LinkGroup), gjson.Get(actual, "active").String(), "%s", actual)
 			assert.EqualValues(t, email, gjson.Get(actual, "ui.nodes.#(attributes.name==email).attributes.value").String(), "%s", actual)
 			assertx.EqualAsJSON(t, text.NewVerificationEmailSent(), json.RawMessage(gjson.Get(actual, "ui.messages.0").Raw))
 
@@ -260,7 +260,7 @@ func TestVerification(t *testing.T) {
 
 	t.Run("description=should verify an email address", func(t *testing.T) {
 		var check = func(t *testing.T, actual string) {
-			assert.EqualValues(t, string(node.VerificationLinkGroup), gjson.Get(actual, "active").String(), "%s", actual)
+			assert.EqualValues(t, string(node.LinkGroup), gjson.Get(actual, "active").String(), "%s", actual)
 			assert.EqualValues(t, verificationEmail, gjson.Get(actual, "ui.nodes.#(attributes.name==email).attributes.value").String(), "%s", actual)
 			assertx.EqualAsJSON(t, text.NewVerificationEmailSent(), json.RawMessage(gjson.Get(actual, "ui.messages.0").Raw))
 

--- a/selfservice/strategy/lookup/strategy.go
+++ b/selfservice/strategy/lookup/strategy.go
@@ -97,7 +97,7 @@ func (s *Strategy) ID() identity.CredentialsType {
 	return identity.CredentialsTypeLookup
 }
 
-func (s *Strategy) NodeGroup() node.Group {
+func (s *Strategy) NodeGroup() node.UiNodeGroup {
 	return node.LookupGroup
 }
 

--- a/selfservice/strategy/oidc/strategy.go
+++ b/selfservice/strategy/oidc/strategy.go
@@ -461,7 +461,7 @@ func (s *Strategy) handleError(w http.ResponseWriter, r *http.Request, f flow.Fl
 	return err
 }
 
-func (s *Strategy) NodeGroup() node.Group {
+func (s *Strategy) NodeGroup() node.UiNodeGroup {
 	return node.OpenIDConnectGroup
 }
 

--- a/selfservice/strategy/password/strategy.go
+++ b/selfservice/strategy/password/strategy.go
@@ -111,6 +111,6 @@ func (s *Strategy) CompletedAuthenticationMethod(ctx context.Context) session.Au
 	}
 }
 
-func (s *Strategy) NodeGroup() node.Group {
+func (s *Strategy) NodeGroup() node.UiNodeGroup {
 	return node.PasswordGroup
 }

--- a/selfservice/strategy/profile/strategy.go
+++ b/selfservice/strategy/profile/strategy.go
@@ -276,6 +276,6 @@ func (s *Strategy) newSettingsProfileDecoder(ctx context.Context, i *identity.Id
 	return o, nil
 }
 
-func (s *Strategy) NodeGroup() node.Group {
+func (s *Strategy) NodeGroup() node.UiNodeGroup {
 	return node.ProfileGroup
 }

--- a/selfservice/strategy/totp/strategy.go
+++ b/selfservice/strategy/totp/strategy.go
@@ -100,7 +100,7 @@ func (s *Strategy) ID() identity.CredentialsType {
 	return identity.CredentialsTypeTOTP
 }
 
-func (s *Strategy) NodeGroup() node.Group {
+func (s *Strategy) NodeGroup() node.UiNodeGroup {
 	return node.TOTPGroup
 }
 

--- a/selfservice/strategy/webauthn/strategy.go
+++ b/selfservice/strategy/webauthn/strategy.go
@@ -107,7 +107,7 @@ func (s *Strategy) ID() identity.CredentialsType {
 	return identity.CredentialsTypeWebAuthn
 }
 
-func (s *Strategy) NodeGroup() node.Group {
+func (s *Strategy) NodeGroup() node.UiNodeGroup {
 	return node.WebAuthnGroup
 }
 

--- a/spec/api.json
+++ b/spec/api.json
@@ -1832,7 +1832,7 @@
             "$ref": "#/components/schemas/uiNodeMeta"
           },
           "type": {
-            "description": "The node's type\n\nCan be one of: text, input, img, a"
+            "description": "The node's type\n\nCan be one of: text, input, img, a, script"
           }
         },
         "required": [

--- a/spec/api.json
+++ b/spec/api.json
@@ -1832,7 +1832,7 @@
             "$ref": "#/components/schemas/uiNodeMeta"
           },
           "type": {
-            "$ref": "#/components/schemas/uiNodeType"
+            "description": "The node's type\n\nCan be one of: text, input, img, a"
           }
         },
         "required": [
@@ -1856,7 +1856,7 @@
             "type": "string"
           },
           "node_type": {
-            "$ref": "#/components/schemas/uiNodeType"
+            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
           },
           "title": {
             "$ref": "#/components/schemas/uiText"
@@ -1916,7 +1916,7 @@
             "type": "string"
           },
           "node_type": {
-            "$ref": "#/components/schemas/uiNodeType"
+            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
           },
           "src": {
             "description": "The image's source URL.\n\nformat: uri",
@@ -1956,7 +1956,7 @@
             "type": "string"
           },
           "node_type": {
-            "$ref": "#/components/schemas/uiNodeType"
+            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
           },
           "onclick": {
             "description": "OnClick may contain javascript which should be executed on click. This is primarily\nused for WebAuthn.",
@@ -2015,7 +2015,7 @@
             "type": "string"
           },
           "node_type": {
-            "$ref": "#/components/schemas/uiNodeType"
+            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
           },
           "nonce": {
             "description": "Nonce for CSP\n\nA nonce you may want to use to improve your Content Security Policy.\nYou do not have to use this value but if you want to improve your CSP\npolicies you may use it. You can also choose to use your own nonce value!",
@@ -2055,7 +2055,7 @@
             "type": "string"
           },
           "node_type": {
-            "$ref": "#/components/schemas/uiNodeType"
+            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
           },
           "text": {
             "$ref": "#/components/schemas/uiText"
@@ -2068,9 +2068,6 @@
         ],
         "title": "TextAttributes represents the attributes of a text node.",
         "type": "object"
-      },
-      "uiNodeType": {
-        "type": "string"
       },
       "uiNodes": {
         "items": {

--- a/spec/api.json
+++ b/spec/api.json
@@ -1846,7 +1846,7 @@
             "$ref": "#/components/schemas/uiNodeMeta"
           },
           "type": {
-            "description": "The node's type\n\nCan be one of: text, input, img, a, script",
+            "description": "The node's type",
             "enum": [
               "text",
               "input",

--- a/spec/api.json
+++ b/spec/api.json
@@ -1901,8 +1901,8 @@
       "uiNodeAttributes": {
         "discriminator": {
           "mapping": {
-            "anchor": "#/components/schemas/uiNodeAnchorAttributes",
-            "image": "#/components/schemas/uiNodeImageAttributes",
+            "a": "#/components/schemas/uiNodeAnchorAttributes",
+            "img": "#/components/schemas/uiNodeImageAttributes",
             "input": "#/components/schemas/uiNodeInputAttributes",
             "script": "#/components/schemas/uiNodeScriptAttributes",
             "text": "#/components/schemas/uiNodeTextAttributes"

--- a/spec/api.json
+++ b/spec/api.json
@@ -1823,7 +1823,18 @@
             "$ref": "#/components/schemas/uiNodeAttributes"
           },
           "group": {
-            "$ref": "#/components/schemas/uiNodeGroup"
+            "description": "Group specifies which group (e.g. password authenticator) this node belongs to.",
+            "enum": [
+              "default",
+              "password",
+              "oidc",
+              "profile",
+              "link",
+              "totp",
+              "lookup_secret",
+              "webauthn"
+            ],
+            "type": "string"
           },
           "messages": {
             "$ref": "#/components/schemas/uiTexts"
@@ -1832,7 +1843,15 @@
             "$ref": "#/components/schemas/uiNodeMeta"
           },
           "type": {
-            "description": "The node's type\n\nCan be one of: text, input, img, a, script"
+            "description": "The node's type\n\nCan be one of: text, input, img, a, script",
+            "enum": [
+              "text",
+              "input",
+              "img",
+              "a",
+              "script"
+            ],
+            "type": "string"
           }
         },
         "required": [
@@ -1856,7 +1875,15 @@
             "type": "string"
           },
           "node_type": {
-            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
+            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0.",
+            "enum": [
+              "text",
+              "input",
+              "img",
+              "a",
+              "script"
+            ],
+            "type": "string"
           },
           "title": {
             "$ref": "#/components/schemas/uiText"
@@ -1901,9 +1928,6 @@
         ],
         "title": "Attributes represents a list of attributes (e.g. `href=\"foo\"` for links)."
       },
-      "uiNodeGroup": {
-        "type": "string"
-      },
       "uiNodeImageAttributes": {
         "properties": {
           "height": {
@@ -1916,7 +1940,15 @@
             "type": "string"
           },
           "node_type": {
-            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
+            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0.",
+            "enum": [
+              "text",
+              "input",
+              "img",
+              "a",
+              "script"
+            ],
+            "type": "string"
           },
           "src": {
             "description": "The image's source URL.\n\nformat: uri",
@@ -1956,7 +1988,15 @@
             "type": "string"
           },
           "node_type": {
-            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
+            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0.",
+            "enum": [
+              "text",
+              "input",
+              "img",
+              "a",
+              "script"
+            ],
+            "type": "string"
           },
           "onclick": {
             "description": "OnClick may contain javascript which should be executed on click. This is primarily\nused for WebAuthn.",
@@ -2015,7 +2055,15 @@
             "type": "string"
           },
           "node_type": {
-            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
+            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0.",
+            "enum": [
+              "text",
+              "input",
+              "img",
+              "a",
+              "script"
+            ],
+            "type": "string"
           },
           "nonce": {
             "description": "Nonce for CSP\n\nA nonce you may want to use to improve your Content Security Policy.\nYou do not have to use this value but if you want to improve your CSP\npolicies you may use it. You can also choose to use your own nonce value!",
@@ -2055,7 +2103,15 @@
             "type": "string"
           },
           "node_type": {
-            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
+            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0.",
+            "enum": [
+              "text",
+              "input",
+              "img",
+              "a",
+              "script"
+            ],
+            "type": "string"
           },
           "text": {
             "$ref": "#/components/schemas/uiText"

--- a/spec/api.json
+++ b/spec/api.json
@@ -1846,7 +1846,15 @@
             "$ref": "#/components/schemas/uiNodeMeta"
           },
           "type": {
-            "description": "The node's type"
+            "description": "The node's type",
+            "enum": [
+              "text",
+              "input",
+              "img",
+              "a",
+              "script"
+            ],
+            "type": "string"
           }
         },
         "required": [
@@ -1870,7 +1878,15 @@
             "type": "string"
           },
           "node_type": {
-            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
+            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0.",
+            "enum": [
+              "text",
+              "input",
+              "img",
+              "a",
+              "script"
+            ],
+            "type": "string"
           },
           "title": {
             "$ref": "#/components/schemas/uiText"
@@ -1927,7 +1943,15 @@
             "type": "string"
           },
           "node_type": {
-            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
+            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0.",
+            "enum": [
+              "text",
+              "input",
+              "img",
+              "a",
+              "script"
+            ],
+            "type": "string"
           },
           "src": {
             "description": "The image's source URL.\n\nformat: uri",
@@ -1967,7 +1991,15 @@
             "type": "string"
           },
           "node_type": {
-            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
+            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0.",
+            "enum": [
+              "text",
+              "input",
+              "img",
+              "a",
+              "script"
+            ],
+            "type": "string"
           },
           "onclick": {
             "description": "OnClick may contain javascript which should be executed on click. This is primarily\nused for WebAuthn.",
@@ -2026,7 +2058,15 @@
             "type": "string"
           },
           "node_type": {
-            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
+            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0.",
+            "enum": [
+              "text",
+              "input",
+              "img",
+              "a",
+              "script"
+            ],
+            "type": "string"
           },
           "nonce": {
             "description": "Nonce for CSP\n\nA nonce you may want to use to improve your Content Security Policy.\nYou do not have to use this value but if you want to improve your CSP\npolicies you may use it. You can also choose to use your own nonce value!",
@@ -2066,7 +2106,15 @@
             "type": "string"
           },
           "node_type": {
-            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
+            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0.",
+            "enum": [
+              "text",
+              "input",
+              "img",
+              "a",
+              "script"
+            ],
+            "type": "string"
           },
           "text": {
             "$ref": "#/components/schemas/uiText"

--- a/spec/api.json
+++ b/spec/api.json
@@ -897,6 +897,7 @@
         },
         "required": [
           "id",
+          "type",
           "expires_at",
           "issued_at",
           "request_url",
@@ -968,6 +969,7 @@
         },
         "required": [
           "id",
+          "type",
           "expires_at",
           "issued_at",
           "request_url",
@@ -1018,6 +1020,7 @@
         },
         "required": [
           "id",
+          "type",
           "expires_at",
           "issued_at",
           "request_url",

--- a/spec/api.json
+++ b/spec/api.json
@@ -1846,15 +1846,7 @@
             "$ref": "#/components/schemas/uiNodeMeta"
           },
           "type": {
-            "description": "The node's type",
-            "enum": [
-              "text",
-              "input",
-              "img",
-              "a",
-              "script"
-            ],
-            "type": "string"
+            "description": "The node's type"
           }
         },
         "required": [
@@ -1878,15 +1870,7 @@
             "type": "string"
           },
           "node_type": {
-            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0.",
-            "enum": [
-              "text",
-              "input",
-              "img",
-              "a",
-              "script"
-            ],
-            "type": "string"
+            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
           },
           "title": {
             "$ref": "#/components/schemas/uiText"
@@ -1943,15 +1927,7 @@
             "type": "string"
           },
           "node_type": {
-            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0.",
-            "enum": [
-              "text",
-              "input",
-              "img",
-              "a",
-              "script"
-            ],
-            "type": "string"
+            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
           },
           "src": {
             "description": "The image's source URL.\n\nformat: uri",
@@ -1991,15 +1967,7 @@
             "type": "string"
           },
           "node_type": {
-            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0.",
-            "enum": [
-              "text",
-              "input",
-              "img",
-              "a",
-              "script"
-            ],
-            "type": "string"
+            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
           },
           "onclick": {
             "description": "OnClick may contain javascript which should be executed on click. This is primarily\nused for WebAuthn.",
@@ -2058,15 +2026,7 @@
             "type": "string"
           },
           "node_type": {
-            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0.",
-            "enum": [
-              "text",
-              "input",
-              "img",
-              "a",
-              "script"
-            ],
-            "type": "string"
+            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
           },
           "nonce": {
             "description": "Nonce for CSP\n\nA nonce you may want to use to improve your Content Security Policy.\nYou do not have to use this value but if you want to improve your CSP\npolicies you may use it. You can also choose to use your own nonce value!",
@@ -2106,15 +2066,7 @@
             "type": "string"
           },
           "node_type": {
-            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0.",
-            "enum": [
-              "text",
-              "input",
-              "img",
-              "a",
-              "script"
-            ],
-            "type": "string"
+            "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
           },
           "text": {
             "$ref": "#/components/schemas/uiText"

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -4054,7 +4054,7 @@
           "$ref": "#/definitions/uiNodeMeta"
         },
         "type": {
-          "description": "The node's type\n\nCan be one of: text, input, img, a, script",
+          "description": "The node's type",
           "type": "string",
           "enum": [
             "text",

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -4031,7 +4031,18 @@
           "$ref": "#/definitions/uiNodeAttributes"
         },
         "group": {
-          "$ref": "#/definitions/uiNodeGroup"
+          "description": "Group specifies which group (e.g. password authenticator) this node belongs to.",
+          "type": "string",
+          "enum": [
+            "default",
+            "password",
+            "oidc",
+            "profile",
+            "link",
+            "totp",
+            "lookup_secret",
+            "webauthn"
+          ]
         },
         "messages": {
           "$ref": "#/definitions/uiTexts"
@@ -4040,7 +4051,15 @@
           "$ref": "#/definitions/uiNodeMeta"
         },
         "type": {
-          "description": "The node's type\n\nCan be one of: text, input, img, a, script"
+          "description": "The node's type\n\nCan be one of: text, input, img, a, script",
+          "type": "string",
+          "enum": [
+            "text",
+            "input",
+            "img",
+            "a",
+            "script"
+          ]
         }
       }
     },
@@ -4063,7 +4082,15 @@
           "type": "string"
         },
         "node_type": {
-          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
+          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0.",
+          "type": "string",
+          "enum": [
+            "text",
+            "input",
+            "img",
+            "a",
+            "script"
+          ]
         },
         "title": {
           "$ref": "#/definitions/uiText"
@@ -4073,9 +4100,6 @@
     "uiNodeAttributes": {
       "type": "object",
       "title": "Attributes represents a list of attributes (e.g. `href=\"foo\"` for links)."
-    },
-    "uiNodeGroup": {
-      "type": "string"
     },
     "uiNodeImageAttributes": {
       "type": "object",
@@ -4098,7 +4122,15 @@
           "type": "string"
         },
         "node_type": {
-          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
+          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0.",
+          "type": "string",
+          "enum": [
+            "text",
+            "input",
+            "img",
+            "a",
+            "script"
+          ]
         },
         "src": {
           "description": "The image's source URL.\n\nformat: uri",
@@ -4136,7 +4168,15 @@
           "type": "string"
         },
         "node_type": {
-          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
+          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0.",
+          "type": "string",
+          "enum": [
+            "text",
+            "input",
+            "img",
+            "a",
+            "script"
+          ]
         },
         "onclick": {
           "description": "OnClick may contain javascript which should be executed on click. This is primarily\nused for WebAuthn.",
@@ -4201,7 +4241,15 @@
           "type": "string"
         },
         "node_type": {
-          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
+          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0.",
+          "type": "string",
+          "enum": [
+            "text",
+            "input",
+            "img",
+            "a",
+            "script"
+          ]
         },
         "nonce": {
           "description": "Nonce for CSP\n\nA nonce you may want to use to improve your Content Security Policy.\nYou do not have to use this value but if you want to improve your CSP\npolicies you may use it. You can also choose to use your own nonce value!",
@@ -4235,7 +4283,15 @@
           "type": "string"
         },
         "node_type": {
-          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
+          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0.",
+          "type": "string",
+          "enum": [
+            "text",
+            "input",
+            "img",
+            "a",
+            "script"
+          ]
         },
         "text": {
           "$ref": "#/definitions/uiText"

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -4054,15 +4054,7 @@
           "$ref": "#/definitions/uiNodeMeta"
         },
         "type": {
-          "description": "The node's type",
-          "type": "string",
-          "enum": [
-            "text",
-            "input",
-            "img",
-            "a",
-            "script"
-          ]
+          "description": "The node's type"
         }
       }
     },
@@ -4085,15 +4077,7 @@
           "type": "string"
         },
         "node_type": {
-          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0.",
-          "type": "string",
-          "enum": [
-            "text",
-            "input",
-            "img",
-            "a",
-            "script"
-          ]
+          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
         },
         "title": {
           "$ref": "#/definitions/uiText"
@@ -4125,15 +4109,7 @@
           "type": "string"
         },
         "node_type": {
-          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0.",
-          "type": "string",
-          "enum": [
-            "text",
-            "input",
-            "img",
-            "a",
-            "script"
-          ]
+          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
         },
         "src": {
           "description": "The image's source URL.\n\nformat: uri",
@@ -4171,15 +4147,7 @@
           "type": "string"
         },
         "node_type": {
-          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0.",
-          "type": "string",
-          "enum": [
-            "text",
-            "input",
-            "img",
-            "a",
-            "script"
-          ]
+          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
         },
         "onclick": {
           "description": "OnClick may contain javascript which should be executed on click. This is primarily\nused for WebAuthn.",
@@ -4244,15 +4212,7 @@
           "type": "string"
         },
         "node_type": {
-          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0.",
-          "type": "string",
-          "enum": [
-            "text",
-            "input",
-            "img",
-            "a",
-            "script"
-          ]
+          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
         },
         "nonce": {
           "description": "Nonce for CSP\n\nA nonce you may want to use to improve your Content Security Policy.\nYou do not have to use this value but if you want to improve your CSP\npolicies you may use it. You can also choose to use your own nonce value!",
@@ -4286,15 +4246,7 @@
           "type": "string"
         },
         "node_type": {
-          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0.",
-          "type": "string",
-          "enum": [
-            "text",
-            "input",
-            "img",
-            "a",
-            "script"
-          ]
+          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
         },
         "text": {
           "$ref": "#/definitions/uiText"

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -4040,7 +4040,7 @@
           "$ref": "#/definitions/uiNodeMeta"
         },
         "type": {
-          "$ref": "#/definitions/uiNodeType"
+          "description": "The node's type\n\nCan be one of: text, input, img, a"
         }
       }
     },
@@ -4063,7 +4063,7 @@
           "type": "string"
         },
         "node_type": {
-          "$ref": "#/definitions/uiNodeType"
+          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
         },
         "title": {
           "$ref": "#/definitions/uiText"
@@ -4098,7 +4098,7 @@
           "type": "string"
         },
         "node_type": {
-          "$ref": "#/definitions/uiNodeType"
+          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
         },
         "src": {
           "description": "The image's source URL.\n\nformat: uri",
@@ -4136,7 +4136,7 @@
           "type": "string"
         },
         "node_type": {
-          "$ref": "#/definitions/uiNodeType"
+          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
         },
         "onclick": {
           "description": "OnClick may contain javascript which should be executed on click. This is primarily\nused for WebAuthn.",
@@ -4201,7 +4201,7 @@
           "type": "string"
         },
         "node_type": {
-          "$ref": "#/definitions/uiNodeType"
+          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
         },
         "nonce": {
           "description": "Nonce for CSP\n\nA nonce you may want to use to improve your Content Security Policy.\nYou do not have to use this value but if you want to improve your CSP\npolicies you may use it. You can also choose to use your own nonce value!",
@@ -4235,15 +4235,12 @@
           "type": "string"
         },
         "node_type": {
-          "$ref": "#/definitions/uiNodeType"
+          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
         },
         "text": {
           "$ref": "#/definitions/uiText"
         }
       }
-    },
-    "uiNodeType": {
-      "type": "string"
     },
     "uiNodes": {
       "type": "array",

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -4040,7 +4040,7 @@
           "$ref": "#/definitions/uiNodeMeta"
         },
         "type": {
-          "description": "The node's type\n\nCan be one of: text, input, img, a"
+          "description": "The node's type\n\nCan be one of: text, input, img, a, script"
         }
       }
     },

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -4054,7 +4054,15 @@
           "$ref": "#/definitions/uiNodeMeta"
         },
         "type": {
-          "description": "The node's type"
+          "description": "The node's type",
+          "type": "string",
+          "enum": [
+            "text",
+            "input",
+            "img",
+            "a",
+            "script"
+          ]
         }
       }
     },
@@ -4077,7 +4085,15 @@
           "type": "string"
         },
         "node_type": {
-          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
+          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0.",
+          "type": "string",
+          "enum": [
+            "text",
+            "input",
+            "img",
+            "a",
+            "script"
+          ]
         },
         "title": {
           "$ref": "#/definitions/uiText"
@@ -4109,7 +4125,15 @@
           "type": "string"
         },
         "node_type": {
-          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
+          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0.",
+          "type": "string",
+          "enum": [
+            "text",
+            "input",
+            "img",
+            "a",
+            "script"
+          ]
         },
         "src": {
           "description": "The image's source URL.\n\nformat: uri",
@@ -4147,7 +4171,15 @@
           "type": "string"
         },
         "node_type": {
-          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
+          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0.",
+          "type": "string",
+          "enum": [
+            "text",
+            "input",
+            "img",
+            "a",
+            "script"
+          ]
         },
         "onclick": {
           "description": "OnClick may contain javascript which should be executed on click. This is primarily\nused for WebAuthn.",
@@ -4212,7 +4244,15 @@
           "type": "string"
         },
         "node_type": {
-          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
+          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0.",
+          "type": "string",
+          "enum": [
+            "text",
+            "input",
+            "img",
+            "a",
+            "script"
+          ]
         },
         "nonce": {
           "description": "Nonce for CSP\n\nA nonce you may want to use to improve your Content Security Policy.\nYou do not have to use this value but if you want to improve your CSP\npolicies you may use it. You can also choose to use your own nonce value!",
@@ -4246,7 +4286,15 @@
           "type": "string"
         },
         "node_type": {
-          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0."
+          "description": "NodeType represents this node's types. It is a mirror of `node.type` and\nis primarily used to allow compatibility with OpenAPI 3.0.",
+          "type": "string",
+          "enum": [
+            "text",
+            "input",
+            "img",
+            "a",
+            "script"
+          ]
         },
         "text": {
           "$ref": "#/definitions/uiText"

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -3183,6 +3183,7 @@
       "title": "A Recovery Flow",
       "required": [
         "id",
+        "type",
         "expires_at",
         "issued_at",
         "request_url",
@@ -3252,6 +3253,7 @@
       "type": "object",
       "required": [
         "id",
+        "type",
         "expires_at",
         "issued_at",
         "request_url",
@@ -3296,6 +3298,7 @@
       "title": "Flow represents a Settings Flow",
       "required": [
         "id",
+        "type",
         "expires_at",
         "issued_at",
         "request_url",

--- a/ui/container/container.go
+++ b/ui/container/container.go
@@ -68,7 +68,7 @@ func New(action string) *Container {
 
 // NewFromHTTPRequest creates a new Container and populates fields by parsing the HTTP Request body.
 // A jsonSchemaRef needs to be added to allow HTTP Form Post Body parsing.
-func NewFromHTTPRequest(r *http.Request, group node.Group, action string, compiler decoderx.HTTPDecoderOption) (*Container, error) {
+func NewFromHTTPRequest(r *http.Request, group node.UiNodeGroup, action string, compiler decoderx.HTTPDecoderOption) (*Container, error) {
 	c := New(action)
 	raw := json.RawMessage(`{}`)
 	if err := decoder.Decode(r, &raw, compiler); err != nil {
@@ -82,7 +82,7 @@ func NewFromHTTPRequest(r *http.Request, group node.Group, action string, compil
 }
 
 // NewFromJSON creates a UI Container based on the provided JSON struct.
-func NewFromJSON(action string, group node.Group, raw json.RawMessage, prefix string) *Container {
+func NewFromJSON(action string, group node.UiNodeGroup, raw json.RawMessage, prefix string) *Container {
 	c := New(action)
 	c.UpdateNodeValuesFromJSON(raw, prefix, group)
 	return c
@@ -90,7 +90,7 @@ func NewFromJSON(action string, group node.Group, raw json.RawMessage, prefix st
 
 // NewFromJSONSchema creates a new Container and populates the fields
 // using the provided JSON Schema.
-func NewFromJSONSchema(ctx context.Context, action string, group node.Group, jsonSchemaRef, prefix string, compiler *jsonschema.Compiler) (*Container, error) {
+func NewFromJSONSchema(ctx context.Context, action string, group node.UiNodeGroup, jsonSchemaRef, prefix string, compiler *jsonschema.Compiler) (*Container, error) {
 	c := New(action)
 	nodes, err := NodesFromJSONSchema(ctx, group, jsonSchemaRef, prefix, compiler)
 	if err != nil {
@@ -101,7 +101,7 @@ func NewFromJSONSchema(ctx context.Context, action string, group node.Group, jso
 	return c, nil
 }
 
-func NodesFromJSONSchema(ctx context.Context, group node.Group, jsonSchemaRef, prefix string, compiler *jsonschema.Compiler) (node.Nodes, error) {
+func NodesFromJSONSchema(ctx context.Context, group node.UiNodeGroup, jsonSchemaRef, prefix string, compiler *jsonschema.Compiler) (node.Nodes, error) {
 	paths, err := jsonschemax.ListPaths(ctx, jsonSchemaRef, compiler)
 	if err != nil {
 		return nil, err
@@ -150,7 +150,7 @@ func (c *Container) Reset(exclude ...string) {
 // formUI Container, the error is returned.
 //
 // This method DOES NOT touch the values of the node values/names, only its errors.
-func (c *Container) ParseError(group node.Group, err error) error {
+func (c *Container) ParseError(group node.UiNodeGroup, err error) error {
 	if e := richError(nil); errors.As(err, &e) {
 		if e.StatusCode() == http.StatusBadRequest {
 			c.AddMessage(group, text.NewValidationErrorGeneric(e.Reason()))
@@ -195,7 +195,7 @@ func (c *Container) ParseError(group node.Group, err error) error {
 }
 
 // UpdateNodeValuesFromJSON sets the container's fields to the provided values.
-func (c *Container) UpdateNodeValuesFromJSON(raw json.RawMessage, prefix string, group node.Group) {
+func (c *Container) UpdateNodeValuesFromJSON(raw json.RawMessage, prefix string, group node.UiNodeGroup) {
 	for k, v := range jsonx.Flatten(raw) {
 		k = addPrefix(k, prefix, ".")
 
@@ -236,7 +236,7 @@ func (c *Container) SetValue(id string, n *node.Node) {
 
 // AddMessage adds the provided error, and if a non-empty names list is set,
 // adds the error on the corresponding field.
-func (c *Container) AddMessage(group node.Group, err *text.Message, setForFields ...string) {
+func (c *Container) AddMessage(group node.UiNodeGroup, err *text.Message, setForFields ...string) {
 	if len(stringslice.TrimSpaceEmptyFilter(setForFields)) == 0 {
 		c.Messages = append(c.Messages, *err)
 		return

--- a/ui/container/types.go
+++ b/ui/container/types.go
@@ -9,7 +9,7 @@ type ErrorParser interface {
 	// ParseError type asserts the given error and sets the forms's errors or a
 	// field's errors and if the error is not something to be handled by the
 	// formUI Container itself, the error is returned for further propagation (e.g. showing a 502 status code).
-	ParseError(group node.Group, err error) error
+	ParseError(group node.UiNodeGroup, err error) error
 }
 
 type NodeSetter interface {

--- a/ui/node/attributes.go
+++ b/ui/node/attributes.go
@@ -36,7 +36,7 @@ type Attributes interface {
 	GetValue() interface{}
 
 	// swagger:ignore
-	GetNodeType() Type
+	GetNodeType() UiNodeType
 }
 
 // InputAttributes represents the attributes of an input node
@@ -78,7 +78,7 @@ type InputAttributes struct {
 	// is primarily used to allow compatibility with OpenAPI 3.0.
 	//
 	// required: true
-	NodeType Type `json:"node_type"`
+	NodeType UiNodeType `json:"node_type"`
 }
 
 // ImageAttributes represents the attributes of an image node.
@@ -110,7 +110,7 @@ type ImageAttributes struct {
 	// is primarily used to allow compatibility with OpenAPI 3.0.
 	//
 	// required: true
-	NodeType Type `json:"node_type"`
+	NodeType UiNodeType `json:"node_type"`
 }
 
 // AnchorAttributes represents the attributes of an anchor node.
@@ -137,7 +137,7 @@ type AnchorAttributes struct {
 	// is primarily used to allow compatibility with OpenAPI 3.0.
 	//
 	// required: true
-	NodeType Type `json:"node_type"`
+	NodeType UiNodeType `json:"node_type"`
 }
 
 // TextAttributes represents the attributes of a text node.
@@ -159,7 +159,7 @@ type TextAttributes struct {
 	// is primarily used to allow compatibility with OpenAPI 3.0.
 	//
 	// required: true
-	NodeType Type `json:"node_type"`
+	NodeType UiNodeType `json:"node_type"`
 }
 
 // ScriptAttributes represent script nodes which load javascript.
@@ -214,7 +214,7 @@ type ScriptAttributes struct {
 	// is primarily used to allow compatibility with OpenAPI 3.0.
 	//
 	// required: true
-	NodeType Type `json:"node_type"`
+	NodeType UiNodeType `json:"node_type"`
 }
 
 var (
@@ -301,22 +301,22 @@ func (a *TextAttributes) Reset() {
 func (a *ScriptAttributes) Reset() {
 }
 
-func (a *InputAttributes) GetNodeType() Type {
+func (a *InputAttributes) GetNodeType() UiNodeType {
 	return a.NodeType
 }
 
-func (a *ImageAttributes) GetNodeType() Type {
+func (a *ImageAttributes) GetNodeType() UiNodeType {
 	return a.NodeType
 }
 
-func (a *AnchorAttributes) GetNodeType() Type {
+func (a *AnchorAttributes) GetNodeType() UiNodeType {
 	return a.NodeType
 }
 
-func (a *TextAttributes) GetNodeType() Type {
+func (a *TextAttributes) GetNodeType() UiNodeType {
 	return a.NodeType
 }
 
-func (a *ScriptAttributes) GetNodeType() Type {
+func (a *ScriptAttributes) GetNodeType() UiNodeType {
 	return a.NodeType
 }

--- a/ui/node/attributes.go
+++ b/ui/node/attributes.go
@@ -36,7 +36,7 @@ type Attributes interface {
 	GetValue() interface{}
 
 	// swagger:ignore
-	GetNodeType() Type
+	GetNodeType() NodeType
 }
 
 // InputAttributes represents the attributes of an input node
@@ -78,7 +78,7 @@ type InputAttributes struct {
 	// is primarily used to allow compatibility with OpenAPI 3.0.
 	//
 	// required: true
-	NodeType Type `json:"node_type"`
+	NodeType NodeType `json:"node_type"`
 }
 
 // ImageAttributes represents the attributes of an image node.
@@ -110,7 +110,7 @@ type ImageAttributes struct {
 	// is primarily used to allow compatibility with OpenAPI 3.0.
 	//
 	// required: true
-	NodeType Type `json:"node_type"`
+	NodeType NodeType `json:"node_type"`
 }
 
 // AnchorAttributes represents the attributes of an anchor node.
@@ -137,7 +137,7 @@ type AnchorAttributes struct {
 	// is primarily used to allow compatibility with OpenAPI 3.0.
 	//
 	// required: true
-	NodeType Type `json:"node_type"`
+	NodeType NodeType `json:"node_type"`
 }
 
 // TextAttributes represents the attributes of a text node.
@@ -159,7 +159,7 @@ type TextAttributes struct {
 	// is primarily used to allow compatibility with OpenAPI 3.0.
 	//
 	// required: true
-	NodeType Type `json:"node_type"`
+	NodeType NodeType `json:"node_type"`
 }
 
 // ScriptAttributes represent script nodes which load javascript.
@@ -214,7 +214,7 @@ type ScriptAttributes struct {
 	// is primarily used to allow compatibility with OpenAPI 3.0.
 	//
 	// required: true
-	NodeType Type `json:"node_type"`
+	NodeType NodeType `json:"node_type"`
 }
 
 var (
@@ -301,22 +301,22 @@ func (a *TextAttributes) Reset() {
 func (a *ScriptAttributes) Reset() {
 }
 
-func (a *InputAttributes) GetNodeType() Type {
+func (a *InputAttributes) GetNodeType() NodeType {
 	return a.NodeType
 }
 
-func (a *ImageAttributes) GetNodeType() Type {
+func (a *ImageAttributes) GetNodeType() NodeType {
 	return a.NodeType
 }
 
-func (a *AnchorAttributes) GetNodeType() Type {
+func (a *AnchorAttributes) GetNodeType() NodeType {
 	return a.NodeType
 }
 
-func (a *TextAttributes) GetNodeType() Type {
+func (a *TextAttributes) GetNodeType() NodeType {
 	return a.NodeType
 }
 
-func (a *ScriptAttributes) GetNodeType() Type {
+func (a *ScriptAttributes) GetNodeType() NodeType {
 	return a.NodeType
 }

--- a/ui/node/attributes.go
+++ b/ui/node/attributes.go
@@ -36,7 +36,7 @@ type Attributes interface {
 	GetValue() interface{}
 
 	// swagger:ignore
-	GetNodeType() NodeType
+	GetNodeType() Type
 }
 
 // InputAttributes represents the attributes of an input node
@@ -78,7 +78,7 @@ type InputAttributes struct {
 	// is primarily used to allow compatibility with OpenAPI 3.0.
 	//
 	// required: true
-	NodeType NodeType `json:"node_type"`
+	NodeType Type `json:"node_type"`
 }
 
 // ImageAttributes represents the attributes of an image node.
@@ -110,7 +110,7 @@ type ImageAttributes struct {
 	// is primarily used to allow compatibility with OpenAPI 3.0.
 	//
 	// required: true
-	NodeType NodeType `json:"node_type"`
+	NodeType Type `json:"node_type"`
 }
 
 // AnchorAttributes represents the attributes of an anchor node.
@@ -137,7 +137,7 @@ type AnchorAttributes struct {
 	// is primarily used to allow compatibility with OpenAPI 3.0.
 	//
 	// required: true
-	NodeType NodeType `json:"node_type"`
+	NodeType Type `json:"node_type"`
 }
 
 // TextAttributes represents the attributes of a text node.
@@ -159,7 +159,7 @@ type TextAttributes struct {
 	// is primarily used to allow compatibility with OpenAPI 3.0.
 	//
 	// required: true
-	NodeType NodeType `json:"node_type"`
+	NodeType Type `json:"node_type"`
 }
 
 // ScriptAttributes represent script nodes which load javascript.
@@ -214,7 +214,7 @@ type ScriptAttributes struct {
 	// is primarily used to allow compatibility with OpenAPI 3.0.
 	//
 	// required: true
-	NodeType NodeType `json:"node_type"`
+	NodeType Type `json:"node_type"`
 }
 
 var (
@@ -301,22 +301,22 @@ func (a *TextAttributes) Reset() {
 func (a *ScriptAttributes) Reset() {
 }
 
-func (a *InputAttributes) GetNodeType() NodeType {
+func (a *InputAttributes) GetNodeType() Type {
 	return a.NodeType
 }
 
-func (a *ImageAttributes) GetNodeType() NodeType {
+func (a *ImageAttributes) GetNodeType() Type {
 	return a.NodeType
 }
 
-func (a *AnchorAttributes) GetNodeType() NodeType {
+func (a *AnchorAttributes) GetNodeType() Type {
 	return a.NodeType
 }
 
-func (a *TextAttributes) GetNodeType() NodeType {
+func (a *TextAttributes) GetNodeType() Type {
 	return a.NodeType
 }
 
-func (a *ScriptAttributes) GetNodeType() NodeType {
+func (a *ScriptAttributes) GetNodeType() Type {
 	return a.NodeType
 }

--- a/ui/node/attributes_input.go
+++ b/ui/node/attributes_input.go
@@ -80,7 +80,7 @@ func applyScriptAttributes(opts ScriptAttributesModifiers, attributes *ScriptAtt
 	return attributes
 }
 
-func NewInputFieldFromJSON(name string, value interface{}, group Group, opts ...InputAttributesModifier) *Node {
+func NewInputFieldFromJSON(name string, value interface{}, group UiNodeGroup, opts ...InputAttributesModifier) *Node {
 	return &Node{
 		Type:       Input,
 		Group:      group,
@@ -89,7 +89,7 @@ func NewInputFieldFromJSON(name string, value interface{}, group Group, opts ...
 	}
 }
 
-func NewInputField(name string, value interface{}, group Group, inputType InputAttributeType, opts ...InputAttributesModifier) *Node {
+func NewInputField(name string, value interface{}, group UiNodeGroup, inputType InputAttributeType, opts ...InputAttributesModifier) *Node {
 	return &Node{
 		Type:       Input,
 		Group:      group,
@@ -98,7 +98,7 @@ func NewInputField(name string, value interface{}, group Group, inputType InputA
 	}
 }
 
-func NewImageField(id string, src string, group Group, opts ...ImageAttributesModifier) *Node {
+func NewImageField(id string, src string, group UiNodeGroup, opts ...ImageAttributesModifier) *Node {
 	return &Node{
 		Type:       Image,
 		Group:      group,
@@ -107,7 +107,7 @@ func NewImageField(id string, src string, group Group, opts ...ImageAttributesMo
 	}
 }
 
-func NewTextField(id string, text *text.Message, group Group) *Node {
+func NewTextField(id string, text *text.Message, group UiNodeGroup) *Node {
 	return &Node{
 		Type:       Text,
 		Group:      group,
@@ -116,7 +116,7 @@ func NewTextField(id string, text *text.Message, group Group) *Node {
 	}
 }
 
-func NewAnchorField(id string, href string, group Group, title *text.Message) *Node {
+func NewAnchorField(id string, href string, group UiNodeGroup, title *text.Message) *Node {
 	return &Node{
 		Type:       Anchor,
 		Group:      group,
@@ -125,7 +125,7 @@ func NewAnchorField(id string, href string, group Group, title *text.Message) *N
 	}
 }
 
-func NewScriptField(name string, src string, group Group, integrity string, opts ...ScriptAttributesModifier) *Node {
+func NewScriptField(name string, src string, group UiNodeGroup, integrity string, opts ...ScriptAttributesModifier) *Node {
 	return &Node{
 		Type:  Script,
 		Group: group,
@@ -143,7 +143,7 @@ func NewScriptField(name string, src string, group Group, integrity string, opts
 	}
 }
 
-func NewInputFieldFromSchema(name string, group Group, p jsonschemax.Path, opts ...InputAttributesModifier) *Node {
+func NewInputFieldFromSchema(name string, group UiNodeGroup, p jsonschemax.Path, opts ...InputAttributesModifier) *Node {
 	attr := &InputAttributes{
 		Name:     name,
 		Type:     toFormType(p.Name, p.Type),

--- a/ui/node/attributes_test.go
+++ b/ui/node/attributes_test.go
@@ -41,7 +41,7 @@ func TestNodeEncode(t *testing.T) {
 }
 
 func TestNodeDecode(t *testing.T) {
-	for _, kind := range []Type{
+	for _, kind := range []UiNodeType{
 		Text,
 		Input,
 		Image,

--- a/ui/node/node.go
+++ b/ui/node/node.go
@@ -17,8 +17,42 @@ import (
 	"github.com/ory/x/stringslice"
 )
 
-// swagger:model uiNodeType
+// swagger:enum uiNodeType
 type Type string
+
+const (
+	Text   Type = "text"
+	Input  Type = "input"
+	Image  Type = "img"
+	Anchor Type = "a"
+	Script Type = "script"
+)
+
+var (
+	ErrUnknownNodeType = errors.New("unknown node type")
+)
+
+func (t Type) String() string {
+	return string(t)
+}
+
+func (t *Type) UnmarshalJSON(v []byte) error {
+	switch string(v) {
+	case `"text"`:
+		*t = Text
+	case `"input"`:
+		*t = Input
+	case `"img"`:
+		*t = Image
+	case `"a"`:
+		*t = Anchor
+	case `"script"`:
+		*t = Script
+	default:
+		return ErrUnknownNodeType
+	}
+	return nil
+}
 
 // swagger:model uiNodeGroup
 type Group string
@@ -37,12 +71,6 @@ const (
 	TOTPGroup             Group = "totp"
 	LookupGroup           Group = "lookup_secret"
 	WebAuthnGroup         Group = "webauthn"
-
-	Text   Type = "text"
-	Input  Type = "input"
-	Image  Type = "img"
-	Anchor Type = "a"
-	Script Type = "script"
 )
 
 // swagger:model uiNodes

--- a/ui/node/node.go
+++ b/ui/node/node.go
@@ -62,8 +62,6 @@ type Nodes []*Node
 type Node struct {
 	// The node's type
 	//
-	// Can be one of: text, input, img, a, script
-	//
 	// required: true
 	Type Type `json:"type" faker:"-"`
 

--- a/ui/node/node.go
+++ b/ui/node/node.go
@@ -17,61 +17,38 @@ import (
 	"github.com/ory/x/stringslice"
 )
 
-// swagger:enum uiNodeType
-type NodeType string
+// swagger:enum Type
+type Type string
 
 const (
-	Text   NodeType = "text"
-	Input  NodeType = "input"
-	Image  NodeType = "img"
-	Anchor NodeType = "a"
-	Script NodeType = "script"
+	Text   Type = "text"
+	Input  Type = "input"
+	Image  Type = "img"
+	Anchor Type = "a"
+	Script Type = "script"
 )
 
-var (
-	ErrUnknownNodeType = errors.New("unknown node type")
-)
-
-func (t NodeType) String() string {
+func (t Type) String() string {
 	return string(t)
 }
 
-func (t *NodeType) UnmarshalJSON(v []byte) error {
-	switch string(v) {
-	case `"text"`:
-		*t = Text
-	case `"input"`:
-		*t = Input
-	case `"img"`:
-		*t = Image
-	case `"a"`:
-		*t = Anchor
-	case `"script"`:
-		*t = Script
-	default:
-		return ErrUnknownNodeType
-	}
-	return nil
-}
-
-// swagger:model uiNodeGroup
+// swagger:enum Group
 type Group string
+
+const (
+	DefaultGroup       Group = "default"
+	PasswordGroup      Group = "password"
+	OpenIDConnectGroup Group = "oidc"
+	ProfileGroup       Group = "profile"
+	LinkGroup          Group = "link"
+	TOTPGroup          Group = "totp"
+	LookupGroup        Group = "lookup_secret"
+	WebAuthnGroup      Group = "webauthn"
+)
 
 func (g Group) String() string {
 	return string(g)
 }
-
-const (
-	DefaultGroup          Group = "default"
-	PasswordGroup         Group = "password"
-	OpenIDConnectGroup    Group = "oidc"
-	ProfileGroup          Group = "profile"
-	RecoveryLinkGroup     Group = "link"
-	VerificationLinkGroup Group = "link"
-	TOTPGroup             Group = "totp"
-	LookupGroup           Group = "lookup_secret"
-	WebAuthnGroup         Group = "webauthn"
-)
 
 // swagger:model uiNodes
 type Nodes []*Node
@@ -88,7 +65,7 @@ type Node struct {
 	// Can be one of: text, input, img, a, script
 	//
 	// required: true
-	Type NodeType `json:"type" faker:"-"`
+	Type Type `json:"type" faker:"-"`
 
 	// Group specifies which group (e.g. password authenticator) this node belongs to.
 	//
@@ -134,7 +111,7 @@ type Meta struct {
 
 // Used for en/decoding the Attributes field.
 type jsonRawNode struct {
-	Type       NodeType      `json:"type"`
+	Type       Type          `json:"type"`
 	Group      Group         `json:"group"`
 	Attributes Attributes    `json:"attributes"`
 	Messages   text.Messages `json:"messages"`
@@ -375,7 +352,7 @@ func (n *Nodes) Append(node *Node) {
 
 func (n *Node) UnmarshalJSON(data []byte) error {
 	var attr Attributes
-	switch t := gjson.GetBytes(data, "type").String(); NodeType(t) {
+	switch t := gjson.GetBytes(data, "type").String(); Type(t) {
 	case Text:
 		attr = &TextAttributes{
 			NodeType: Text,
@@ -416,7 +393,7 @@ func (n *Node) UnmarshalJSON(data []byte) error {
 }
 
 func (n *Node) MarshalJSON() ([]byte, error) {
-	var t NodeType
+	var t Type
 	if n.Attributes != nil {
 		switch attr := n.Attributes.(type) {
 		case *TextAttributes:

--- a/ui/node/node.go
+++ b/ui/node/node.go
@@ -18,17 +18,17 @@ import (
 )
 
 // swagger:enum Type
-type Type string
+type NodeType string
 
 const (
-	Text   Type = "text"
-	Input  Type = "input"
-	Image  Type = "img"
-	Anchor Type = "a"
-	Script Type = "script"
+	Text   NodeType = "text"
+	Input  NodeType = "input"
+	Image  NodeType = "img"
+	Anchor NodeType = "a"
+	Script NodeType = "script"
 )
 
-func (t Type) String() string {
+func (t NodeType) String() string {
 	return string(t)
 }
 
@@ -63,7 +63,7 @@ type Node struct {
 	// The node's type
 	//
 	// required: true
-	Type Type `json:"type" faker:"-"`
+	Type NodeType `json:"type" faker:"-"`
 
 	// Group specifies which group (e.g. password authenticator) this node belongs to.
 	//
@@ -109,7 +109,7 @@ type Meta struct {
 
 // Used for en/decoding the Attributes field.
 type jsonRawNode struct {
-	Type       Type          `json:"type"`
+	Type       NodeType      `json:"type"`
 	Group      Group         `json:"group"`
 	Attributes Attributes    `json:"attributes"`
 	Messages   text.Messages `json:"messages"`
@@ -350,7 +350,7 @@ func (n *Nodes) Append(node *Node) {
 
 func (n *Node) UnmarshalJSON(data []byte) error {
 	var attr Attributes
-	switch t := gjson.GetBytes(data, "type").String(); Type(t) {
+	switch t := gjson.GetBytes(data, "type").String(); NodeType(t) {
 	case Text:
 		attr = &TextAttributes{
 			NodeType: Text,
@@ -391,7 +391,7 @@ func (n *Node) UnmarshalJSON(data []byte) error {
 }
 
 func (n *Node) MarshalJSON() ([]byte, error) {
-	var t Type
+	var t NodeType
 	if n.Attributes != nil {
 		switch attr := n.Attributes.(type) {
 		case *TextAttributes:

--- a/ui/node/node.go
+++ b/ui/node/node.go
@@ -18,25 +18,25 @@ import (
 )
 
 // swagger:enum uiNodeType
-type Type string
+type NodeType string
 
 const (
-	Text   Type = "text"
-	Input  Type = "input"
-	Image  Type = "img"
-	Anchor Type = "a"
-	Script Type = "script"
+	Text   NodeType = "text"
+	Input  NodeType = "input"
+	Image  NodeType = "img"
+	Anchor NodeType = "a"
+	Script NodeType = "script"
 )
 
 var (
 	ErrUnknownNodeType = errors.New("unknown node type")
 )
 
-func (t Type) String() string {
+func (t NodeType) String() string {
 	return string(t)
 }
 
-func (t *Type) UnmarshalJSON(v []byte) error {
+func (t *NodeType) UnmarshalJSON(v []byte) error {
 	switch string(v) {
 	case `"text"`:
 		*t = Text
@@ -88,7 +88,7 @@ type Node struct {
 	// Can be one of: text, input, img, a, script
 	//
 	// required: true
-	Type Type `json:"type" faker:"-"`
+	Type NodeType `json:"type" faker:"-"`
 
 	// Group specifies which group (e.g. password authenticator) this node belongs to.
 	//
@@ -134,7 +134,7 @@ type Meta struct {
 
 // Used for en/decoding the Attributes field.
 type jsonRawNode struct {
-	Type       Type          `json:"type"`
+	Type       NodeType      `json:"type"`
 	Group      Group         `json:"group"`
 	Attributes Attributes    `json:"attributes"`
 	Messages   text.Messages `json:"messages"`
@@ -375,7 +375,7 @@ func (n *Nodes) Append(node *Node) {
 
 func (n *Node) UnmarshalJSON(data []byte) error {
 	var attr Attributes
-	switch t := gjson.GetBytes(data, "type").String(); Type(t) {
+	switch t := gjson.GetBytes(data, "type").String(); NodeType(t) {
 	case Text:
 		attr = &TextAttributes{
 			NodeType: Text,
@@ -416,7 +416,7 @@ func (n *Node) UnmarshalJSON(data []byte) error {
 }
 
 func (n *Node) MarshalJSON() ([]byte, error) {
-	var t Type
+	var t NodeType
 	if n.Attributes != nil {
 		switch attr := n.Attributes.(type) {
 		case *TextAttributes:

--- a/ui/node/node.go
+++ b/ui/node/node.go
@@ -18,17 +18,17 @@ import (
 )
 
 // swagger:enum Type
-type NodeType string
+type Type string
 
 const (
-	Text   NodeType = "text"
-	Input  NodeType = "input"
-	Image  NodeType = "img"
-	Anchor NodeType = "a"
-	Script NodeType = "script"
+	Text   Type = "text"
+	Input  Type = "input"
+	Image  Type = "img"
+	Anchor Type = "a"
+	Script Type = "script"
 )
 
-func (t NodeType) String() string {
+func (t Type) String() string {
 	return string(t)
 }
 
@@ -63,7 +63,7 @@ type Node struct {
 	// The node's type
 	//
 	// required: true
-	Type NodeType `json:"type" faker:"-"`
+	Type Type `json:"type" faker:"-"`
 
 	// Group specifies which group (e.g. password authenticator) this node belongs to.
 	//
@@ -109,7 +109,7 @@ type Meta struct {
 
 // Used for en/decoding the Attributes field.
 type jsonRawNode struct {
-	Type       NodeType      `json:"type"`
+	Type       Type          `json:"type"`
 	Group      Group         `json:"group"`
 	Attributes Attributes    `json:"attributes"`
 	Messages   text.Messages `json:"messages"`
@@ -350,7 +350,7 @@ func (n *Nodes) Append(node *Node) {
 
 func (n *Node) UnmarshalJSON(data []byte) error {
 	var attr Attributes
-	switch t := gjson.GetBytes(data, "type").String(); NodeType(t) {
+	switch t := gjson.GetBytes(data, "type").String(); Type(t) {
 	case Text:
 		attr = &TextAttributes{
 			NodeType: Text,
@@ -391,7 +391,7 @@ func (n *Node) UnmarshalJSON(data []byte) error {
 }
 
 func (n *Node) MarshalJSON() ([]byte, error) {
-	var t NodeType
+	var t Type
 	if n.Attributes != nil {
 		switch attr := n.Attributes.(type) {
 		case *TextAttributes:

--- a/ui/node/node.go
+++ b/ui/node/node.go
@@ -85,7 +85,7 @@ type Nodes []*Node
 type Node struct {
 	// The node's type
 	//
-	// Can be one of: text, input, img, a
+	// Can be one of: text, input, img, a, script
 	//
 	// required: true
 	Type Type `json:"type" faker:"-"`

--- a/ui/node/node.go
+++ b/ui/node/node.go
@@ -17,18 +17,18 @@ import (
 	"github.com/ory/x/stringslice"
 )
 
-// swagger:enum Type
-type Type string
+// swagger:enum UiNodeType
+type UiNodeType string
 
 const (
-	Text   Type = "text"
-	Input  Type = "input"
-	Image  Type = "img"
-	Anchor Type = "a"
-	Script Type = "script"
+	Text   UiNodeType = "text"
+	Input  UiNodeType = "input"
+	Image  UiNodeType = "img"
+	Anchor UiNodeType = "a"
+	Script UiNodeType = "script"
 )
 
-func (t Type) String() string {
+func (t UiNodeType) String() string {
 	return string(t)
 }
 
@@ -63,7 +63,7 @@ type Node struct {
 	// The node's type
 	//
 	// required: true
-	Type Type `json:"type" faker:"-"`
+	Type UiNodeType `json:"type" faker:"-"`
 
 	// Group specifies which group (e.g. password authenticator) this node belongs to.
 	//
@@ -109,7 +109,7 @@ type Meta struct {
 
 // Used for en/decoding the Attributes field.
 type jsonRawNode struct {
-	Type       Type          `json:"type"`
+	Type       UiNodeType    `json:"type"`
 	Group      Group         `json:"group"`
 	Attributes Attributes    `json:"attributes"`
 	Messages   text.Messages `json:"messages"`
@@ -350,7 +350,7 @@ func (n *Nodes) Append(node *Node) {
 
 func (n *Node) UnmarshalJSON(data []byte) error {
 	var attr Attributes
-	switch t := gjson.GetBytes(data, "type").String(); Type(t) {
+	switch t := gjson.GetBytes(data, "type").String(); UiNodeType(t) {
 	case Text:
 		attr = &TextAttributes{
 			NodeType: Text,
@@ -391,7 +391,7 @@ func (n *Node) UnmarshalJSON(data []byte) error {
 }
 
 func (n *Node) MarshalJSON() ([]byte, error) {
-	var t Type
+	var t UiNodeType
 	if n.Attributes != nil {
 		switch attr := n.Attributes.(type) {
 		case *TextAttributes:

--- a/ui/node/node.go
+++ b/ui/node/node.go
@@ -32,21 +32,21 @@ func (t UiNodeType) String() string {
 	return string(t)
 }
 
-// swagger:enum Group
-type Group string
+// swagger:enum UiNodeGroup
+type UiNodeGroup string
 
 const (
-	DefaultGroup       Group = "default"
-	PasswordGroup      Group = "password"
-	OpenIDConnectGroup Group = "oidc"
-	ProfileGroup       Group = "profile"
-	LinkGroup          Group = "link"
-	TOTPGroup          Group = "totp"
-	LookupGroup        Group = "lookup_secret"
-	WebAuthnGroup      Group = "webauthn"
+	DefaultGroup       UiNodeGroup = "default"
+	PasswordGroup      UiNodeGroup = "password"
+	OpenIDConnectGroup UiNodeGroup = "oidc"
+	ProfileGroup       UiNodeGroup = "profile"
+	LinkGroup          UiNodeGroup = "link"
+	TOTPGroup          UiNodeGroup = "totp"
+	LookupGroup        UiNodeGroup = "lookup_secret"
+	WebAuthnGroup      UiNodeGroup = "webauthn"
 )
 
-func (g Group) String() string {
+func (g UiNodeGroup) String() string {
 	return string(g)
 }
 
@@ -68,7 +68,7 @@ type Node struct {
 	// Group specifies which group (e.g. password authenticator) this node belongs to.
 	//
 	// required: true
-	Group Group `json:"group"`
+	Group UiNodeGroup `json:"group"`
 
 	// The node's attributes.
 	//
@@ -110,7 +110,7 @@ type Meta struct {
 // Used for en/decoding the Attributes field.
 type jsonRawNode struct {
 	Type       UiNodeType    `json:"type"`
-	Group      Group         `json:"group"`
+	Group      UiNodeGroup   `json:"group"`
 	Attributes Attributes    `json:"attributes"`
 	Messages   text.Messages `json:"messages"`
 	Meta       *Meta         `json:"meta"`
@@ -193,7 +193,7 @@ type sortOptions struct {
 
 type SortOption func(*sortOptions)
 
-func SortByGroups(orderByGroups []Group) func(*sortOptions) {
+func SortByGroups(orderByGroups []UiNodeGroup) func(*sortOptions) {
 	return func(options *sortOptions) {
 		options.orderByGroups = make([]string, len(orderByGroups))
 		for k := range orderByGroups {

--- a/ui/node/node_test.go
+++ b/ui/node/node_test.go
@@ -49,7 +49,7 @@ func TestNodesSort(t *testing.T) {
 		"1.json": {
 			node.SortUseOrder([]string{"password_identifier"}),
 			node.SortUpdateOrder(node.PasswordLoginOrder),
-			node.SortByGroups([]node.Group{
+			node.SortByGroups([]node.UiNodeGroup{
 				node.DefaultGroup,
 				node.ProfileGroup,
 				node.OpenIDConnectGroup,
@@ -61,7 +61,7 @@ func TestNodesSort(t *testing.T) {
 		"2.json": {
 			node.SortBySchema(filepath.Join("fixtures/sort/schema", "2.json")),
 			node.SortUpdateOrder(node.PasswordLoginOrder),
-			node.SortByGroups([]node.Group{
+			node.SortByGroups([]node.UiNodeGroup{
 				node.DefaultGroup,
 				node.OpenIDConnectGroup,
 				node.PasswordGroup,
@@ -69,7 +69,7 @@ func TestNodesSort(t *testing.T) {
 		},
 		"3.json": {
 			node.SortBySchema(filepath.Join("fixtures/sort/schema", "3.json")),
-			node.SortByGroups([]node.Group{
+			node.SortByGroups([]node.UiNodeGroup{
 				node.DefaultGroup,
 				node.OpenIDConnectGroup,
 				node.PasswordGroup,
@@ -77,7 +77,7 @@ func TestNodesSort(t *testing.T) {
 		},
 		"4.json": {
 			node.SortBySchema(filepath.Join("fixtures/sort/schema", "4.json")),
-			node.SortByGroups([]node.Group{
+			node.SortByGroups([]node.UiNodeGroup{
 				node.DefaultGroup,
 				node.ProfileGroup,
 				node.PasswordGroup,

--- a/ui/node/node_test.go
+++ b/ui/node/node_test.go
@@ -54,8 +54,8 @@ func TestNodesSort(t *testing.T) {
 				node.ProfileGroup,
 				node.OpenIDConnectGroup,
 				node.PasswordGroup,
-				node.RecoveryLinkGroup,
-				node.VerificationLinkGroup,
+				node.LinkGroup,
+				node.LinkGroup,
 			}),
 		},
 		"2.json": {


### PR DESCRIPTION
This PR updates the API schema.

resolves #2357 

- [x] turn `uiNodeType` into enum
- [x] turn `uiNodeGroup` into enum
- [x] ensure select field value for `attributes.node_type` matches actual node_type value (see screenshot)
- [x] add task for previewing API documentation
- [x] In `api.openapi.json`, the `LoginFlow` and the `VerificationFlow` list `type` as a required property. The other flows don't, and none of the flows in `openapi.json` list it. I assume the type should always be set to either `"api"` or `"browser"` and never be omitted or `null`. Is that so? If so, I'll add `type` as a required property to all the flows.

<img width="320" alt="imagen" src="https://user-images.githubusercontent.com/13847569/162198450-613f007d-745a-4989-976c-769b7b6ba940.png">

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).