### PR TITLE
docs: Fix documentation regarding "recovery lifespan"

### DIFF
--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -2641,7 +2641,7 @@
       ],
       "properties": {
         "expires_in": {
-          "description": "Link Expires In\n\nThe recovery link will expire at that point in time. Defaults to the configuration value of\n`selfservice.flows.recovery.request_lifespan`.",
+          "description": "Link Expires In\n\nThe recovery link will expire at that point in time. Defaults to the configuration value of\n`selfservice.flows.recovery.lifespan`.",
           "type": "string",
           "pattern": "^[0-9]+(ns|us|ms|s|m|h)$"
         },


### PR DESCRIPTION
```
The API documentation was outdated for the recovery lifespan.
```

## Related issue(s)
https://github.com/ory/kratos/issues/2579

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I am following the [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security. vulnerability, 
      I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

This PR fixes the API documentation as seen on https://www.ory.sh/docs/reference/api#operation/adminCreateSelfServiceRecoveryLink .
There are actually more occurrences of `selfservice.flows.recovery.request_lifespan` which might need to be fixed to `selfservice.flows.recovery.lifespan`. I'd like some feedback if and how I should update those as well. Some of them looks like swagger outputs; is there anyway to automatically generate that swagger output?