### PR TITLE
feat: disable mail dispatch for invalid recovery email

### DIFF
--- a/driver/config/config.go
+++ b/driver/config/config.go
@@ -66,6 +66,7 @@ const (
 	ViperKeyCourierSMTPClientKeyPath                         = "courier.smtp.client_key_path"
 	ViperKeyCourierTemplatesPath                             = "courier.template_override_path"
 	ViperKeyCourierTemplatesRecoveryInvalidEmail             = "courier.templates.recovery.invalid.email"
+	ViperKeyCourierTemplatesRecoveryInvalidSend              = "courier.templates.recovery.invalid.send"
 	ViperKeyCourierTemplatesRecoveryValidEmail               = "courier.templates.recovery.valid.email"
 	ViperKeyCourierTemplatesRecoveryCodeInvalidEmail         = "courier.templates.recovery_code.invalid.email"
 	ViperKeyCourierTemplatesRecoveryCodeValidEmail           = "courier.templates.recovery_code.valid.email"
@@ -993,6 +994,10 @@ func (p *Config) CourierTemplatesRecoveryInvalid(ctx context.Context) *CourierEm
 
 func (p *Config) CourierTemplatesRecoveryValid(ctx context.Context) *CourierEmailTemplate {
 	return p.CourierTemplatesHelper(ctx, ViperKeyCourierTemplatesRecoveryValidEmail)
+}
+
+func (p *Config) CourierTemplatesRecoveryInvalidSend(ctx context.Context) bool {
+	return p.p.BoolF(ViperKeyCourierTemplatesRecoveryInvalidSend, true)
 }
 
 func (p *Config) CourierTemplatesRecoveryCodeInvalid(ctx context.Context) *CourierEmailTemplate {

--- a/embedx/config.schema.json
+++ b/embedx/config.schema.json
@@ -1545,7 +1545,7 @@
         }
       }
     },
-    "database":  {
+    "database": {
       "type": "object",
       "title": "Database related configuration",
       "description": "Miscellaneous settings used in database related tasks (cleanup, etc.)",
@@ -1555,7 +1555,7 @@
           "title": "Database cleanup settings",
           "description": "Settings that controls how the database cleanup process is configured (delays, batch size, etc.)",
           "properties": {
-            "batch_size" : {
+            "batch_size": {
               "type": "integer",
               "title": "Number of records to clean in one iteration",
               "description": "Controls how many records should be purged from one table during database cleanup task",
@@ -1609,7 +1609,35 @@
           "type": "object",
           "properties": {
             "recovery": {
-              "$ref": "#/definitions/courierTemplates"
+              "invalid": {
+                "additionalProperties": false,
+                "type": "object",
+                "properties": {
+                  "send": {
+                    "type": "boolean",
+                    "description": "Enable sending invalid recovery email",
+                    "default": true
+                  },
+                  "email": {
+                    "$ref": "#/definitions/emailCourierTemplate"
+                  }
+                },
+                "required": [
+                  "email"
+                ]
+              },
+              "valid": {
+                "additionalProperties": false,
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "$ref": "#/definitions/emailCourierTemplate"
+                  }
+                },
+                "required": [
+                  "email"
+                ]
+              }
             },
             "recovery_code": {
               "$ref": "#/definitions/courierTemplates"

--- a/selfservice/strategy/link/sender.go
+++ b/selfservice/strategy/link/sender.go
@@ -67,6 +67,12 @@ func (s *Sender) SendRecoveryLink(ctx context.Context, r *http.Request, f *recov
 
 	address, err := s.r.IdentityPool().FindRecoveryAddressByValue(ctx, identity.RecoveryAddressTypeEmail, to)
 	if err != nil {
+		if !s.r.Config().CourierTemplatesRecoveryInvalidSend(ctx) {
+			s.r.Logger().Info("Suppressing invalid recovery email.")
+
+			return nil
+		}
+
 		if err := s.send(ctx, string(via), email.NewRecoveryInvalid(s.r, &email.RecoveryInvalidModel{To: to})); err != nil {
 			return err
 		}

--- a/selfservice/strategy/link/sender_test.go
+++ b/selfservice/strategy/link/sender_test.go
@@ -7,8 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ory/kratos/internal/testhelpers"
 	"github.com/pkg/errors"
+
+	"github.com/ory/kratos/internal/testhelpers"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
Added `send` property for `courier.templates.recovery.invalid` configuration field, suppressing email sending when recovery email does not exist.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

#2345
<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
2. implements a new feature, link the issue containing the design document in the format of `#1234`;
3. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I am following the [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security. vulnerability, 
      I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

Included additional configuration field for invalid recovery. I've also considered extending directly email field by `send` property but it would affect all other flows using the same struct.  Extended schema definition. Here I wasn't sure if `$ref` template can be extended, so just overwrote it. For `getEmail` cypress command now it's possible to omit check if email is existing. 

