### PR TITLE
fix: Internal Server Error on Empty PUT /identities/id body

### DIFF
--- a/examples/go/selfservice/login/main.go
+++ b/examples/go/selfservice/login/main.go
@@ -33,7 +33,7 @@ func performLogin() *ory.SuccessfulSelfServiceLoginWithoutBrowser {
 		ory.SubmitSelfServiceLoginFlowWithPasswordMethodBodyAsSubmitSelfServiceLoginFlowBody(&ory.SubmitSelfServiceLoginFlowWithPasswordMethodBody{
 			Method:             "password",
 			Password:           password,
-			PasswordIdentifier: email,
+			PasswordIdentifier: &email,
 		}),
 	).Execute()
 	pkg.SDKExitOnError(err, res)

--- a/identity/handler.go
+++ b/identity/handler.go
@@ -436,9 +436,9 @@ type AdminUpdateIdentityBody struct {
 //       500: jsonError
 func (h *Handler) update(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	var ur AdminUpdateIdentityBody
-        if err := errors.WithStack(jsonx.NewStrictDecoder(r.Body).Decode(&ur)); err == io.EOF {
-               h.r.Writer().WriteError(w, r, errors.WithStack(herodot.ErrBadRequest.WithReasonf(`Empty input json or file does not exits`).WithWrap(err)))
-               return
+        if err := errors.WithStack(jsonx.NewStrictDecoder(r.Body).Decode(&ur)); errors.Is(err, io.EOF) {
+                h.r.Writer().WriteError(w, r, errors.WithStack(herodot.ErrBadRequest.WithReasonf(`Empty input json or file does not exist`).WithWrap(err)))
+                return
         } else if err != nil {
                 h.r.Writer().WriteError(w, r, err)
                 return

--- a/identity/handler_test.go
+++ b/identity/handler_test.go
@@ -74,8 +74,8 @@ func TestHandler(t *testing.T) {
 	var send = func(t *testing.T, base *httptest.Server, method, href string, expectCode int, send interface{}) gjson.Result {
 		var b bytes.Buffer
 		if send != nil {
-                        require.NoError(t, json.NewEncoder(&b).Encode(send))
-                }
+			require.NoError(t, json.NewEncoder(&b).Encode(send))
+		}
 		req, err := http.NewRequest(method, base.URL+href, &b)
 		require.NoError(t, err)
 		req.Header.Set("Content-Type", "application/json")
@@ -676,19 +676,20 @@ func TestHandler(t *testing.T) {
 	})
 
 	t.Run("case=should fail to update identity if input json is empty or json file does not exist", func(t *testing.T) {
-                for name, ts := range map[string]*httptest.Server{"public": publicTS, "admin": adminTS} {
-                        t.Run("endpoint="+name, func(t *testing.T) {
-                                        var cr identity.AdminCreateIdentityBody
-                                        cr.SchemaID = "employee"
-                                        cr.Traits = []byte(`{"email":"` + x.NewUUID().String() + `@ory.sh", "department": "ory"}`)
-                                        res := send(t, ts, "POST", "/identities", http.StatusCreated, &cr)
+		for name, ts := range map[string]*httptest.Server{"public": publicTS, "admin": adminTS} {
+			t.Run("endpoint="+name, func(t *testing.T) {
+				var cr identity.AdminCreateIdentityBody
+				cr.SchemaID = "employee"
+				cr.Traits = []byte(`{"email":"` + x.NewUUID().String() + `@ory.sh", "department": "ory"}`)
+				res := send(t, ts, "POST", "/identities", http.StatusCreated, &cr)
 
-                                        id := res.Get("id").String()
-                                        res = send(t, ts, "PUT", "/identities/"+id, http.StatusBadRequest, nil)
-                                        assert.Contains(t, res.Get("error.reason").String(), `Empty input json or file does not exist`, "%s", res.Raw)
-                        })
-                }
-        })
+				id := res.Get("id").String()
+				res = send(t, ts, "PUT", "/identities/"+id, http.StatusBadRequest, nil)
+				assert.Contains(t, res.Get("error.reason").String(), `Unable to decode HTTP Request Body because its HTTP `+
+					`Header "Content-Length" is zero`, "%s", res.Raw)
+			})
+		}
+	})
 
 	t.Run("case=should list all identities", func(t *testing.T) {
 		for name, ts := range map[string]*httptest.Server{"public": publicTS, "admin": adminTS} {


### PR DESCRIPTION
Signed-off-by: Veena Saini <veena.code.assignment@gmail.com>

<!--

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->
## Description of the changes
This PR fixes the issue https://github.com/ory/kratos/issues/2307. 

Currently if a user sends HTTP PUT request with empty json data or incorrect json path (means the file does not exist), then that results into "internal server error". This error message is a generic and creates confusion. 

Empty json (or we can say http request without body) triggers io.EOF error.  This PR provides the user a better error message when io.EOF error is encountered.

**Affected Module: Identity Update** 

There can be other scenarios of malformed user requests that may trigger "internal server error" during identity update, but those are not handled in this PR.

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
2. implements a new feature, link the issue containing the design document in the format of `#1234`;
3. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x ] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
