### PR TITLE
feat: add identity id to "account disabled" error

### DIFF
--- a/selfservice/strategy/link/strategy_recovery_test.go
+++ b/selfservice/strategy/link/strategy_recovery_test.go
@@ -402,11 +402,11 @@ func TestRecovery(t *testing.T) {
 			if isAPI {
 				assert.Equal(t, http.StatusUnauthorized, res.StatusCode)
 				assert.Contains(t, res.Request.URL.String(), public.URL+recovery.RouteSubmitFlow)
-				assertx.EqualAsJSON(t, session.ErrIdentityDisabled, json.RawMessage(gjson.GetBytes(body, "error").Raw), "%s", body)
+				assertx.EqualAsJSON(t, session.ErrIdentityDisabled.WithDetail("identity_id", addr.IdentityID), json.RawMessage(gjson.GetBytes(body, "error").Raw), "%s", body)
 			} else {
 				assert.Equal(t, http.StatusOK, res.StatusCode)
 				assert.Contains(t, res.Request.URL.String(), conf.SelfServiceFlowErrorURL().String())
-				assertx.EqualAsJSON(t, session.ErrIdentityDisabled, json.RawMessage(body), "%s", body)
+				assertx.EqualAsJSON(t, session.ErrIdentityDisabled.WithDetail("identity_id", addr.IdentityID), json.RawMessage(body), "%s", body)
 			}
 		}
 

--- a/session/session.go
+++ b/session/session.go
@@ -170,7 +170,7 @@ func NewInactiveSession() *Session {
 
 func (s *Session) Activate(i *identity.Identity, c lifespanProvider, authenticatedAt time.Time) error {
 	if i != nil && !i.IsActive() {
-		return ErrIdentityDisabled
+		return ErrIdentityDisabled.WithDetail("identity_id", i.ID)
 	}
 
 	s.Active = true


### PR DESCRIPTION
When user tries to login with oidc and encounters "account disabled" error it is hard to find which identity is inactive.
oidc provider user id (subject) is needed to find the identity.

To make this simpler, this PR adds identity id to the logs.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
2. implements a new feature, link the issue containing the design document in the format of `#1234`;
3. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [ x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [ x] I am following the [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [ x] I have read the [security policy](../security/policy).
- [ x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security. vulnerability, 
      I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
