### PR TITLE
fix: add IssuerURL for Apple ID

### DIFF
--- a/selfservice/strategy/oidc/provider_apple.go
+++ b/selfservice/strategy/oidc/provider_apple.go
@@ -24,6 +24,7 @@ func NewProviderApple(
 	config *Configuration,
 	reg dependencies,
 ) *ProviderApple {
+	config.IssuerURL = "https://appleid.apple.com"
 	return &ProviderApple{
 		ProviderGenericOIDC: &ProviderGenericOIDC{
 			config: config,


### PR DESCRIPTION
No issuer url was specified when using the Apple ID provider, this forced usersers to manually enter it in the provider config.

This PR adds the Apple ID issuer url to the provider simplifying the setup.

## Related issue(s)
Fixes: https://github.com/ory/kratos/issues/2558

## Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I am following the [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security. vulnerability, 
      I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added or changed [the documentation](https://github.com/ory/docs).
