### PR TITLE
Selfservice: change flow sort, oidc below password

### DIFF
--- a/selfservice/flow/login/sort.go
+++ b/selfservice/flow/login/sort.go
@@ -9,10 +9,10 @@ import (
 func sortNodes(ctx context.Context, n node.Nodes) error {
 	return n.SortBySchema(ctx,
 		node.SortByGroups([]node.UiNodeGroup{
-			node.OpenIDConnectGroup,
 			node.DefaultGroup,
 			node.WebAuthnGroup,
 			node.PasswordGroup,
+			node.OpenIDConnectGroup,
 			node.TOTPGroup,
 			node.LookupGroup,
 		}),

--- a/selfservice/flow/registration/sort.go
+++ b/selfservice/flow/registration/sort.go
@@ -11,9 +11,9 @@ func SortNodes(ctx context.Context, n node.Nodes, schemaRef string) error {
 		node.SortBySchema(schemaRef),
 		node.SortByGroups([]node.UiNodeGroup{
 			node.DefaultGroup,
-			node.OpenIDConnectGroup,
 			node.WebAuthnGroup,
 			node.PasswordGroup,
+			node.OpenIDConnectGroup,
 		}),
 		node.SortUpdateOrder(node.PasswordLoginOrder),
 		node.SortUseOrderAppend([]string{


### PR DESCRIPTION
Changed the order, to have password group above oidc, to fix so the top submit  button is not the oidc.
So enter = password, not oidc



There might be a reason for the previous order I dont know about.  
But using nextjs  or nodejs selfservice reference  implementation with oidc enabled, it will render oidc on top which causes enter press inside a input to trigger the oidc action.  
Which is very annoying :)  
![image](https://user-images.githubusercontent.com/2227028/174343435-0fdfca3e-736c-4941-acce-dae8b9b6c2b3.png)
![image](https://user-images.githubusercontent.com/2227028/174343475-caecc4e0-334c-4fe5-82c7-7e56228ba2ff.png)



<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
2. implements a new feature, link the issue containing the design document in the format of `#1234`;
3. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [ ] I am following the [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [ ] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security.
      vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the
      maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments
I have not tested webauthn and the others, so, dont know if this is suboptimal in relation to them.
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
