### PR TITLE
Shorten the CI badge label

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: CI Tasks for Ory Kratos
+name: CI
 on:
   push:
     branches:


### PR DESCRIPTION
The label for the CI badge currently reads "CI Tasks for Ory Kratos", resulting in this long badge:

![image](https://user-images.githubusercontent.com/268934/172947755-31da6058-2789-4798-9a49-d621c8564468.png)

This PR shortens the badge label to "CI".

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I am following the [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security.
      vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the
      maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).
