### PR TITLE
fix: serve.admin.request_log.disable_for_health behaviour

### DIFF
--- a/cmd/daemon/serve.go
+++ b/cmd/daemon/serve.go
@@ -160,8 +160,9 @@ func ServeAdmin(r driver.Registry, wg *sync.WaitGroup, cmd *cobra.Command, args 
 		l,
 		"admin#"+c.SelfPublicURL().String(),
 	)
+
 	if r.Config(ctx).DisableAdminHealthRequestLog() {
-		adminLogger.ExcludePaths(healthx.AliveCheckPath, healthx.ReadyCheckPath)
+		adminLogger.ExcludePaths(x.AdminPrefix+healthx.AliveCheckPath, x.AdminPrefix+healthx.ReadyCheckPath)
 	}
 	n.Use(adminLogger)
 	n.UseFunc(x.RedirectAdminMiddleware)


### PR DESCRIPTION
Since admin endpoints have been moved under /admin prefix, `serve.admin.request_log.disable_for_health` parameter doesn't work anymore.
This PR fixes the issue by adding the missing prefix in front of ignored URLs.

## Related issue(s)

### How to reproduce

Using kratos quickstart:

```bash
# Set serve.admin.request_log.disable_for_health parameter to true to disable access logs for probes
yq -i '.serve.admin.request_log.disable_for_health  = true' contrib/quickstart/kratos/email-password/kratos.yml

# Start quickstart
docker-compose -f quickstart.yml -f quickstart-standalone.yml up --build --force-recreate

# In another terminal
curl http://127.0.0.1:4434/admin/health/ready
```

Output in logs:
```
kratos_1                      | time=2022-04-14T12:25:38Z level=info msg=started handling request func=github.com/ory/x/reqlog.(*Middleware).ServeHTTP file=/go/pkg/mod/github.com/ory/x@v0.0.358/reqlog/middleware.go:131 http_request=map[headers:map[accept:*/* user-agent:curl/7.68.0] host:127.0.0.1:4434 method:GET path:/admin/health/ready query:<nil> remote:172.18.0.1:49652 scheme:http]
kratos_1                      | time=2022-04-14T12:25:38Z level=info msg=completed handling request func=github.com/ory/x/reqlog.(*Middleware).ServeHTTP file=/go/pkg/mod/github.com/ory/x@v0.0.358/reqlog/middleware.go:139 http_request=map[headers:map[accept:*/* user-agent:curl/7.68.0] host:127.0.0.1:4434 method:GET path:/admin/health/ready query:<nil> remote:172.18.0.1:49652 scheme:http] http_response=map[headers:map[cache-control:private, no-cache, no-store, must-revalidate content-type:application/json; charset=utf-8] size:16 status:200 text_status:OK took:221.412µs]

```
while no logs would be expected.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further Comments
