### PR TITLE
add phone verification through SMS using magic link

### DIFF
--- a/courier/sms.go
+++ b/courier/sms.go
@@ -3,6 +3,7 @@ package courier
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -106,8 +107,15 @@ func (c *courier) dispatchSMS(ctx context.Context, msg Message) error {
 	case http.StatusOK:
 	case http.StatusCreated:
 	default:
+		errMsg, err := io.ReadAll(res.Body)
+		if err != nil {
+			return err
+		}
+		c.deps.Logger().
+			WithField("message_id", msg.ID).
+			WithField("error_message", string(errMsg)).
+			Error(`Unable to send SMS.`)
 		return errors.New(http.StatusText(res.StatusCode))
 	}
-
 	return nil
 }

--- a/courier/sms_templates.go
+++ b/courier/sms_templates.go
@@ -21,6 +21,8 @@ func SMSTemplateType(t SMSTemplate) (TemplateType, error) {
 		return TypeOTP, nil
 	case *sms.TestStub:
 		return TypeTestStub, nil
+	case *sms.VerificationMessage:
+		return TypeVerificationValid, nil
 	default:
 		return "", errors.Errorf("unexpected template type")
 	}
@@ -40,6 +42,12 @@ func NewSMSTemplateFromMessage(d Dependencies, m Message) (SMSTemplate, error) {
 			return nil, err
 		}
 		return sms.NewTestStub(d, &t), nil
+	case TypeVerificationValid:
+		var t sms.VerificationMessageModel
+		if err := json.Unmarshal(m.TemplateData, &t); err != nil {
+			return nil, err
+		}
+		return sms.NewVerificationMessage(d, &t), nil
 	default:
 		return nil, errors.Errorf("received unexpected message template type: %s", m.TemplateType)
 	}

