### PR TITLE
improvement: add autocomplete attributes

### DIFF
--- a/internal/httpclient/api/openapi.yaml
+++ b/internal/httpclient/api/openapi.yaml
@@ -5251,6 +5251,16 @@ components:
     uiNodeInputAttributes:
       description: InputAttributes represents the attributes of an input node
       properties:
+        autocomplete:
+          description: The autocomplete attribute for the input.
+          enum:
+          - email
+          - tel
+          - url
+          - current-password
+          - new-password
+          - one-time-code
+          type: string
         disabled:
           description: Sets the input's disabled field to true or false.
           type: boolean

--- a/internal/httpclient/docs/UiNodeAttributes.md
+++ b/internal/httpclient/docs/UiNodeAttributes.md
@@ -4,6 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**Autocomplete** | Pointer to **string** | The autocomplete attribute for the input. | [optional] 
 **Disabled** | **bool** | Sets the input&#39;s disabled field to true or false. | 
 **Label** | Pointer to [**UiText**](UiText.md) |  | [optional] 
 **Name** | **string** | The input&#39;s element name. | 
@@ -44,6 +45,31 @@ will change when the set of required properties is changed
 NewUiNodeAttributesWithDefaults instantiates a new UiNodeAttributes object
 This constructor will only assign default values to properties that have it defined,
 but it doesn't guarantee that properties required by API are set
+
+### GetAutocomplete
+
+`func (o *UiNodeAttributes) GetAutocomplete() string`
+
+GetAutocomplete returns the Autocomplete field if non-nil, zero value otherwise.
+
+### GetAutocompleteOk
+
+`func (o *UiNodeAttributes) GetAutocompleteOk() (*string, bool)`
+
+GetAutocompleteOk returns a tuple with the Autocomplete field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetAutocomplete
+
+`func (o *UiNodeAttributes) SetAutocomplete(v string)`
+
+SetAutocomplete sets Autocomplete field to given value.
+
+### HasAutocomplete
+
+`func (o *UiNodeAttributes) HasAutocomplete() bool`
+
+HasAutocomplete returns a boolean if a field has been set.
 
 ### GetDisabled
 

--- a/internal/httpclient/docs/UiNodeInputAttributes.md
+++ b/internal/httpclient/docs/UiNodeInputAttributes.md
@@ -4,6 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**Autocomplete** | Pointer to **string** | The autocomplete attribute for the input. | [optional] 
 **Disabled** | **bool** | Sets the input&#39;s disabled field to true or false. | 
 **Label** | Pointer to [**UiText**](UiText.md) |  | [optional] 
 **Name** | **string** | The input&#39;s element name. | 
@@ -32,6 +33,31 @@ will change when the set of required properties is changed
 NewUiNodeInputAttributesWithDefaults instantiates a new UiNodeInputAttributes object
 This constructor will only assign default values to properties that have it defined,
 but it doesn't guarantee that properties required by API are set
+
+### GetAutocomplete
+
+`func (o *UiNodeInputAttributes) GetAutocomplete() string`
+
+GetAutocomplete returns the Autocomplete field if non-nil, zero value otherwise.
+
+### GetAutocompleteOk
+
+`func (o *UiNodeInputAttributes) GetAutocompleteOk() (*string, bool)`
+
+GetAutocompleteOk returns a tuple with the Autocomplete field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetAutocomplete
+
+`func (o *UiNodeInputAttributes) SetAutocomplete(v string)`
+
+SetAutocomplete sets Autocomplete field to given value.
+
+### HasAutocomplete
+
+`func (o *UiNodeInputAttributes) HasAutocomplete() bool`
+
+HasAutocomplete returns a boolean if a field has been set.
 
 ### GetDisabled
 

