### PR TITLE
feat: add localName to smtp config

### DIFF
--- a/courier/smtp.go
+++ b/courier/smtp.go
@@ -43,14 +43,16 @@ func newSMTP(ctx context.Context, deps Dependencies) *smtpClient {
 		}
 	}
 
+	localName := deps.CourierConfig(ctx).CourierSMTPLocalName()
 	password, _ := uri.User.Password()
 	port, _ := strconv.ParseInt(uri.Port(), 10, 0)
 
 	dialer := &gomail.Dialer{
-		Host:     uri.Hostname(),
-		Port:     int(port),
-		Username: uri.User.Username(),
-		Password: password,
+		Host:      uri.Hostname(),
+		Port:      int(port),
+		Username:  uri.User.Username(),
+		Password:  password,
+		LocalName: localName,
 
 		Timeout:      time.Second * 10,
 		RetryFailure: true,

--- a/driver/config/config.go
+++ b/driver/config/config.go
@@ -70,6 +70,7 @@ const (
 	ViperKeyCourierSMTPFrom                                  = "courier.smtp.from_address"
 	ViperKeyCourierSMTPFromName                              = "courier.smtp.from_name"
 	ViperKeyCourierSMTPHeaders                               = "courier.smtp.headers"
+	ViperKeyCourierSMTPLocalName                             = "courier.smtp.local_name"
 	ViperKeyCourierSMSRequestConfig                          = "courier.sms.request_config"
 	ViperKeyCourierSMSEnabled                                = "courier.sms.enabled"
 	ViperKeyCourierSMSFrom                                   = "courier.sms.from"
@@ -245,6 +246,7 @@ type (
 		CourierSMTPFrom() string
 		CourierSMTPFromName() string
 		CourierSMTPHeaders() map[string]string
+		CourierSMTPLocalName() string
 		CourierSMSEnabled() bool
 		CourierSMSFrom() string
 		CourierSMSRequestConfig() json.RawMessage
@@ -877,6 +879,10 @@ func (p *Config) CourierSMTPFrom() string {
 
 func (p *Config) CourierSMTPFromName() string {
 	return p.p.StringF(ViperKeyCourierSMTPFromName, "")
+}
+
+func (p *Config) CourierSMTPLocalName() string {
+	return p.p.StringF(ViperKeyCourierSMTPLocalName, "localhost")
 }
 
 func (p *Config) CourierTemplatesRoot() string {

--- a/embedx/config.schema.json
+++ b/embedx/config.schema.json
@@ -1539,6 +1539,12 @@
                   "X-SES-RETURN-PATH-ARN": "arn:aws:ses:us-west-2:123456789012:identity/example.com"
                 }
               ]
+            },
+            "local_name": {
+              "title": "SMTP HELO/EHLO name",
+              "description": "Identifier used in the SMTP HELO/EHLO command. Some SMTP relays require a unique identifier.",
+              "type": "string",
+              "default": "localhost"
             }
           },
           "required": [


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:


```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

This PR introduces a new configuration `courier.smtp.local_name` that is passed to the SMTP dialer used in kratos courier.
The config value is used in the  SMTP HELO/EHLO command and was previously hardcoded to `localhost`.
Some SMTP relays (e.g. Gmail) require a unique identifier during the HELO command and close the connection if a generic value like `localhost` is used. Therefore those SMTP relays can currently not be used with Kratos.

See https://support.google.com/a/answer/2956491?product_name=UnuFlow&hl=en&visit_id=637871815371283723-3216367043&rd=1&src=supportwidget0&hl=en

> We recommend that you configure your mail server to present a unique identifier (such as your domain name or the name of your mail server) in the HELO or EHLO command in the SMTP relay connections your server makes to Google. Avoid using generic names such as "localhost" or "smtp-relay.gmail.com," which can occasionally result in issues with DoS limits.
 
Note that you may not be able to reproduce the bug with an Gmail SMTP relay, since Gmail does not close every connection. For us, it worked fine for some time before Gmail started to close the connections.

## Related issue(s)

#2425

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
2. implements a new feature, link the issue containing the design document in the format of `#1234`;
3. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