--- a/courier/sms_templates_test.go
+++ b/courier/sms_templates_test.go
@@ -15,8 +15,9 @@ import (
 
 func TestSMSTemplateType(t *testing.T) {
 	for expectedType, tmpl := range map[courier.TemplateType]courier.SMSTemplate{
-		courier.TypeOTP:      &sms.OTPMessage{},
-		courier.TypeTestStub: &sms.TestStub{},
+		courier.TypeOTP:               &sms.OTPMessage{},
+		courier.TypeTestStub:          &sms.TestStub{},
+		courier.TypeVerificationValid: &sms.VerificationMessage{},
 	} {
 		t.Run(fmt.Sprintf("case=%s", expectedType), func(t *testing.T) {
 			actualType, err := courier.SMSTemplateType(tmpl)
@@ -31,8 +32,9 @@ func TestNewSMSTemplateFromMessage(t *testing.T) {
 	ctx := context.Background()
 
 	for tmplType, expectedTmpl := range map[courier.TemplateType]courier.SMSTemplate{
-		courier.TypeOTP:      sms.NewOTPMessage(reg, &sms.OTPMessageModel{To: "+12345678901"}),
-		courier.TypeTestStub: sms.NewTestStub(reg, &sms.TestStubModel{To: "+12345678901", Body: "test body"}),
+		courier.TypeOTP:               sms.NewOTPMessage(reg, &sms.OTPMessageModel{To: "+12345678901"}),
+		courier.TypeTestStub:          sms.NewTestStub(reg, &sms.TestStubModel{To: "+12345678901", Body: "test body"}),
+		courier.TypeVerificationValid: sms.NewVerificationMessage(reg, &sms.VerificationMessageModel{To: "+12345678901", VerificationURL: "http://bar.foo"}),
 	} {
 		t.Run(fmt.Sprintf("case=%s", tmplType), func(t *testing.T) {
 			tmplData, err := json.Marshal(expectedTmpl)

--- a/courier/stub/request.config.twilio.jsonnet
+++ b/courier/stub/request.config.twilio.jsonnet
@@ -1,5 +1,5 @@
 function(ctx) {
-  from: ctx.from,
-  to: ctx.to,
-  body: ctx.body
+  From: ctx.from,
+  To: ctx.to,
+  Body: ctx.body
 }

--- a/courier/template/courier/builtin/templates/verification/valid/sms.body.gotmpl
+++ b/courier/template/courier/builtin/templates/verification/valid/sms.body.gotmpl
@@ -1,0 +1,3 @@
+Hi, please verify your account by clicking the following link:
+
+{{ .VerificationURL }}

--- a/courier/template/sms/verification.go
+++ b/courier/template/sms/verification.go
@@ -1,0 +1,37 @@
+package sms
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+
+	"github.com/ory/kratos/courier/template"
+)
+
+type (
+	VerificationMessage struct {
+		d template.Dependencies
+		m *VerificationMessageModel
+	}
+	VerificationMessageModel struct {
+		To              string
+		VerificationURL string
+		Identity        map[string]interface{}
+	}
+)
+
+func NewVerificationMessage(d template.Dependencies, m *VerificationMessageModel) *VerificationMessage {
+	return &VerificationMessage{d: d, m: m}
+}
+
+func (t *VerificationMessage) PhoneNumber() (string, error) {
+	return t.m.To, nil
+}
+
+func (t *VerificationMessage) SMSBody(ctx context.Context) (string, error) {
+	return template.LoadText(ctx, t.d, os.DirFS(t.d.CourierConfig(ctx).CourierTemplatesRoot()), "verification/valid/sms.body.gotmpl", "verification/valid/sms.body*", t.m, t.d.CourierConfig(ctx).CourierTemplatesVerificationValid().Body.PlainText)
+}
+
+func (t *VerificationMessage) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.m)
+}

--- a/courier/template/sms/verification_test.go
+++ b/courier/template/sms/verification_test.go
@@ -1,0 +1,34 @@
+package sms_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ory/kratos/courier/template/sms"
+	"github.com/ory/kratos/internal"
+)
+
+func TestNewVerificationMessage(t *testing.T) {
+	_, reg := internal.NewFastRegistryWithMocks(t)
+
+	const (
+		expectedPhone           = "+12345678901"
+		expectedVerificationURL = "http://bar.foo"
+	)
+
+	tpl := sms.NewVerificationMessage(reg, &sms.VerificationMessageModel{To: expectedPhone, VerificationURL: expectedVerificationURL})
+
+	expectedBody := fmt.Sprintf("Hi, please verify your account by clicking the following link:\n\n%s\n", expectedVerificationURL)
+
+	actualBody, err := tpl.SMSBody(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, expectedBody, actualBody)
+
+	actualPhone, err := tpl.PhoneNumber()
+	require.NoError(t, err)
+	assert.Equal(t, expectedPhone, actualPhone)
+}

--- a/selfservice/strategy/link/sender.go
+++ b/selfservice/strategy/link/sender.go
@@ -109,10 +109,11 @@ func (s *Sender) SendVerificationLink(ctx context.Context, f *verification.Flow,
 				WithField("via", via).
 				WithSensitiveField("email_address", address).
 				Info("Sending out invalid verification email because address is unknown.")
-			if err := s.send(ctx, email.NewVerificationInvalid(s.r, &email.VerificationInvalidModel{To: to})); err != nil {
-				return err
+			if identity.AddressTypeEmail == via {
+				if err := s.send(ctx, email.NewVerificationInvalid(s.r, &email.VerificationInvalidModel{To: to})); err != nil {
+					return err
+				}
 			}
-
 			return errors.Cause(ErrUnknownAddress)
 		}
 		return err

--- a/selfservice/strategy/link/stub/phone.schema.json
+++ b/selfservice/strategy/link/stub/phone.schema.json
@@ -1,0 +1,28 @@
+{
+  "$id": "https://example.com/person.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Person",
+  "type": "object",
+  "properties": {
+    "traits": {
+      "type": "object",
+      "properties": {
+        "phone": {
+          "title": "Phone",
+          "type": "string",
+          "format": "tel",
+          "ory.sh/kratos": {
+            "credentials": {
+              "password": {
+                "identifier": true
+              }
+            },
+            "verification": {
+              "via": "phone"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Related issue(s)

We can have a phone number verified (see commit 294dfa85b4552b9266c44bb3376b8610c1ff5521) but we need to be able to send a verification message through SMS to verify the phone number.

The code was only supporting email courier and failed to process sms with  `received unexpected via type: phone` error

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

This PR modify the link sender so we can send a magic link through SMS to verify a phone number.  The magic link is the same mechanism used to verify an email.

This PR also fix an issue with provided Twilio template which did not work.
