### PR TITLE
fix: add flow id when return_to is passed to the verification

### DIFF
--- a/selfservice/flow/verification/flow.go
+++ b/selfservice/flow/verification/flow.go
@@ -175,7 +175,9 @@ func (f *Flow) Valid() error {
 }
 
 func (f *Flow) AppendTo(src *url.URL) *url.URL {
-	return urlx.CopyWithQuery(src, url.Values{"flow": {f.ID.String()}})
+	values := src.Query()
+	values.Set("flow", f.ID.String())
+	return urlx.CopyWithQuery(src, values)
 }
 
 func (f Flow) GetID() uuid.UUID {

--- a/selfservice/strategy/link/strategy_verification.go
+++ b/selfservice/strategy/link/strategy_verification.go
@@ -265,7 +265,7 @@ func (s *Strategy) verificationUseToken(w http.ResponseWriter, r *http.Request, 
 		return errors.WithStack(flow.ErrCompletedByStrategy)
 	}
 
-	http.Redirect(w, r, returnTo.String(), http.StatusSeeOther)
+	http.Redirect(w, r, f.AppendTo(returnTo).String(), http.StatusSeeOther)
 	return errors.WithStack(flow.ErrCompletedByStrategy)
 }
 

--- a/selfservice/strategy/link/strategy_verification_test.go
+++ b/selfservice/strategy/link/strategy_verification_test.go
@@ -380,7 +380,6 @@ func TestVerification(t *testing.T) {
 		assert.Equal(t, http.StatusSeeOther, res.StatusCode)
 		redirectURL, err := res.Location()
 		require.NoError(t, err)
-		assert.Equal(t, returnToURL, redirectURL.String())
-
+		assert.Equal(t, returnToURL + "?flow=" + flow.ID.String(), redirectURL.String())
 	})
 }

--- a/test/e2e/cypress/support/commands.ts
+++ b/test/e2e/cypress/support/commands.ts
@@ -873,6 +873,8 @@ Cypress.Commands.add(
       expect(message.toAddresses[0].trim()).to.equal(email)
 
       const link = parseHtml(message.body).querySelector('a')
+      const flow = new URL(link.href).searchParams.get('flow')
+
       expect(link).to.not.be.null
       expect(link.href).to.contain(APP_URL)
 
@@ -880,7 +882,7 @@ Cypress.Commands.add(
         (response) => {
           expect(response.status).to.eq(303)
           if (redirectTo) {
-            expect(response.redirectedToUrl).to.eq(redirectTo)
+            expect(response.redirectedToUrl).to.eq(`${redirectTo}?flow=${flow}`)
           } else {
             expect(response.redirectedToUrl).to.not.contain('verification')
           }


### PR DESCRIPTION
This pull request basically appends the flow ID when redirecting the user to the passed `return_to` URL after clicking the verification link.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

#2481

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
2. implements a new feature, link the issue containing the design document in the format of `#1234`;
3. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
works.
- [ ] I have added or changed [the documentation](../docs/docs).

