### PR TITLE
docs: write messages as single json document

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,15 @@ Some tests use fixtures. If payloads change, you can update them with:
 make test-update-snapshots
 ```
 
+This will only update the snapshots of the short tests. To update all snapshots,
+run:
+
+```bash
+UPDATE_SNAPSHOTS=true go test -p 4 -tags sqlite ./...
+```
+
+You can also run this command from a sub folder.
+
 ##### End-to-End Tests
 
 We use [Cypress](https://www.cypress.io) to run our e2e tests.

--- a/cmd/clidoc/main.go
+++ b/cmd/clidoc/main.go
@@ -136,8 +136,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := writeMessages(filepath.Join(os.Args[2], "concepts/ui-user-interface.mdx")); err != nil {
+	sortedMessages := sortMessages()
+
+	if err := writeMessages(filepath.Join(os.Args[2], "concepts/ui-user-interface.mdx"), sortedMessages); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Unable to generate message table: %+v\n", err)
+		os.Exit(1)
+	}
+
+	if err := writeMessagesJson(filepath.Join(os.Args[2], "concepts/messages.json"), sortedMessages); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Unable to generate messages.json: %+v\n", err)
 		os.Exit(1)
 	}
 
@@ -154,12 +161,7 @@ func codeEncode(in interface{}) string {
 	return string(out)
 }
 
-func writeMessages(path string) error {
-	content, err := os.ReadFile(path)
-	if err != nil {
-		return err
-	}
-
+func sortMessages() []*text.Message {
 	var toSort []*text.Message
 	for _, m := range messages {
 		toSort = append(toSort, m)
@@ -172,11 +174,45 @@ func writeMessages(path string) error {
 		return toSort[i].ID < toSort[j].ID
 	})
 
+	return toSort
+}
+
+func writeMessages(path string, sortedMessages []*text.Message) error {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
 	var w bytes.Buffer
-	w.WriteString("\n\n```json\n" + codeEncode(toSort) + "\n```")
+	for _, m := range sortedMessages {
+		w.WriteString(fmt.Sprintf(`###### %s (%d)
+
+%s
+
+`, m.Text, m.ID, "```json\n"+codeEncode(m)+"\n```"))
+	}
 
 	r := regexp.MustCompile(`(?s)<!-- START MESSAGE TABLE -->(.*?)<!-- END MESSAGE TABLE -->`)
 	result := r.ReplaceAllString(string(content), "<!-- START MESSAGE TABLE -->\n"+w.String()+"\n<!-- END MESSAGE TABLE -->")
+
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
+	if err != nil {
+		return err
+	}
+
+	if _, err := f.WriteString(result); err != nil {
+		return err
+	}
+
+	if err := f.Close(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func writeMessagesJson(path string, sortedMessages []*text.Message) error {
+	result := codeEncode(sortedMessages)
 
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
 	if err != nil {

--- a/cmd/clidoc/main.go
+++ b/cmd/clidoc/main.go
@@ -173,13 +173,7 @@ func writeMessages(path string) error {
 	})
 
 	var w bytes.Buffer
-	for _, m := range toSort {
-		w.WriteString(fmt.Sprintf(`###### %s (%d)
-
-%s
-
-`, m.Text, m.ID, "```json\n"+codeEncode(m)+"\n```"))
-	}
+	w.WriteString("\n\n```json\n" + codeEncode(toSort) + "\n```")
 
 	r := regexp.MustCompile(`(?s)<!-- START MESSAGE TABLE -->(.*?)<!-- END MESSAGE TABLE -->`)
 	result := r.ReplaceAllString(string(content), "<!-- START MESSAGE TABLE -->\n"+w.String()+"\n<!-- END MESSAGE TABLE -->")


### PR DESCRIPTION
This changes the message list on the [Customize User Interface](https://www.ory.sh/docs/kratos/concepts/ui-user-interface#ui-message-codes) page to be rendered as a single JSON block, so that it's easier to copy and paste when dealing with translations.

I removed the original rendering with the headers for each message, since it felt weird to put both renderings underneath each other, and the headers didn't seem very useful anyway. If you disagree, I can bring them back, just let me know.

resolves #2498 

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I am following the [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security.
      vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the
      maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added or changed [the documentation](https://github.com/ory/docs).