--- a/internal/httpclient/model_ui_node_input_attributes.go
+++ b/internal/httpclient/model_ui_node_input_attributes.go
@@ -17,6 +17,8 @@ import (
 
 // UiNodeInputAttributes InputAttributes represents the attributes of an input node
 type UiNodeInputAttributes struct {
+	// The autocomplete attribute for the input.
+	Autocomplete *string `json:"autocomplete,omitempty"`
 	// Sets the input's disabled field to true or false.
 	Disabled bool    `json:"disabled"`
 	Label    *UiText `json:"label,omitempty"`
@@ -54,6 +56,38 @@ func NewUiNodeInputAttributes(disabled bool, name string, nodeType string, type_
 func NewUiNodeInputAttributesWithDefaults() *UiNodeInputAttributes {
 	this := UiNodeInputAttributes{}
 	return &this
+}
+
+// GetAutocomplete returns the Autocomplete field value if set, zero value otherwise.
+func (o *UiNodeInputAttributes) GetAutocomplete() string {
+	if o == nil || o.Autocomplete == nil {
+		var ret string
+		return ret
+	}
+	return *o.Autocomplete
+}
+
+// GetAutocompleteOk returns a tuple with the Autocomplete field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *UiNodeInputAttributes) GetAutocompleteOk() (*string, bool) {
+	if o == nil || o.Autocomplete == nil {
+		return nil, false
+	}
+	return o.Autocomplete, true
+}
+
+// HasAutocomplete returns a boolean if a field has been set.
+func (o *UiNodeInputAttributes) HasAutocomplete() bool {
+	if o != nil && o.Autocomplete != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetAutocomplete gets a reference to the given string and assigns it to the Autocomplete field.
+func (o *UiNodeInputAttributes) SetAutocomplete(v string) {
+	o.Autocomplete = &v
 }
 
 // GetDisabled returns the Disabled field value
@@ -315,6 +349,9 @@ func (o *UiNodeInputAttributes) SetValue(v interface{}) {
 
 func (o UiNodeInputAttributes) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
+	if o.Autocomplete != nil {
+		toSerialize["autocomplete"] = o.Autocomplete
+	}
 	if true {
 		toSerialize["disabled"] = o.Disabled
 	}

--- a/selfservice/strategy/oidc/.snapshots/TestSettingsStrategy-case=should_adjust_linkable_providers_based_on_linked_credentials-agent=githuber.json
+++ b/selfservice/strategy/oidc/.snapshots/TestSettingsStrategy-case=should_adjust_linkable_providers_based_on_linked_credentials-agent=githuber.json
@@ -14,6 +14,7 @@
   },
   {
     "attributes": {
+      "autocomplete": "email",
       "disabled": false,
       "name": "traits.email",
       "node_type": "input",
@@ -58,6 +59,7 @@
   },
   {
     "attributes": {
+      "autocomplete": "new-password",
       "disabled": false,
       "name": "password",
       "node_type": "input",

--- a/selfservice/strategy/oidc/.snapshots/TestSettingsStrategy-case=should_adjust_linkable_providers_based_on_linked_credentials-agent=multiuser.json
+++ b/selfservice/strategy/oidc/.snapshots/TestSettingsStrategy-case=should_adjust_linkable_providers_based_on_linked_credentials-agent=multiuser.json
@@ -14,6 +14,7 @@
   },
   {
     "attributes": {
+      "autocomplete": "email",
       "disabled": false,
       "name": "traits.email",
       "node_type": "input",
@@ -58,6 +59,7 @@
   },
   {
     "attributes": {
+      "autocomplete": "new-password",
       "disabled": false,
       "name": "password",
       "node_type": "input",

--- a/selfservice/strategy/oidc/.snapshots/TestSettingsStrategy-case=should_adjust_linkable_providers_based_on_linked_credentials-agent=oryer.json
+++ b/selfservice/strategy/oidc/.snapshots/TestSettingsStrategy-case=should_adjust_linkable_providers_based_on_linked_credentials-agent=oryer.json
@@ -14,6 +14,7 @@
   },
   {
     "attributes": {
+      "autocomplete": "email",
       "disabled": false,
       "name": "traits.email",
       "node_type": "input",
@@ -58,6 +59,7 @@
   },
   {
     "attributes": {
+      "autocomplete": "new-password",
       "disabled": false,
       "name": "password",
       "node_type": "input",

--- a/selfservice/strategy/oidc/.snapshots/TestSettingsStrategy-case=should_adjust_linkable_providers_based_on_linked_credentials-agent=password.json
+++ b/selfservice/strategy/oidc/.snapshots/TestSettingsStrategy-case=should_adjust_linkable_providers_based_on_linked_credentials-agent=password.json
@@ -14,6 +14,7 @@
   },
   {
     "attributes": {
+      "autocomplete": "email",
       "disabled": false,
       "name": "traits.email",
       "node_type": "input",
@@ -58,6 +59,7 @@
   },
   {
     "attributes": {
+      "autocomplete": "new-password",
       "disabled": false,
       "name": "password",
       "node_type": "input",

--- a/selfservice/strategy/oidc/.snapshots/TestSettingsStrategy-suite=link-case=should_link_a_connection-flow=fetch.json
+++ b/selfservice/strategy/oidc/.snapshots/TestSettingsStrategy-suite=link-case=should_link_a_connection-flow=fetch.json
@@ -14,6 +14,7 @@
   },
   {
     "attributes": {
+      "autocomplete": "email",
       "disabled": false,
       "name": "traits.email",
       "node_type": "input",
@@ -58,6 +59,7 @@
   },
   {
     "attributes": {
+      "autocomplete": "new-password",
       "disabled": false,
       "name": "password",
       "node_type": "input",

--- a/selfservice/strategy/oidc/.snapshots/TestSettingsStrategy-suite=link-case=should_link_a_connection-flow=original.json
+++ b/selfservice/strategy/oidc/.snapshots/TestSettingsStrategy-suite=link-case=should_link_a_connection-flow=original.json
@@ -14,6 +14,7 @@
   },
   {
     "attributes": {
+      "autocomplete": "email",
       "disabled": false,
       "name": "traits.email",
       "node_type": "input",
@@ -58,6 +59,7 @@
   },
   {
     "attributes": {
+      "autocomplete": "new-password",
       "disabled": false,
       "name": "password",
       "node_type": "input",

--- a/selfservice/strategy/oidc/.snapshots/TestSettingsStrategy-suite=link-case=should_link_a_connection-flow=response.json
+++ b/selfservice/strategy/oidc/.snapshots/TestSettingsStrategy-suite=link-case=should_link_a_connection-flow=response.json
@@ -19,6 +19,7 @@
       "name": "traits.email",
       "type": "email",
       "required": true,
+      "autocomplete": "email",
       "disabled": false,
       "node_type": "input"
     },
@@ -63,6 +64,7 @@
       "name": "password",
       "type": "password",
       "required": true,
+      "autocomplete": "new-password",
       "disabled": false,
       "node_type": "input"
     },

--- a/selfservice/strategy/oidc/.snapshots/TestSettingsStrategy-suite=link-case=should_link_a_connection_even_if_user_does_not_have_oidc_credentials_yet.json
+++ b/selfservice/strategy/oidc/.snapshots/TestSettingsStrategy-suite=link-case=should_link_a_connection_even_if_user_does_not_have_oidc_credentials_yet.json
@@ -14,6 +14,7 @@
   },
   {
     "attributes": {
+      "autocomplete": "email",
       "disabled": false,
       "name": "traits.email",
       "node_type": "input",
@@ -58,6 +59,7 @@
   },
   {
     "attributes": {
+      "autocomplete": "new-password",
       "disabled": false,
       "name": "password",
       "node_type": "input",

--- a/selfservice/strategy/oidc/.snapshots/TestSettingsStrategy-suite=link-case=should_not_be_able_to_link_a_connection_which_already_exists.json
+++ b/selfservice/strategy/oidc/.snapshots/TestSettingsStrategy-suite=link-case=should_not_be_able_to_link_a_connection_which_already_exists.json
@@ -19,6 +19,7 @@
       "name": "traits.email",
       "type": "email",
       "required": true,
+      "autocomplete": "email",
       "disabled": false,
       "node_type": "input"
     },
@@ -63,6 +64,7 @@
       "name": "password",
       "type": "password",
       "required": true,
+      "autocomplete": "new-password",
       "disabled": false,
       "node_type": "input"
     },

--- a/selfservice/strategy/oidc/.snapshots/TestSettingsStrategy-suite=link-case=should_not_be_able_to_link_an_non-existing_connection.json
+++ b/selfservice/strategy/oidc/.snapshots/TestSettingsStrategy-suite=link-case=should_not_be_able_to_link_an_non-existing_connection.json
@@ -19,6 +19,7 @@
       "name": "traits.email",
       "type": "email",
       "required": true,
+      "autocomplete": "email",
       "disabled": false,
       "node_type": "input"
     },
@@ -63,6 +64,7 @@
       "name": "password",
       "type": "password",
       "required": true,
+      "autocomplete": "new-password",
       "disabled": false,
       "node_type": "input"
     },

--- a/selfservice/strategy/oidc/.snapshots/TestSettingsStrategy-suite=unlink-case=should_not_be_able_to_unlink_a_connection_not_yet_linked-flow=fetch.json
+++ b/selfservice/strategy/oidc/.snapshots/TestSettingsStrategy-suite=unlink-case=should_not_be_able_to_unlink_a_connection_not_yet_linked-flow=fetch.json
@@ -14,6 +14,7 @@
   },
   {
     "attributes": {
+      "autocomplete": "email",
       "disabled": false,
       "name": "traits.email",
       "node_type": "input",
@@ -58,6 +59,7 @@
   },
   {
     "attributes": {
+      "autocomplete": "new-password",
       "disabled": false,
       "name": "password",
       "node_type": "input",

--- a/selfservice/strategy/oidc/.snapshots/TestSettingsStrategy-suite=unlink-case=should_not_be_able_to_unlink_a_connection_not_yet_linked-flow=json.json
+++ b/selfservice/strategy/oidc/.snapshots/TestSettingsStrategy-suite=unlink-case=should_not_be_able_to_unlink_a_connection_not_yet_linked-flow=json.json
@@ -19,6 +19,7 @@
       "name": "traits.email",
       "type": "email",
       "required": true,
+      "autocomplete": "email",
       "disabled": false,
       "node_type": "input"
     },
@@ -63,6 +64,7 @@
       "name": "password",
       "type": "password",
       "required": true,
+      "autocomplete": "new-password",
       "disabled": false,
       "node_type": "input"
     },

--- a/selfservice/strategy/oidc/.snapshots/TestSettingsStrategy-suite=unlink-case=should_not_be_able_to_unlink_an_non-existing_connection-flow=fetch.json
+++ b/selfservice/strategy/oidc/.snapshots/TestSettingsStrategy-suite=unlink-case=should_not_be_able_to_unlink_an_non-existing_connection-flow=fetch.json
@@ -14,6 +14,7 @@
   },
   {
     "attributes": {
+      "autocomplete": "email",
       "disabled": false,
       "name": "traits.email",
       "node_type": "input",
@@ -58,6 +59,7 @@
   },
   {
     "attributes": {
+      "autocomplete": "new-password",
       "disabled": false,
       "name": "password",
       "node_type": "input",

--- a/selfservice/strategy/oidc/.snapshots/TestSettingsStrategy-suite=unlink-case=should_not_be_able_to_unlink_an_non-existing_connection-flow=json.json
+++ b/selfservice/strategy/oidc/.snapshots/TestSettingsStrategy-suite=unlink-case=should_not_be_able_to_unlink_an_non-existing_connection-flow=json.json
@@ -19,6 +19,7 @@
       "name": "traits.email",
       "type": "email",
       "required": true,
+      "autocomplete": "email",
       "disabled": false,
       "node_type": "input"
     },
@@ -63,6 +64,7 @@
       "name": "password",
       "type": "password",
       "required": true,
+      "autocomplete": "new-password",
       "disabled": false,
       "node_type": "input"
     },

--- a/selfservice/strategy/oidc/.snapshots/TestSettingsStrategy-suite=unlink-case=should_not_be_able_to_unlink_the_last_remaining_connection-flow=fetch.json
+++ b/selfservice/strategy/oidc/.snapshots/TestSettingsStrategy-suite=unlink-case=should_not_be_able_to_unlink_the_last_remaining_connection-flow=fetch.json
@@ -14,6 +14,7 @@
   },
   {
     "attributes": {
+      "autocomplete": "email",
       "disabled": false,
       "name": "traits.email",
       "node_type": "input",
@@ -58,6 +59,7 @@
   },
   {
     "attributes": {
+      "autocomplete": "new-password",
       "disabled": false,
       "name": "password",
       "node_type": "input",

--- a/selfservice/strategy/oidc/.snapshots/TestSettingsStrategy-suite=unlink-case=should_not_be_able_to_unlink_the_last_remaining_connection-flow=json.json
+++ b/selfservice/strategy/oidc/.snapshots/TestSettingsStrategy-suite=unlink-case=should_not_be_able_to_unlink_the_last_remaining_connection-flow=json.json
@@ -19,6 +19,7 @@
       "name": "traits.email",
       "type": "email",
       "required": true,
+      "autocomplete": "email",
       "disabled": false,
       "node_type": "input"
     },
@@ -63,6 +64,7 @@
       "name": "password",
       "type": "password",
       "required": true,
+      "autocomplete": "new-password",
       "disabled": false,
       "node_type": "input"
     },

--- a/selfservice/strategy/password/login.go
+++ b/selfservice/strategy/password/login.go
@@ -150,7 +150,7 @@ func (s *Strategy) PopulateLoginMethod(r *http.Request, requestedAAL identity.Au
 	}
 
 	sr.UI.SetCSRF(s.d.GenerateCSRFToken(r))
-	sr.UI.SetNode(NewPasswordNode("password"))
+	sr.UI.SetNode(NewPasswordNode("password", node.InputAttributeAutocompleteCurrentPassword))
 	sr.UI.GetNodes().Append(node.NewInputField("method", "password", node.PasswordGroup, node.InputAttributeTypeSubmit).WithMetaLabel(text.NewInfoLogin()))
 
 	return nil

--- a/selfservice/strategy/password/nodes.go
+++ b/selfservice/strategy/password/nodes.go
@@ -5,9 +5,12 @@ import (
 	"github.com/ory/kratos/ui/node"
 )
 
-func NewPasswordNode(name string) *node.Node {
+func NewPasswordNode(name string, autocomplete node.InputAttributeAutocomplete) *node.Node {
 	return node.NewInputField(name, nil, node.PasswordGroup,
 		node.InputAttributeTypePassword,
-		node.WithRequiredInputAttribute).
+		node.WithRequiredInputAttribute,
+		node.WithInputAttributes(func(a *node.InputAttributes) {
+			a.Autocomplete = autocomplete
+		})).
 		WithMetaLabel(text.NewInfoNodeInputPassword())
 }

--- a/selfservice/strategy/password/registration.go
+++ b/selfservice/strategy/password/registration.go
@@ -150,7 +150,7 @@ func (s *Strategy) PopulateRegistrationMethod(r *http.Request, f *registration.F
 	}
 
 	f.UI.SetCSRF(s.d.GenerateCSRFToken(r))
-	f.UI.Nodes.Upsert(NewPasswordNode("password"))
+	f.UI.Nodes.Upsert(NewPasswordNode("password", node.InputAttributeAutocompleteNewPassword))
 	f.UI.Nodes.Append(node.NewInputField("method", "password", node.PasswordGroup, node.InputAttributeTypeSubmit).WithMetaLabel(text.NewInfoRegistration()))
 
 	return nil

--- a/selfservice/strategy/password/registration_test.go
+++ b/selfservice/strategy/password/registration_test.go
@@ -487,7 +487,9 @@ func TestRegistration(t *testing.T) {
 			Nodes: node.Nodes{
 				node.NewCSRFNode(x.FakeCSRFToken),
 				node.NewInputField("traits.username", nil, node.PasswordGroup, node.InputAttributeTypeText),
-				node.NewInputField("password", nil, node.PasswordGroup, node.InputAttributeTypePassword, node.WithRequiredInputAttribute).WithMetaLabel(text.NewInfoNodeInputPassword()),
+				node.NewInputField("password", nil, node.PasswordGroup, node.InputAttributeTypePassword, node.WithRequiredInputAttribute, node.WithInputAttributes(func(a *node.InputAttributes) {
+					a.Autocomplete = node.InputAttributeAutocompleteNewPassword
+				})).WithMetaLabel(text.NewInfoNodeInputPassword()),
 				node.NewInputField("traits.bar", nil, node.PasswordGroup, node.InputAttributeTypeText),
 				node.NewInputField("method", "password", node.PasswordGroup, node.InputAttributeTypeSubmit).WithMetaLabel(text.NewInfoRegistration()),
 			},

--- a/selfservice/strategy/password/settings.go
+++ b/selfservice/strategy/password/settings.go
@@ -146,7 +146,7 @@ func (s *Strategy) continueSettingsFlow(
 
 func (s *Strategy) PopulateSettingsMethod(r *http.Request, _ *identity.Identity, f *settings.Flow) error {
 	f.UI.SetCSRF(s.d.GenerateCSRFToken(r))
-	f.UI.Nodes.Upsert(NewPasswordNode("password").WithMetaLabel(text.NewInfoNodeInputPassword()))
+	f.UI.Nodes.Upsert(NewPasswordNode("password", node.InputAttributeAutocompleteNewPassword).WithMetaLabel(text.NewInfoNodeInputPassword()))
 	f.UI.Nodes.Append(node.NewInputField("method", "password", node.PasswordGroup, node.InputAttributeTypeSubmit).WithMetaLabel(text.NewInfoNodeLabelSave()))
 
 	return nil

--- a/selfservice/strategy/profile/.snapshots/TestStrategyTraits-description=hydrate_the_proper_fields-type=api#01.json
+++ b/selfservice/strategy/profile/.snapshots/TestStrategyTraits-description=hydrate_the_proper_fields-type=api#01.json
@@ -112,6 +112,7 @@
     },
     {
       "attributes": {
+        "autocomplete": "new-password",
         "disabled": false,
         "name": "password",
         "node_type": "input",

--- a/selfservice/strategy/profile/.snapshots/TestStrategyTraits-description=hydrate_the_proper_fields-type=api.json
+++ b/selfservice/strategy/profile/.snapshots/TestStrategyTraits-description=hydrate_the_proper_fields-type=api.json
@@ -112,6 +112,7 @@
     },
     {
       "attributes": {
+        "autocomplete": "new-password",
         "disabled": false,
         "name": "password",
         "node_type": "input",

--- a/selfservice/strategy/profile/.snapshots/TestStrategyTraits-description=hydrate_the_proper_fields-type=browser.json
+++ b/selfservice/strategy/profile/.snapshots/TestStrategyTraits-description=hydrate_the_proper_fields-type=browser.json
@@ -112,6 +112,7 @@
     },
     {
       "attributes": {
+        "autocomplete": "new-password",
         "disabled": false,
         "name": "password",
         "node_type": "input",

--- a/selfservice/strategy/webauthn/.snapshots/TestRegistration-case=webauthn_button_does_not_exist_when_passwordless_is_disabled-browser.json
+++ b/selfservice/strategy/webauthn/.snapshots/TestRegistration-case=webauthn_button_does_not_exist_when_passwordless_is_disabled-browser.json
@@ -27,6 +27,7 @@
   },
   {
     "attributes": {
+      "autocomplete": "new-password",
       "disabled": false,
       "name": "password",
       "node_type": "input",

--- a/selfservice/strategy/webauthn/.snapshots/TestRegistration-case=webauthn_button_does_not_exist_when_passwordless_is_disabled-spa.json
+++ b/selfservice/strategy/webauthn/.snapshots/TestRegistration-case=webauthn_button_does_not_exist_when_passwordless_is_disabled-spa.json
@@ -27,6 +27,7 @@
   },
   {
     "attributes": {
+      "autocomplete": "new-password",
       "disabled": false,
       "name": "password",
       "node_type": "input",

--- a/selfservice/strategy/webauthn/.snapshots/TestRegistration-case=webauthn_button_exists-browser.json
+++ b/selfservice/strategy/webauthn/.snapshots/TestRegistration-case=webauthn_button_exists-browser.json
@@ -106,6 +106,7 @@
   },
   {
     "attributes": {
+      "autocomplete": "new-password",
       "disabled": false,
       "name": "password",
       "node_type": "input",

--- a/selfservice/strategy/webauthn/.snapshots/TestRegistration-case=webauthn_button_exists-spa.json
+++ b/selfservice/strategy/webauthn/.snapshots/TestRegistration-case=webauthn_button_exists-spa.json
@@ -106,6 +106,7 @@
   },
   {
     "attributes": {
+      "autocomplete": "new-password",
       "disabled": false,
       "name": "password",
       "node_type": "input",

--- a/spec/api.json
+++ b/spec/api.json
@@ -1985,6 +1985,18 @@
       "uiNodeInputAttributes": {
         "description": "InputAttributes represents the attributes of an input node",
         "properties": {
+          "autocomplete": {
+            "description": "The autocomplete attribute for the input.",
+            "enum": [
+              "email",
+              "tel",
+              "url",
+              "current-password",
+              "new-password",
+              "one-time-code"
+            ],
+            "type": "string"
+          },
           "disabled": {
             "description": "Sets the input's disabled field to true or false.",
             "type": "boolean"

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -4205,6 +4205,18 @@
         "node_type"
       ],
       "properties": {
+        "autocomplete": {
+          "description": "The autocomplete attribute for the input.",
+          "type": "string",
+          "enum": [
+            "email",
+            "tel",
+            "url",
+            "current-password",
+            "new-password",
+            "one-time-code"
+          ]
+        },
         "disabled": {
           "description": "Sets the input's disabled field to true or false.",
           "type": "boolean"

--- a/ui/node/attributes.go
+++ b/ui/node/attributes.go
@@ -9,6 +9,7 @@ const (
 	InputAttributeTypeCheckbox      InputAttributeType = "checkbox"
 	InputAttributeTypeHidden        InputAttributeType = "hidden"
 	InputAttributeTypeEmail         InputAttributeType = "email"
+	InputAttributeTypeTel           InputAttributeType = "tel"
 	InputAttributeTypeSubmit        InputAttributeType = "submit"
 	InputAttributeTypeButton        InputAttributeType = "button"
 	InputAttributeTypeDateTimeLocal InputAttributeType = "datetime-local"
@@ -16,8 +17,20 @@ const (
 	InputAttributeTypeURI           InputAttributeType = "url"
 )
 
+const (
+	InputAttributeAutocompleteEmail           InputAttributeAutocomplete = "email"
+	InputAttributeAutocompleteTel             InputAttributeAutocomplete = "tel"
+	InputAttributeAutocompleteUrl             InputAttributeAutocomplete = "url"
+	InputAttributeAutocompleteCurrentPassword InputAttributeAutocomplete = "current-password"
+	InputAttributeAutocompleteNewPassword     InputAttributeAutocomplete = "new-password"
+	InputAttributeAutocompleteOneTimeCode     InputAttributeAutocomplete = "one-time-code"
+)
+
 // swagger:model uiNodeInputAttributeType
 type InputAttributeType string
+
+// swagger:enum InputAttributeAutocomplete
+type InputAttributeAutocomplete string
 
 // Attributes represents a list of attributes (e.g. `href="foo"` for links).
 //
@@ -58,6 +71,9 @@ type InputAttributes struct {
 
 	// Mark this input field as required.
 	Required bool `json:"required,omitempty"`
+
+	// The autocomplete attribute for the input.
+	Autocomplete InputAttributeAutocomplete `json:"autocomplete,omitempty"`
 
 	// The input's label text.
 	Label *text.Message `json:"label,omitempty"`

--- a/ui/node/attributes_input.go
+++ b/ui/node/attributes_input.go
@@ -156,10 +156,15 @@ func NewInputFieldFromSchema(name string, group UiNodeGroup, p jsonschemax.Path,
 		attr.Type = InputAttributeTypeDateTimeLocal
 	case "email":
 		attr.Type = InputAttributeTypeEmail
+		attr.Autocomplete = InputAttributeAutocompleteEmail
+	case "tel":
+		attr.Type = InputAttributeTypeTel
+		attr.Autocomplete = InputAttributeAutocompleteTel
 	case "date":
 		attr.Type = InputAttributeTypeDate
 	case "uri":
 		attr.Type = InputAttributeTypeURI
+		attr.Autocomplete = InputAttributeAutocompleteUrl
 	case "regex":
 		attr.Type = InputAttributeTypeText
 	}

--- a/ui/node/attributes_input_test.go
+++ b/ui/node/attributes_input_test.go
@@ -37,6 +37,12 @@ func TestFieldFromPath(t *testing.T) {
 			assert.EqualValues(t, gjson.GetBytes(schema, fmt.Sprintf("properties.%s.test_expected_type", path.Name)).String(), attr.Type)
 			assert.True(t, !gjson.GetBytes(schema, fmt.Sprintf("properties.%s.test_expected_pattern", path.Name)).Exists() ||
 				(gjson.GetBytes(schema, fmt.Sprintf("properties.%s.test_expected_pattern", path.Name)).Bool() && attr.Pattern != ""))
+
+			expectedAutocomplete := gjson.GetBytes(schema, fmt.Sprintf("properties.%s.test_expected_autocomplete", path.Name))
+
+			if expectedAutocomplete.Exists() {
+				assert.EqualValues(t, expectedAutocomplete.String(), attr.Autocomplete)
+			}
 		}
 	})
 }

--- a/ui/node/fixtures/all_formats.schema.json
+++ b/ui/node/fixtures/all_formats.schema.json
@@ -26,7 +26,14 @@
     "emailString": {
       "type": "string",
       "format": "email",
-      "test_expected_type": "email"
+      "test_expected_type": "email",
+      "test_expected_autocomplete": "email"
+    },
+    "phoneString": {
+      "type": "string",
+      "format": "tel",
+      "test_expected_type": "tel",
+      "test_expected_autocomplete": "tel"
     },
     "dateTimeString": {
       "type": "string",
@@ -46,7 +53,8 @@
     "uriString": {
       "type": "string",
       "format": "uri",
-      "test_expected_type": "url"
+      "test_expected_type": "url",
+      "test_expected_autocomplete": "url"
     },
     "patternString": {
       "type": "string",


### PR DESCRIPTION
- adds `autocomplete` attribute to node attributes
- sets the `autocomplete` attribute on password inputs to `new-password` (registration, settings) or `current-password` (login)
- sets the `autocomplete` attribute for email, tel and url inputs depending on the `format` of the trait
- sets input type to `tel` if trait format is `tel`

This relates to two of the points mentioned in #2396.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I am following the [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security.
      vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the
      maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added or changed [the documentation](https://github.com/ory/docs).
