### PR TITLE
fix: Re-issue outdated cookie in /whoami

### DIFF
--- a/session/handler.go
+++ b/session/handler.go
@@ -199,6 +199,8 @@ func (h *Handler) whoami(w http.ResponseWriter, r *http.Request, ps httprouter.P
 	// Set userId as the X-Kratos-Authenticated-Identity-Id header.
 	w.Header().Set("X-Kratos-Authenticated-Identity-Id", s.Identity.ID.String())
 
+	h.r.SessionManager().ReIssueRefreshedCookie(r.Context(), w, r, s)
+
 	h.r.Writer().Write(w, r, s)
 }
 

--- a/session/handler.go
+++ b/session/handler.go
@@ -199,7 +199,11 @@ func (h *Handler) whoami(w http.ResponseWriter, r *http.Request, ps httprouter.P
 	// Set userId as the X-Kratos-Authenticated-Identity-Id header.
 	w.Header().Set("X-Kratos-Authenticated-Identity-Id", s.Identity.ID.String())
 
-	h.r.SessionManager().ReIssueRefreshedCookie(r.Context(), w, r, s)
+	if err := h.r.SessionManager().ReIssueRefreshedCookie(r.Context(), w, r, s); err != nil {
+		h.r.Audit().WithRequest(r).WithError(err).Info("Could not re-issue cookie.")
+		h.r.Writer().WriteError(w, r, err)
+		return
+	}
 
 	h.r.Writer().Write(w, r, s)
 }

--- a/session/handler.go
+++ b/session/handler.go
@@ -199,7 +199,7 @@ func (h *Handler) whoami(w http.ResponseWriter, r *http.Request, ps httprouter.P
 	// Set userId as the X-Kratos-Authenticated-Identity-Id header.
 	w.Header().Set("X-Kratos-Authenticated-Identity-Id", s.Identity.ID.String())
 
-	if err := h.r.SessionManager().ReIssueRefreshedCookie(r.Context(), w, r, s); err != nil {
+	if err := h.r.SessionManager().RefreshCookie(r.Context(), w, r, s); err != nil {
 		h.r.Audit().WithRequest(r).WithError(err).Info("Could not re-issue cookie.")
 		h.r.Writer().WriteError(w, r, err)
 		return

--- a/session/handler_test.go
+++ b/session/handler_test.go
@@ -661,7 +661,7 @@ func TestHandlerSelfServiceSessionManagement(t *testing.T) {
 
 		require.Len(t, resp.Cookies(), 1)
 		for _, c := range resp.Cookies() {
-			assert.True(t, session.ExpiresAt.Sub(c.Expires).Seconds() < 5, "Ensure the expiry does not deviate +- 5 seconds from the expiry of the session for cookie: %s", c.Name)
+			assert.WithinDuration(t, session.ExpiresAt, c.Expires, 5*time.Second, "Ensure the expiry does not deviate +- 5 seconds from the expiry of the session for cookie: %s", c.Name)
 			assert.NotEqual(t, oldExpires, c.Expires, "%s", c.Name)
 		}
 	})

--- a/session/manager.go
+++ b/session/manager.go
@@ -91,6 +91,9 @@ type Manager interface {
 	// Also regenerates CSRF tokens due to assumed principal change.
 	IssueCookie(context.Context, http.ResponseWriter, *http.Request, *Session) error
 
+	// Checks if the request uses an outdated cookie and re-issues the cookie if needed
+	ReIssueRefreshedCookie(context.Context, http.ResponseWriter, *http.Request, *Session) error
+
 	// FetchFromRequest creates an HTTP session using cookies.
 	FetchFromRequest(context.Context, *http.Request) (*Session, error)
 

--- a/session/manager.go
+++ b/session/manager.go
@@ -91,8 +91,8 @@ type Manager interface {
 	// Also regenerates CSRF tokens due to assumed principal change.
 	IssueCookie(context.Context, http.ResponseWriter, *http.Request, *Session) error
 
-	// Checks if the request uses an outdated cookie and re-issues the cookie if needed
-	ReIssueRefreshedCookie(context.Context, http.ResponseWriter, *http.Request, *Session) error
+	// RefreshCookie checks if the request uses an outdated cookie and refreshes the cookie if needed.
+	RefreshCookie(context.Context, http.ResponseWriter, *http.Request, *Session) error
 
 	// FetchFromRequest creates an HTTP session using cookies.
 	FetchFromRequest(context.Context, *http.Request) (*Session, error)

--- a/session/manager_http.go
+++ b/session/manager_http.go
@@ -63,8 +63,9 @@ func (s *ManagerHTTP) UpsertAndIssueCookie(ctx context.Context, w http.ResponseW
 
 func (s *ManagerHTTP) RefreshCookie(ctx context.Context, w http.ResponseWriter, r *http.Request, session *Session) error {
 	// If it is a session token there is nothing to do.
-	token := s.extractToken(r)
-	if token != "" {
+	cookieHeader := r.Header.Get("X-Session-Cookie")
+	_, cookieErr := r.Cookie(s.cookieName(r.Context()))
+	if len(cookieHeader) == 0 && errors.Is(cookieErr, http.ErrNoCookie) {
 		return nil
 	}
 

--- a/session/manager_http.go
+++ b/session/manager_http.go
@@ -62,6 +62,12 @@ func (s *ManagerHTTP) UpsertAndIssueCookie(ctx context.Context, w http.ResponseW
 }
 
 func (s *ManagerHTTP) RefreshCookie(ctx context.Context, w http.ResponseWriter, r *http.Request, session *Session) error {
+	// If it is a session token there is nothing to do.
+	token := s.extractToken(r)
+	if token != "" {
+		return nil
+	}
+
 	cookie, err := s.getCookie(r)
 	if err != nil {
 		return err

--- a/session/manager_http.go
+++ b/session/manager_http.go
@@ -116,7 +116,7 @@ func (s *ManagerHTTP) IssueCookie(ctx context.Context, w http.ResponseWriter, r 
 		if session.ExpiresAt.IsZero() {
 			cookie.Options.MaxAge = int(s.r.Config(ctx).SessionLifespan().Seconds())
 		} else {
-			cookie.Options.MaxAge = int(session.ExpiresAt.UTC().Sub(time.Now()).Seconds())
+			cookie.Options.MaxAge = int(time.Until(session.ExpiresAt).Seconds())
 		}
 	}
 


### PR DESCRIPTION
Closes #2562

I chose to use the method proposed here https://github.com/ory/kratos/issues/2562#issuecomment-1181382333 and added the new value `expires_at` to the cookie.
Additionally I added a new method `ReIssueRefreshedCookie()` to `session.Manager` that checks if the `expires_at` value of the cookie and the stored session are out of sync and re-issues the cookie.
The `/session/whoami` endpoint now also calls `ReIssueRefreshedCookie()`.

I added two new test cases. The first case tests that no cookies are issued when the session wasn't extended.
The second case tests that the cookie is issued after extending the session in the backend.

## Related issue(s)

#2562

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I am following the [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security. vulnerability, 
      I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).
