### PR TITLE
fix: do not invalidate recovery addr on update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ory/kratos
 
-go 1.17
+go 1.18
 
 replace (
 	github.com/bradleyjkemp/cupaloy/v2 => github.com/aeneasr/cupaloy/v2 v2.6.1-0.20210924214125-3dfdd01210a3

--- a/identity/identity_recovery.go
+++ b/identity/identity_recovery.go
@@ -58,7 +58,7 @@ func (a RecoveryAddress) ValidateNID() error {
 
 // Hash returns a unique string representation for the recovery address.
 func (a RecoveryAddress) Hash() string {
-	return fmt.Sprintf("%s|%s|%s|%s", a.Value, a.Via, a.IdentityID, a.NID)
+	return fmt.Sprintf("%v|%v|%v|%v", a.Value, a.Via, a.IdentityID, a.NID)
 }
 
 func NewRecoveryEmailAddress(

--- a/identity/identity_recovery.go
+++ b/identity/identity_recovery.go
@@ -2,6 +2,7 @@ package identity
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -53,6 +54,11 @@ func (a RecoveryAddress) TableName(ctx context.Context) string {
 
 func (a RecoveryAddress) ValidateNID() error {
 	return nil
+}
+
+// Hash returns a unique string representation for the recovery address.
+func (a RecoveryAddress) Hash() string {
+	return fmt.Sprintf("%s|%s|%s|%s", a.Value, a.Via, a.IdentityID, a.NID)
 }
 
 func NewRecoveryEmailAddress(

--- a/identity/identity_verification.go
+++ b/identity/identity_verification.go
@@ -2,6 +2,7 @@ package identity
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -128,4 +129,8 @@ func (a VerifiableAddress) GetNID() uuid.UUID {
 
 func (a VerifiableAddress) ValidateNID() error {
 	return nil
+}
+
+func (a VerifiableAddress) Hash() string {
+	return fmt.Sprintf("%s|%v|%s|%s|%s|%s", a.Value, a.Verified, a.Via, a.Status, a.IdentityID, a.NID)
 }

--- a/identity/identity_verification.go
+++ b/identity/identity_verification.go
@@ -131,6 +131,7 @@ func (a VerifiableAddress) ValidateNID() error {
 	return nil
 }
 
+// Hash returns a unique string representation for the recovery address.
 func (a VerifiableAddress) Hash() string {
-	return fmt.Sprintf("%s|%v|%s|%s|%s|%s", a.Value, a.Verified, a.Via, a.Status, a.IdentityID, a.NID)
+	return fmt.Sprintf("%v|%v|%v|%v|%v|%v", a.Value, a.Verified, a.Via, a.Status, a.IdentityID, a.NID)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "tmp.T01PPIJfY2",
+  "name": "kratos",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -5088,7 +5088,8 @@
       "version": "7.5.7",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
       "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "y18n": {
       "version": "5.0.8",

--- a/persistence/sql/persister_identity.go
+++ b/persistence/sql/persister_identity.go
@@ -208,7 +208,7 @@ func updateAssociation[T interface {
 		Order("id ASC").
 		All(&inDB); err != nil {
 
-		return err
+		return sqlcon.HandleError(err)
 	}
 
 	newAssocs := make(map[string]*T)
@@ -227,7 +227,7 @@ func updateAssociation[T interface {
 			newAssocs[h] = nil // Ignore associations that are already in the db.
 		} else {
 			if err := p.GetConnection(ctx).Destroy(a); err != nil {
-				return err
+				return sqlcon.HandleError(err)
 			}
 		}
 	}
@@ -235,7 +235,7 @@ func updateAssociation[T interface {
 	for _, a := range newAssocs {
 		if a != nil {
 			if err := p.GetConnection(ctx).Create(a); err != nil {
-				return err
+				return sqlcon.HandleError(err)
 			}
 		}
 	}
@@ -426,7 +426,7 @@ func (p *Persister) UpdateIdentity(ctx context.Context, i *identity.Identity) er
 				new(identity.Credentials).TableName(ctx)),
 			i.ID, p.NetworkID(ctx)).Exec(); err != nil {
 
-			return err
+			return sqlcon.HandleError(err)
 		}
 
 		if err := p.update(WithTransaction(ctx, tx), i); err != nil {

--- a/persistence/sql/persister_test.go
+++ b/persistence/sql/persister_test.go
@@ -285,7 +285,7 @@ func TestPersister_Transaction(t *testing.T) {
 			Traits: ri.Traits(`{}`),
 		}
 		errMessage := "failing because why not"
-		err := p.Transaction(context.Background(), func(ctx context.Context, connection *pop.Connection) error {
+		err := p.Transaction(context.Background(), func(_ context.Context, connection *pop.Connection) error {
 			require.NoError(t, connection.Create(i))
 			return errors.Errorf(errMessage)
 		})


### PR DESCRIPTION
This PR modifies persister.UpdateIdentity to only update the recovery addresses that changed, leaving the unchanged once (and their associated recovery tokens) valid.

Shout-out to @thcyron for the analysis.

Fixes #2433

---

## TODO

- [x] Is everything Go 1.18 ready? (CI, Docker, ...)