### PR TITLE
feat: replace message_ttl with static max retry count

### DIFF
--- a/.schemastore/config.schema.json
+++ b/.schemastore/config.schema.json
@@ -1471,15 +1471,13 @@
             "/conf/courier-templates"
           ]
         },
-        "message_ttl": {
-          "description": "Defines a Time-To-Live for courier messages that could not be delivered. After the defined TTL has expired for a message that message is abandoned.",
-          "type": "string",
-          "pattern": "^([0-9]+(ns|us|ms|s|m|h))+$",
-          "default": "1h",
+        "message_retries": {
+          "description": "Defines the maximum number of times the sending of a message is retried after it failed before it is marked as abandoned",
+          "type": "integer",
+          "default": 5,
           "examples": [
-            "1h",
-            "1m",
-            "1s"
+            10,
+            60
           ]
         },
         "smtp": {

--- a/courier/courier_dispatcher.go
+++ b/courier/courier_dispatcher.go
@@ -50,7 +50,7 @@ func (c *courier) DispatchQueue(ctx context.Context) error {
 	maxRetries := c.deps.CourierConfig(ctx).CourierMessageRetries()
 
 	for k, msg := range messages {
-		if msg.SendCount >= maxRetries {
+		if msg.SendCount > maxRetries {
 			if err := c.deps.CourierPersister().SetMessageStatus(ctx, msg.ID, MessageStatusAbandoned); err != nil {
 				if c.failOnError {
 					return err
@@ -58,7 +58,7 @@ func (c *courier) DispatchQueue(ctx context.Context) error {
 				c.deps.Logger().
 					WithError(err).
 					WithField("message_id", msg.ID).
-					Error(`Unable to reset the timed out message's status to "abandoned".`)
+					Error(`Unable to reset the retried message's status to "abandoned".`)
 			}
 		} else {
 			if err := c.deps.CourierPersister().IncrementMessageSendCount(ctx, msg.ID); err != nil {

--- a/courier/courier_dispatcher.go
+++ b/courier/courier_dispatcher.go
@@ -7,6 +7,32 @@ import (
 )
 
 func (c *courier) DispatchMessage(ctx context.Context, msg Message) error {
+	maxRetries := c.deps.CourierConfig(ctx).CourierMessageRetries()
+
+	if msg.SendCount > maxRetries {
+		if err := c.deps.CourierPersister().SetMessageStatus(ctx, msg.ID, MessageStatusAbandoned); err != nil {
+			c.deps.Logger().
+				WithError(err).
+				WithField("message_id", msg.ID).
+				Error(`Unable to reset the retried message's status to "abandoned".`)
+			return err
+		}
+
+		// Skip the message
+		c.deps.Logger().
+			WithField("message_id", msg.ID).
+			Warnf(`Message was abandoned because it did not deliver after %d tries`, msg.SendCount)
+		return nil
+	}
+
+	if err := c.deps.CourierPersister().IncrementMessageSendCount(ctx, msg.ID); err != nil {
+		c.deps.Logger().
+			WithError(err).
+			WithField("message_id", msg.ID).
+			Error(`Unable to increment the message's "send_count" field`)
+		return err
+	}
+
 	switch msg.Type {
 	case MessageTypeEmail:
 		if err := c.dispatchEmail(ctx, msg); err != nil {
@@ -47,45 +73,22 @@ func (c *courier) DispatchQueue(ctx context.Context) error {
 		return err
 	}
 
-	maxRetries := c.deps.CourierConfig(ctx).CourierMessageRetries()
-
 	for k, msg := range messages {
-		if msg.SendCount > maxRetries {
-			if err := c.deps.CourierPersister().SetMessageStatus(ctx, msg.ID, MessageStatusAbandoned); err != nil {
-				if c.failOnError {
-					return err
-				}
-				c.deps.Logger().
-					WithError(err).
-					WithField("message_id", msg.ID).
-					Error(`Unable to reset the retried message's status to "abandoned".`)
-			}
-		} else {
-			if err := c.deps.CourierPersister().IncrementMessageSendCount(ctx, msg.ID); err != nil {
-				if c.failOnError {
-					return err
-				}
-				c.deps.Logger().
-					WithError(err).
-					WithField("message_id", msg.ID).
-					Error(`Unable to increment the message's "send_count" field`)
-			}
+		if err := c.DispatchMessage(ctx, msg); err != nil {
 
-			if err := c.DispatchMessage(ctx, msg); err != nil {
-				for _, replace := range messages[k:] {
-					if err := c.deps.CourierPersister().SetMessageStatus(ctx, replace.ID, MessageStatusQueued); err != nil {
-						if c.failOnError {
-							return err
-						}
-						c.deps.Logger().
-							WithError(err).
-							WithField("message_id", replace.ID).
-							Error(`Unable to reset the failed message's status to "queued".`)
+			for _, replace := range messages[k:] {
+				if err := c.deps.CourierPersister().SetMessageStatus(ctx, replace.ID, MessageStatusQueued); err != nil {
+					if c.failOnError {
+						return err
 					}
+					c.deps.Logger().
+						WithError(err).
+						WithField("message_id", replace.ID).
+						Error(`Unable to reset the failed message's status to "queued".`)
 				}
-
-				return err
 			}
+
+			return err
 		}
 	}
 

--- a/courier/courier_dispatcher.go
+++ b/courier/courier_dispatcher.go
@@ -21,7 +21,7 @@ func (c *courier) DispatchMessage(ctx context.Context, msg Message) error {
 		// Skip the message
 		c.deps.Logger().
 			WithField("message_id", msg.ID).
-			Warnf(`Message was abandoned because it did not deliver after %d tries`, msg.SendCount)
+			Warnf(`Message was abandoned because it did not deliver after %d attempts`, msg.SendCount)
 		return nil
 	}
 

--- a/courier/courier_dispatcher_test.go
+++ b/courier/courier_dispatcher_test.go
@@ -5,22 +5,73 @@ import (
 	"testing"
 
 	"github.com/gofrs/uuid"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ory/kratos/courier"
+	"github.com/ory/kratos/courier/template"
 	templates "github.com/ory/kratos/courier/template/email"
 	"github.com/ory/kratos/driver/config"
 	"github.com/ory/kratos/internal"
 )
 
-func TestMessageRetries(t *testing.T) {
+func queueNewMessage(t *testing.T, ctx context.Context, c courier.Courier, d template.Dependencies) uuid.UUID {
+	t.Helper()
+	id, err := c.QueueEmail(ctx, templates.NewTestStub(d, &templates.TestStubModel{
+		To:      "test-recipient-1@example.org",
+		Subject: "test-subject-1",
+		Body:    "test-body-1",
+	}))
+	require.NoError(t, err)
+	return id
+}
+
+func TestDispatchMessageWithInvalidSMTP(t *testing.T) {
+	ctx := context.Background()
+
+	conf, reg := internal.NewRegistryDefaultWithDSN(t, "")
+	conf.MustSet(config.ViperKeyCourierMessageRetries, 5)
+	conf.MustSet(config.ViperKeyCourierSMTPURL, "http://foo.url")
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	c := reg.Courier(ctx)
+
+	t.Run("case=failed sending", func(t *testing.T) {
+		id := queueNewMessage(t, ctx, c, reg)
+		message, err := reg.CourierPersister().LatestQueuedMessage(ctx)
+		require.NoError(t, err)
+		require.Equal(t, id, message.ID)
+
+		err = c.DispatchMessage(ctx, *message)
+		// sending the email fails, because there is no SMTP server at foo.url
+		require.Error(t, err)
+
+		messages, err := reg.CourierPersister().NextMessages(ctx, 10)
+		require.Len(t, messages, 1)
+	})
+
+	t.Run("case=max retries reached", func(t *testing.T) {
+		id := queueNewMessage(t, ctx, c, reg)
+		message, err := reg.CourierPersister().LatestQueuedMessage(ctx)
+		require.NoError(t, err)
+		require.Equal(t, id, message.ID)
+		message.SendCount = 6
+
+		err = c.DispatchMessage(ctx, *message)
+		require.NoError(t, err)
+
+		messages, err := reg.CourierPersister().NextMessages(ctx, 1)
+		require.Empty(t, messages)
+	})
+
+}
+
+func TestDispatchMessage2(t *testing.T) {
 	ctx := context.Background()
 
 	conf, reg := internal.NewRegistryDefaultWithDSN(t, "")
 	conf.MustSet(config.ViperKeyCourierMessageRetries, 1)
-
-	reg.Logger().Level = logrus.TraceLevel
 
 	c := reg.Courier(ctx)
 
@@ -39,7 +90,7 @@ func TestMessageRetries(t *testing.T) {
 	err = c.DispatchQueue(ctx)
 	require.Error(t, err)
 
-	// Retry once, as we set above
+	// Retry once, as we set above - still fails
 	err = c.DispatchQueue(ctx)
 	require.Error(t, err)
 

--- a/courier/courier_dispatcher_test.go
+++ b/courier/courier_dispatcher_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/gofrs/uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
@@ -32,11 +33,17 @@ func TestMessageRetries(t *testing.T) {
 		Body:    "test-body-1",
 	}))
 	require.NoError(t, err)
-	require.NotZero(t, id)
+	require.NotEqual(t, uuid.Nil, id)
 
+	// Fails to deliver the first time
 	err = c.DispatchQueue(ctx)
 	require.Error(t, err)
 
+	// Retry once, as we set above
+	err = c.DispatchQueue(ctx)
+	require.Error(t, err)
+
+	// Now it has been retried once, which means 2 > 1 is true and it is no longer tried
 	err = c.DispatchQueue(ctx)
 	require.NoError(t, err)
 

--- a/courier/message.go
+++ b/courier/message.go
@@ -27,21 +27,21 @@ const (
 
 // swagger:ignore
 type Message struct {
-	ID           uuid.UUID     `json:"-" faker:"-" db:"id"`
+	ID           uuid.UUID     `json:"id" faker:"-" db:"id"`
 	NID          uuid.UUID     `json:"-" faker:"-" db:"nid"`
-	Status       MessageStatus `json:"-" db:"status"`
-	Type         MessageType   `json:"-" db:"type"`
-	Recipient    string        `json:"-" db:"recipient"`
-	Body         string        `json:"-" db:"body"`
-	Subject      string        `json:"-" db:"subject"`
-	TemplateType TemplateType  `json:"-" db:"template_type"`
+	Status       MessageStatus `json:"status" db:"status"`
+	Type         MessageType   `json:"type" db:"type"`
+	Recipient    string        `json:"recipient" db:"recipient"`
+	Body         string        `json:"body" db:"body"`
+	Subject      string        `json:"subject" db:"subject"`
+	TemplateType TemplateType  `json:"template_type" db:"template_type"`
 	TemplateData []byte        `json:"-" db:"template_data"`
-	SendCount    int           `json:"-" db:"send_count"`
+	SendCount    int           `json:"send_count" db:"send_count"`
 
 	// CreatedAt is a helper struct field for gobuffalo.pop.
-	CreatedAt time.Time `json:"-" faker:"-" db:"created_at"`
+	CreatedAt time.Time `json:"created_at" faker:"-" db:"created_at"`
 	// UpdatedAt is a helper struct field for gobuffalo.pop.
-	UpdatedAt time.Time `json:"-" faker:"-" db:"updated_at"`
+	UpdatedAt time.Time `json:"updated_at" faker:"-" db:"updated_at"`
 }
 
 func (m Message) TableName(ctx context.Context) string {

--- a/courier/message.go
+++ b/courier/message.go
@@ -28,7 +28,7 @@ const (
 // swagger:ignore
 type Message struct {
 	ID           uuid.UUID     `json:"-" faker:"-" db:"id"`
-	NID          uuid.UUID     `json:"-"  faker:"-" db:"nid"`
+	NID          uuid.UUID     `json:"-" faker:"-" db:"nid"`
 	Status       MessageStatus `json:"-" db:"status"`
 	Type         MessageType   `json:"-" db:"type"`
 	Recipient    string        `json:"-" db:"recipient"`
@@ -36,6 +36,7 @@ type Message struct {
 	Subject      string        `json:"-" db:"subject"`
 	TemplateType TemplateType  `json:"-" db:"template_type"`
 	TemplateData []byte        `json:"-" db:"template_data"`
+	SendCount    int           `json:"-" db:"send_count"`
 
 	// CreatedAt is a helper struct field for gobuffalo.pop.
 	CreatedAt time.Time `json:"-" faker:"-" db:"created_at"`

--- a/courier/persistence.go
+++ b/courier/persistence.go
@@ -18,6 +18,8 @@ type (
 		SetMessageStatus(context.Context, uuid.UUID, MessageStatus) error
 
 		LatestQueuedMessage(ctx context.Context) (*Message, error)
+
+		IncrementMessageSendCount(context.Context, uuid.UUID) error
 	}
 	PersistenceProvider interface {
 		CourierPersister() Persister

--- a/courier/smtp.go
+++ b/courier/smtp.go
@@ -201,7 +201,8 @@ func (c *courier) dispatchEmail(ctx context.Context, msg Message) error {
 			WithField("message_from", from).
 			Error("Unable to send email using SMTP connection.")
 
-		if protoErr, success := err.(*textproto.Error); success && protoErr.Code >= 500 {
+		var protoErr textproto.Error
+		if containsProtoErr := errors.As(err, &protoErr); containsProtoErr && protoErr.Code >= 500 {
 			// See https://en.wikipedia.org/wiki/List_of_SMTP_server_return_codes
 			// If the SMTP server responds with 5xx, sending the message should not be retried (without changing something about the request)
 			if err := c.deps.CourierPersister().SetMessageStatus(ctx, msg.ID, MessageStatusAbandoned); err != nil {

--- a/courier/smtp.go
+++ b/courier/smtp.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"net/textproto"
 	"strconv"
 	"time"
 
@@ -199,6 +200,18 @@ func (c *courier) dispatchEmail(ctx context.Context, msg Message) error {
 			// WithField("email_to", msg.Recipient).
 			WithField("message_from", from).
 			Error("Unable to send email using SMTP connection.")
+
+		if protoErr, success := err.(*textproto.Error); success && protoErr.Code >= 500 {
+			// See https://en.wikipedia.org/wiki/List_of_SMTP_server_return_codes
+			// If the SMTP server responds with 5xx, sending the message should not be retried (without changing something about the request)
+			if err := c.deps.CourierPersister().SetMessageStatus(ctx, msg.ID, MessageStatusAbandoned); err != nil {
+				c.deps.Logger().
+					WithError(err).
+					WithField("message_id", msg.ID).
+					Error(`Unable to reset the retried message's status to "abandoned".`)
+				return err
+			}
+		}
 		return errors.WithStack(err)
 	}
 

--- a/courier/smtp.go
+++ b/courier/smtp.go
@@ -201,7 +201,7 @@ func (c *courier) dispatchEmail(ctx context.Context, msg Message) error {
 			WithField("message_from", from).
 			Error("Unable to send email using SMTP connection.")
 
-		var protoErr textproto.Error
+		var protoErr *textproto.Error
 		if containsProtoErr := errors.As(err, &protoErr); containsProtoErr && protoErr.Code >= 500 {
 			// See https://en.wikipedia.org/wiki/List_of_SMTP_server_return_codes
 			// If the SMTP server responds with 5xx, sending the message should not be retried (without changing something about the request)

--- a/courier/test/persistence.go
+++ b/courier/test/persistence.go
@@ -95,6 +95,18 @@ func TestPersister(ctx context.Context, newNetworkUnlessExisting NetworkWrapper,
 			require.ErrorIs(t, err, courier.ErrQueueEmpty)
 		})
 
+		t.Run("case=incrementing send count", func(t *testing.T) {
+			originalSendCount := messages[0].SendCount
+			require.NoError(t, p.SetMessageStatus(ctx, messages[0].ID, courier.MessageStatusQueued))
+
+			require.NoError(t, p.IncrementMessageSendCount(ctx, messages[0].ID))
+			ms, err := p.NextMessages(ctx, 1)
+			require.NoError(t, err)
+			require.Len(t, ms, 1)
+			assert.Equal(t, messages[0].ID, ms[0].ID)
+			assert.Equal(t, originalSendCount+1, ms[0].SendCount)
+		})
+
 		t.Run("case=network", func(t *testing.T) {
 			id := x.NewUUID()
 

--- a/driver/config/config.go
+++ b/driver/config/config.go
@@ -74,7 +74,7 @@ const (
 	ViperKeyCourierSMSRequestConfig                          = "courier.sms.request_config"
 	ViperKeyCourierSMSEnabled                                = "courier.sms.enabled"
 	ViperKeyCourierSMSFrom                                   = "courier.sms.from"
-	ViperKeyCourierMessageTTL                                = "courier.message_ttl"
+	ViperKeyCourierMessageRetries                            = "courier.message_retries"
 	ViperKeySecretsDefault                                   = "secrets.default"
 	ViperKeySecretsCookie                                    = "secrets.cookie"
 	ViperKeySecretsCipher                                    = "secrets.cipher"
@@ -257,7 +257,7 @@ type (
 		CourierTemplatesVerificationValid() *CourierEmailTemplate
 		CourierTemplatesRecoveryInvalid() *CourierEmailTemplate
 		CourierTemplatesRecoveryValid() *CourierEmailTemplate
-		CourierMessageTTL() time.Duration
+		CourierMessageRetries() int
 	}
 )
 
@@ -948,8 +948,8 @@ func (p *Config) CourierTemplatesRecoveryValid() *CourierEmailTemplate {
 	return p.CourierTemplatesHelper(ViperKeyCourierTemplatesRecoveryValidEmail)
 }
 
-func (p *Config) CourierMessageTTL() time.Duration {
-	return p.p.DurationF(ViperKeyCourierMessageTTL, time.Hour)
+func (p *Config) CourierMessageRetries() int {
+	return p.p.IntF(ViperKeyCourierMessageRetries, 5)
 }
 
 func (p *Config) CourierSMTPHeaders() map[string]string {

--- a/driver/config/config_test.go
+++ b/driver/config/config_test.go
@@ -1110,13 +1110,13 @@ func TestCourierMessageTTL(t *testing.T) {
 
 	t.Run("case=configs set", func(t *testing.T) {
 		conf, _ := config.New(ctx, logrusx.New("", ""), os.Stderr,
-			configx.WithConfigFiles("stub/.kratos.courier.messageTTL.yaml"), configx.SkipValidation())
-		assert.Equal(t, conf.CourierMessageTTL(), time.Duration(5*time.Minute))
+			configx.WithConfigFiles("stub/.kratos.courier.message_retries.yaml"), configx.SkipValidation())
+		assert.Equal(t, conf.CourierMessageRetries(), 10)
 	})
 
 	t.Run("case=defaults", func(t *testing.T) {
 		conf, _ := config.New(ctx, logrusx.New("", ""), os.Stderr, configx.SkipValidation())
-		assert.Equal(t, conf.CourierMessageTTL(), time.Duration(1*time.Hour))
+		assert.Equal(t, conf.CourierMessageRetries(), 5)
 	})
 }
 

--- a/driver/config/stub/.kratos.courier.messageTTL.yaml
+++ b/driver/config/stub/.kratos.courier.messageTTL.yaml
@@ -1,2 +1,0 @@
-courier:
-  message_ttl: 5m

--- a/driver/config/stub/.kratos.courier.message_retries.yaml
+++ b/driver/config/stub/.kratos.courier.message_retries.yaml
@@ -1,0 +1,2 @@
+courier:
+  message_retries: 10

--- a/embedx/config.schema.json
+++ b/embedx/config.schema.json
@@ -1549,15 +1549,13 @@
             "/conf/courier-templates"
           ]
         },
-        "message_ttl": {
-          "description": "Defines a Time-To-Live for courier messages that could not be delivered. After the defined TTL has expired for a message that message is abandoned.",
-          "type": "string",
-          "pattern": "^([0-9]+(ns|us|ms|s|m|h))+$",
-          "default": "1h",
+        "message_retries": {
+          "description": "Defines the maximum number of times the sending of a message is retried after it failed before it is marked as abandoned",
+          "type": "integer",
+          "default": 5,
           "examples": [
-            "1h",
-            "1m",
-            "1s"
+            10,
+            60
           ]
         },
         "smtp": {

--- a/persistence/sql/README.md
+++ b/persistence/sql/README.md
@@ -1,11 +1,26 @@
 # SQL Migrations
 
-To create a new [fizz](https://gobuffalo.io/en/docs/db/fizz/) migration run in the project root:
+Migrations consist of one `up` and one `down` file.
+To create these SQL migrations, copy the last migration in `./persistence/sql/migrations/sql` and change the timestamp to the current timestamp and the name to the desired name.
 
-```
-$ name=
-$ ory dev pop migration create ./persistence/sql/migrations/templates $name
-```
+If some logic is different for one of the database systems, add the id after the name to the file name.
+The content of that file will override the content of the "general" file for that particular DB system.
+
+Example:
+
+`20220802103909000000_courier_send_count.up.sql`
+and
+`20220802103909000000_courier_send_count.down.sql`
+
+With for example cockroach specific behavior:
+
+`20220802103909000000_courier_send_count.cockroach.up.sql`
+and
+`20220802103909000000_courier_send_count.cockroach.down.sql`
+
+Replace `cockroach` with `mysql`, `postgres` or `sqlite` if applicable.
+
+## Old Way
 
 To create SQL migrations, target each database individually and run
 

--- a/persistence/sql/migrations/sql/20220802103909000000_courier_send_count.down.sql
+++ b/persistence/sql/migrations/sql/20220802103909000000_courier_send_count.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "courier_messages" DROP COLUMN send_count;

--- a/persistence/sql/migrations/sql/20220802103909000000_courier_send_count.down.sql
+++ b/persistence/sql/migrations/sql/20220802103909000000_courier_send_count.down.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "courier_messages" DROP COLUMN send_count;
+ALTER TABLE courier_messages DROP COLUMN send_count;

--- a/persistence/sql/migrations/sql/20220802103909000000_courier_send_count.up.sql
+++ b/persistence/sql/migrations/sql/20220802103909000000_courier_send_count.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "courier_messages" ADD COLUMN send_count INT NOT NULL DEFAULT 0;

--- a/persistence/sql/migrations/sql/20220802103909000000_courier_send_count.up.sql
+++ b/persistence/sql/migrations/sql/20220802103909000000_courier_send_count.up.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "courier_messages" ADD COLUMN send_count INT NOT NULL DEFAULT 0;
+ALTER TABLE "courier_messages" ADD send_count INT NOT NULL DEFAULT 0;

--- a/persistence/sql/migrations/sql/20220802103909000000_courier_send_count.up.sql
+++ b/persistence/sql/migrations/sql/20220802103909000000_courier_send_count.up.sql
@@ -1,1 +1,2 @@
-ALTER TABLE "courier_messages" ADD send_count INT NOT NULL DEFAULT 0;
+ALTER TABLE courier_messages
+ADD send_count INT NOT NULL DEFAULT 0;

--- a/test/schema/fixtures/config.schema.test.failure/root.invalidTypes.yaml
+++ b/test/schema/fixtures/config.schema.test.failure/root.invalidTypes.yaml
@@ -33,7 +33,7 @@ courier:
   smtp:
     connection_uri: 0
     from_address: 0
-  message_ttl: invalid-value
+  message_retries: invalid-value
 
 serve:
   admin:

--- a/test/schema/fixtures/config.schema.test.success/root.courierSMS.yaml
+++ b/test/schema/fixtures/config.schema.test.success/root.courierSMS.yaml
@@ -9,7 +9,7 @@ identity:
       url: https://example.com
 
 courier:
-  message_ttl: 50m
+  message_retries: 50
   smtp:
     connection_uri: smtps://foo:bar@my-mailserver:1234/
     from_address: no-reply@ory.kratos.sh


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->
This PR replaces the `courier.message_ttl` configuration option with a `courier.message_retries` option to limit how often the sending of a message is retried before it is marked as `abandoned`. 

This is a breaking change, as it removes the `message_ttl` config key.

## Related issue(s)

https://github.com/ory/kratos/issues/402 https://github.com/ory/kratos/issues/1598

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
2. implements a new feature, link the issue containing the design document in the format of `#1234`;
3. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I am following the [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security. vulnerability, 
      I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
