### PR TITLE
fix: Fix debugging Docker setup

### DIFF
--- a/.docker/Dockerfile-debug
+++ b/.docker/Dockerfile-debug
@@ -2,7 +2,7 @@ FROM golang:1.18-buster
 ENV CGO_ENABLED 1
 
 RUN apt-get update && apt-get install -y --no-install-recommends inotify-tools psmisc
-RUN go get github.com/go-delve/delve/cmd/dlv
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
 COPY script/debug-entrypoint.sh /entrypoint.sh
 

--- a/script/debug-entrypoint.sh
+++ b/script/debug-entrypoint.sh
@@ -17,7 +17,7 @@ build() {
   log "Building ${SERVICE_NAME} binary"
   go env -w GOPROXY="proxy.golang.org,direct"
   go mod download
-  go build -gcflags "all=-N -l" -o /${SERVICE_NAME}
+  go build -buildvcs=false -gcflags "all=-N -l" -o /${SERVICE_NAME}
 }
 
 start() {


### PR DESCRIPTION
The new go version needs some tweaks in our debugging setup.
* Disabling `-buildvcs=false` in go build, this is a new "feature" introduced in go 1.18 but is not required for working binary and if turned on can throw errors on incompatible versions of git
* `RUN go get github.com/go-delve/delve/cmd/dlv` doesn't work on the new version and instead is recommended to use `go install` with the specified version

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I am following the [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security. vulnerability, 
      I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
