### PR TITLE
fix: return browser to 'return_to' when logging in without registered account using oidc. 

### DIFF
--- a/selfservice/flow/login/flow.go
+++ b/selfservice/flow/login/flow.go
@@ -193,7 +193,7 @@ func (f Flow) MarshalJSON() ([]byte, error) {
 
 func (f *Flow) SetReturnTo() {
 	// Return to is already set, do not overwrite it.
-	if f.ReturnTo != "" {
+	if len(f.ReturnTo) > 0 {
 		return
 	}
 	if u, err := url.Parse(f.RequestURL); err == nil {

--- a/selfservice/flow/login/flow.go
+++ b/selfservice/flow/login/flow.go
@@ -192,6 +192,10 @@ func (f Flow) MarshalJSON() ([]byte, error) {
 }
 
 func (f *Flow) SetReturnTo() {
+	// Return to is already set, do not overwrite it.
+	if f.ReturnTo != "" {
+		return
+	}
 	if u, err := url.Parse(f.RequestURL); err == nil {
 		f.ReturnTo = u.Query().Get("return_to")
 	}

--- a/selfservice/flow/login/flow_test.go
+++ b/selfservice/flow/login/flow_test.go
@@ -158,3 +158,13 @@ func TestFlowEncodeJSON(t *testing.T) {
 	assert.EqualValues(t, "/bar", gjson.Get(jsonx.TestMarshalJSONString(t, &login.Flow{RequestURL: "https://foo.bar?return_to=/bar"}), "return_to").String())
 	assert.EqualValues(t, "/bar", gjson.Get(jsonx.TestMarshalJSONString(t, login.Flow{RequestURL: "https://foo.bar?return_to=/bar"}), "return_to").String())
 }
+
+func TestFlowDontOverrideReturnTo(t *testing.T) {
+	f := &login.Flow{ReturnTo: "/foo"}
+	f.SetReturnTo()
+	assert.Equal(t, "/foo", f.ReturnTo)
+
+	f = &login.Flow{RequestURL: "https://foo.bar?return_to=/bar"}
+	f.SetReturnTo()
+	assert.Equal(t, "/bar", f.ReturnTo)
+}

--- a/selfservice/flow/login/handler.go
+++ b/selfservice/flow/login/handler.go
@@ -86,11 +86,22 @@ func (h *Handler) RegisterAdminRoutes(admin *x.RouterAdmin) {
 	admin.GET(RouteSubmitFlow, x.RedirectToPublicRoute(h.d))
 }
 
-func (h *Handler) NewLoginFlow(w http.ResponseWriter, r *http.Request, ft flow.Type) (*Flow, error) {
+type FlowOption func(f *Flow)
+
+func WithFlowReturnTo(returnTo string) FlowOption {
+	return func(f *Flow) {
+		f.ReturnTo = returnTo
+	}
+}
+
+func (h *Handler) NewLoginFlow(w http.ResponseWriter, r *http.Request, ft flow.Type, opts ...FlowOption) (*Flow, error) {
 	conf := h.d.Config(r.Context())
 	f, err := NewFlow(conf, conf.SelfServiceFlowLoginRequestLifespan(), h.d.GenerateCSRFToken(r), r, ft)
 	if err != nil {
 		return nil, err
+	}
+	for _, o := range opts {
+		o(f)
 	}
 
 	if f.RequestedAAL == "" {

--- a/selfservice/flow/login/hook.go
+++ b/selfservice/flow/login/hook.go
@@ -82,6 +82,7 @@ func (e *HookExecutor) PostLoginHook(w http.ResponseWriter, r *http.Request, a *
 	// Verify the redirect URL before we do any other processing.
 	c := e.d.Config(r.Context())
 	returnTo, err := x.SecureRedirectTo(r, c.SelfServiceBrowserDefaultReturnTo(),
+		x.SecureRedirectReturnTo(a.ReturnTo),
 		x.SecureRedirectUseSourceURL(a.RequestURL),
 		x.SecureRedirectAllowURLs(c.SelfServiceBrowserAllowedReturnToDomains()),
 		x.SecureRedirectAllowSelfServiceURLs(c.SelfPublicURL()),

--- a/selfservice/flow/recovery/flow.go
+++ b/selfservice/flow/recovery/flow.go
@@ -191,6 +191,10 @@ func (f Flow) MarshalJSON() ([]byte, error) {
 }
 
 func (f *Flow) SetReturnTo() {
+	// Return to is already set, do not overwrite it.
+	if len(f.ReturnTo) > 0 {
+		return
+	}
 	if u, err := url.Parse(f.RequestURL); err == nil {
 		f.ReturnTo = u.Query().Get("return_to")
 	}

--- a/selfservice/flow/recovery/flow_test.go
+++ b/selfservice/flow/recovery/flow_test.go
@@ -101,3 +101,13 @@ func TestFromOldFlow(t *testing.T) {
 		})
 	}
 }
+
+func TestFlowDontOverrideReturnTo(t *testing.T) {
+	f := &recovery.Flow{ReturnTo: "/foo"}
+	f.SetReturnTo()
+	assert.Equal(t, "/foo", f.ReturnTo)
+
+	f = &recovery.Flow{RequestURL: "https://foo.bar?return_to=/bar"}
+	f.SetReturnTo()
+	assert.Equal(t, "/bar", f.ReturnTo)
+}

--- a/selfservice/flow/registration/flow.go
+++ b/selfservice/flow/registration/flow.go
@@ -159,6 +159,10 @@ func (f Flow) MarshalJSON() ([]byte, error) {
 }
 
 func (f *Flow) SetReturnTo() {
+	// Return to is already set, do not overwrite it.
+	if f.ReturnTo != "" {
+		return
+	}
 	if u, err := url.Parse(f.RequestURL); err == nil {
 		f.ReturnTo = u.Query().Get("return_to")
 	}

--- a/selfservice/flow/registration/flow.go
+++ b/selfservice/flow/registration/flow.go
@@ -160,7 +160,7 @@ func (f Flow) MarshalJSON() ([]byte, error) {
 
 func (f *Flow) SetReturnTo() {
 	// Return to is already set, do not overwrite it.
-	if f.ReturnTo != "" {
+	if len(f.ReturnTo) > 0 {
 		return
 	}
 	if u, err := url.Parse(f.RequestURL); err == nil {

--- a/selfservice/flow/registration/flow_test.go
+++ b/selfservice/flow/registration/flow_test.go
@@ -125,3 +125,13 @@ func TestFlowEncodeJSON(t *testing.T) {
 	assert.EqualValues(t, "/bar", gjson.Get(jsonx.TestMarshalJSONString(t, &registration.Flow{RequestURL: "https://foo.bar?return_to=/bar"}), "return_to").String())
 	assert.EqualValues(t, "/bar", gjson.Get(jsonx.TestMarshalJSONString(t, registration.Flow{RequestURL: "https://foo.bar?return_to=/bar"}), "return_to").String())
 }
+
+func TestFlowDontOverrideReturnTo(t *testing.T) {
+	f := &registration.Flow{ReturnTo: "/foo"}
+	f.SetReturnTo()
+	assert.Equal(t, "/foo", f.ReturnTo)
+
+	f = &registration.Flow{RequestURL: "https://foo.bar?return_to=/bar"}
+	f.SetReturnTo()
+	assert.Equal(t, "/bar", f.ReturnTo)
+}

--- a/selfservice/flow/registration/hook.go
+++ b/selfservice/flow/registration/hook.go
@@ -128,6 +128,7 @@ func (e *HookExecutor) PostRegistrationHook(w http.ResponseWriter, r *http.Reque
 	// Verify the redirect URL before we do any other processing.
 	c := e.d.Config(r.Context())
 	returnTo, err := x.SecureRedirectTo(r, c.SelfServiceBrowserDefaultReturnTo(),
+		x.SecureRedirectReturnTo(a.ReturnTo),
 		x.SecureRedirectUseSourceURL(a.RequestURL),
 		x.SecureRedirectAllowURLs(c.SelfServiceBrowserAllowedReturnToDomains()),
 		x.SecureRedirectAllowSelfServiceURLs(c.SelfPublicURL()),

--- a/selfservice/flow/settings/flow.go
+++ b/selfservice/flow/settings/flow.go
@@ -203,6 +203,10 @@ func (f Flow) MarshalJSON() ([]byte, error) {
 }
 
 func (f *Flow) SetReturnTo() {
+	// Return to is already set, do not overwrite it.
+	if len(f.ReturnTo) > 0 {
+		return
+	}
 	if u, err := url.Parse(f.RequestURL); err == nil {
 		f.ReturnTo = u.Query().Get("return_to")
 	}

--- a/selfservice/flow/settings/flow_test.go
+++ b/selfservice/flow/settings/flow_test.go
@@ -166,3 +166,13 @@ func TestFlowEncodeJSON(t *testing.T) {
 	assert.EqualValues(t, "/bar", gjson.Get(jsonx.TestMarshalJSONString(t, &settings.Flow{RequestURL: "https://foo.bar?return_to=/bar"}), "return_to").String())
 	assert.EqualValues(t, "/bar", gjson.Get(jsonx.TestMarshalJSONString(t, settings.Flow{RequestURL: "https://foo.bar?return_to=/bar"}), "return_to").String())
 }
+
+func TestFlowDontOverrideReturnTo(t *testing.T) {
+	f := &settings.Flow{ReturnTo: "/foo"}
+	f.SetReturnTo()
+	assert.Equal(t, "/foo", f.ReturnTo)
+
+	f = &settings.Flow{RequestURL: "https://foo.bar?return_to=/bar"}
+	f.SetReturnTo()
+	assert.Equal(t, "/bar", f.ReturnTo)
+}

--- a/selfservice/strategy/oidc/strategy_login.go
+++ b/selfservice/strategy/oidc/strategy_login.go
@@ -89,7 +89,7 @@ func (s *Strategy) processLogin(w http.ResponseWriter, r *http.Request, a *login
 
 			// If return_to was set before, we need to preserve it.
 			var opts []registration.FlowOption
-			if a.ReturnTo != "" {
+			if len(a.ReturnTo) > 0 {
 				opts = append(opts, registration.WithFlowReturnTo(a.ReturnTo))
 			}
 

--- a/selfservice/strategy/oidc/strategy_login.go
+++ b/selfservice/strategy/oidc/strategy_login.go
@@ -85,12 +85,15 @@ func (s *Strategy) processLogin(w http.ResponseWriter, r *http.Request, a *login
 			// not need additional consent/login.
 
 			// This is kinda hacky but the only way to ensure seamless login/registration flows when using OIDC.
-
 			s.d.Logger().WithField("provider", provider.Config().ID).WithField("subject", claims.Subject).Debug("Received successful OpenID Connect callback but user is not registered. Re-initializing registration flow now.")
 
 			// This flow only works for browsers anyways.
 			// Create a fake request to start the registraton flow.
-			rr, _ := http.NewRequestWithContext(r.Context(), "GET", "/self-service/registration/browser", nil)
+			rr, err := http.NewRequestWithContext(r.Context(), "GET", "/self-service/registration/browser", nil)
+			if err != nil {
+				return nil, s.handleError(w, r, a, provider.Config().ID, nil, errors.WithStack(err))
+			}
+
 			q := rr.URL.Query()
 			q.Add("return_to", a.ReturnTo)
 			rr.URL.RawQuery = q.Encode()

--- a/selfservice/strategy/oidc/strategy_login.go
+++ b/selfservice/strategy/oidc/strategy_login.go
@@ -89,7 +89,12 @@ func (s *Strategy) processLogin(w http.ResponseWriter, r *http.Request, a *login
 			s.d.Logger().WithField("provider", provider.Config().ID).WithField("subject", claims.Subject).Debug("Received successful OpenID Connect callback but user is not registered. Re-initializing registration flow now.")
 
 			// This flow only works for browsers anyways.
-			aa, err := s.d.RegistrationHandler().NewRegistrationFlow(w, r, flow.TypeBrowser)
+			// Create a fake request to start the registraton flow.
+			rr, _ := http.NewRequestWithContext(r.Context(), "GET", "/self-service/registration/browser", nil)
+			q := rr.URL.Query()
+			q.Add("return_to", a.ReturnTo)
+			rr.URL.RawQuery = q.Encode()
+			aa, err := s.d.RegistrationHandler().NewRegistrationFlow(w, rr, flow.TypeBrowser)
 			if err != nil {
 				return nil, s.handleError(w, r, a, provider.Config().ID, nil, err)
 			}

--- a/selfservice/strategy/oidc/strategy_registration.go
+++ b/selfservice/strategy/oidc/strategy_registration.go
@@ -179,7 +179,7 @@ func (s *Strategy) processRegistration(w http.ResponseWriter, r *http.Request, a
 
 		// If return_to was set before, we need to preserve it.
 		var opts []login.FlowOption
-		if a.ReturnTo != "" {
+		if len(a.ReturnTo) > 0 {
 			opts = append(opts, login.WithFlowReturnTo(a.ReturnTo))
 		}
 

--- a/selfservice/strategy/oidc/strategy_registration.go
+++ b/selfservice/strategy/oidc/strategy_registration.go
@@ -177,8 +177,14 @@ func (s *Strategy) processRegistration(w http.ResponseWriter, r *http.Request, a
 			WithField("subject", claims.Subject).
 			Debug("Received successful OpenID Connect callback but user is already registered. Re-initializing login flow now.")
 
+		// If return_to was set before, we need to preserve it.
+		var opts []login.FlowOption
+		if a.ReturnTo != "" {
+			opts = append(opts, login.WithFlowReturnTo(a.ReturnTo))
+		}
+
 		// This endpoint only handles browser flow at the moment.
-		ar, err := s.d.LoginHandler().NewLoginFlow(w, r, flow.TypeBrowser)
+		ar, err := s.d.LoginHandler().NewLoginFlow(w, r, flow.TypeBrowser, opts...)
 		if err != nil {
 			return nil, s.handleError(w, r, a, provider.Config().ID, nil, err)
 		}

--- a/selfservice/strategy/oidc/strategy_test.go
+++ b/selfservice/strategy/oidc/strategy_test.go
@@ -399,6 +399,15 @@ func TestStrategy(t *testing.T) {
 			res, body := makeRequest(t, "valid", action, url.Values{})
 			ai(t, res, body)
 		})
+
+		t.Run("case=should pass third time registration with return to", func(t *testing.T) {
+			returnTo := "/foo"
+			r := newLoginFlow(t, fmt.Sprintf("%s?return_to=%s", returnTS.URL, returnTo), time.Minute)
+			action := afv(t, r.ID, "valid")
+			res, body := makeRequest(t, "valid", action, url.Values{})
+			assert.True(t, strings.HasSuffix(res.Request.URL.String(), returnTo))
+			ai(t, res, body)
+		})
 	})
 
 	t.Run("case=register, merge, and complete data", func(t *testing.T) {

--- a/selfservice/strategy/oidc/strategy_test.go
+++ b/selfservice/strategy/oidc/strategy_test.go
@@ -58,9 +58,9 @@ func TestStrategy(t *testing.T) {
 		claims    idTokenClaims
 		scope     []string
 	)
-
 	remoteAdmin, remotePublic, hydraIntegrationTSURL := newHydra(t, &subject, &claims, &scope)
 	returnTS := newReturnTs(t, reg)
+	conf.MustSet(config.ViperKeyURLsAllowedReturnToDomains, []string{returnTS.URL})
 	uiTS := newUI(t, reg)
 	errTS := testhelpers.NewErrorTestServer(t, reg)
 	routerP := x.NewRouterPublic()
@@ -364,6 +364,20 @@ func TestStrategy(t *testing.T) {
 			r := newLoginFlow(t, returnTS.URL, time.Minute)
 			action := afv(t, r.ID, "valid")
 			res, body := makeRequest(t, "valid", action, url.Values{})
+			ai(t, res, body)
+		})
+	})
+
+	t.Run("case=login without registered account with return_to", func(t *testing.T) {
+		subject = "login-without-register-return-to@ory.sh"
+		scope = []string{"openid"}
+		returnTo := "/foo"
+
+		t.Run("case=should pass login", func(t *testing.T) {
+			r := newLoginFlow(t, fmt.Sprintf("%s?return_to=%s", returnTS.URL, returnTo), time.Minute)
+			action := afv(t, r.ID, "valid")
+			res, body := makeRequest(t, "valid", action, url.Values{})
+			assert.True(t, strings.HasSuffix(res.Request.URL.String(), returnTo))
 			ai(t, res, body)
 		})
 	})

--- a/x/http_secure_redirect.go
+++ b/x/http_secure_redirect.go
@@ -89,15 +89,18 @@ func SecureRedirectTo(r *http.Request, defaultReturnTo *url.URL, opts ...SecureR
 	if o.sourceURL != "" {
 		source, err = url.ParseRequestURI(o.sourceURL)
 		if err != nil {
-			return nil, herodot.ErrInternalServerError.WithWrap(err).WithReasonf("Unable to parse the original request URL: %s", err)
+			return nil, errors.WithStack(herodot.ErrInternalServerError.WithWrap(err).WithReasonf("Unable to parse the original request URL: %s", err))
 		}
 	}
 
 	rawReturnTo := stringsx.Coalesce(o.returnTo, source.Query().Get("return_to"))
 	if rawReturnTo == "" {
 		return o.defaultReturnTo, nil
-	} else if returnTo, err = url.Parse(rawReturnTo); err != nil {
-		return nil, herodot.ErrInternalServerError.WithWrap(err).WithReasonf("Unable to parse the return_to query parameter as an URL: %s", err)
+	}
+
+	returnTo, err = url.Parse(rawReturnTo)
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithWrap(err).WithReasonf("Unable to parse the return_to query parameter as an URL: %s", err))
 	}
 
 	returnTo.Host = stringsx.Coalesce(returnTo.Host, o.defaultReturnTo.Host)

--- a/x/http_secure_redirect.go
+++ b/x/http_secure_redirect.go
@@ -20,6 +20,7 @@ import (
 type secureRedirectOptions struct {
 	allowlist       []url.URL
 	defaultReturnTo *url.URL
+	returnTo        string
 	sourceURL       string
 }
 
@@ -37,6 +38,13 @@ func SecureRedirectAllowURLs(urls []url.URL) SecureRedirectOption {
 func SecureRedirectUseSourceURL(source string) SecureRedirectOption {
 	return func(o *secureRedirectOptions) {
 		o.sourceURL = source
+	}
+}
+
+// SecureRedirectReturnTo uses the provided URL to redirect the user to it.
+func SecureRedirectReturnTo(returnTo string) SecureRedirectOption {
+	return func(o *secureRedirectOptions) {
+		o.returnTo = returnTo
 	}
 }
 
@@ -85,9 +93,10 @@ func SecureRedirectTo(r *http.Request, defaultReturnTo *url.URL, opts ...SecureR
 		}
 	}
 
-	if len(source.Query().Get("return_to")) == 0 {
+	rawReturnTo := stringsx.Coalesce(o.returnTo, source.Query().Get("return_to"))
+	if rawReturnTo == "" {
 		return o.defaultReturnTo, nil
-	} else if returnTo, err = url.Parse(source.Query().Get("return_to")); err != nil {
+	} else if returnTo, err = url.Parse(rawReturnTo); err != nil {
 		return nil, herodot.ErrInternalServerError.WithWrap(err).WithReasonf("Unable to parse the return_to query parameter as an URL: %s", err)
 	}
 


### PR DESCRIPTION
When handling the callback from the oidc provider and starting a new registration flow to sign up the user we create a new temp request that contains the initial request parameters from the login flow.

## Related issue(s)

Proposal to close https://github.com/ory/kratos/issues/2444.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments