### PR TITLE
feat: complete session devices upsert

### DIFF
--- a/persistence/sql/migratest/testdata/20220907132836_testdata.sql
+++ b/persistence/sql/migratest/testdata/20220907132836_testdata.sql
@@ -5,7 +5,7 @@ VALUES ('7458af86-c1d8-401c-978a-8da89133f98b', '884f556e-eb3a-4b9f-bee3-1134564
         'eVwBt7UAAAAVwBt7XAMw', '5ff66179-c240-4703-b0d8-494592cefff5', true, '123eVwBt7UAAAeVwBt7XAMw', 'aal2',
         '[{"method":"password"},{"method":"totp"}]');
 
-INSERT INTO session_devices (id, nid, session_id, ip_address, user_agent, location, created_at, last_seen)
+INSERT INTO session_devices (id, nid, session_id, ip_address, user_agent, location, created_at, updated_at)
 VALUES ('884f556e-eb3a-4b9f-bee3-11763642c6c0', '884f556e-eb3a-4b9f-bee3-11345642c6c0',
         '7458af86-c1d8-401c-978a-8da89133f98b', '54.155.246.232',
         'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36',

--- a/persistence/sql/migrations/sql/20220907132836000000_sessions_add_client_fields.cockroach.up.sql
+++ b/persistence/sql/migrations/sql/20220907132836000000_sessions_add_client_fields.cockroach.up.sql
@@ -8,7 +8,7 @@ CREATE TABLE "session_devices"
   "session_id" UUID      NOT NULL,
   "nid"        UUID      NOT NULL,
   "created_at" timestamp NOT NULL,
-  "last_seen"  timestamp NOT NULL,
+  "updated_at"  timestamp NOT NULL,
   CONSTRAINT "session_metadata_sessions_id_fk" FOREIGN KEY ("session_id") REFERENCES "sessions" ("id") ON DELETE cascade,
   CONSTRAINT "session_metadata_nid_fk" FOREIGN KEY ("nid") REFERENCES "networks" ("id") ON DELETE cascade,
   CONSTRAINT unique_session_device UNIQUE (nid, session_id, ip_address, user_agent)

--- a/persistence/sql/migrations/sql/20220907132836000000_sessions_add_client_fields.cockroach.up.sql
+++ b/persistence/sql/migrations/sql/20220907132836000000_sessions_add_client_fields.cockroach.up.sql
@@ -10,5 +10,6 @@ CREATE TABLE "session_devices"
   "created_at" timestamp NOT NULL,
   "last_seen"  timestamp NOT NULL,
   CONSTRAINT "session_metadata_sessions_id_fk" FOREIGN KEY ("session_id") REFERENCES "sessions" ("id") ON DELETE cascade,
-  CONSTRAINT "session_metadata_nid_fk" FOREIGN KEY ("nid") REFERENCES "networks" ("id") ON DELETE cascade
+  CONSTRAINT "session_metadata_nid_fk" FOREIGN KEY ("nid") REFERENCES "networks" ("id") ON DELETE cascade,
+  CONSTRAINT unique_session_device UNIQUE (nid, session_id, ip_address, user_agent)
 );

--- a/persistence/sql/migrations/sql/20220907132836000000_sessions_add_client_fields.mysql.up.sql
+++ b/persistence/sql/migrations/sql/20220907132836000000_sessions_add_client_fields.mysql.up.sql
@@ -10,5 +10,6 @@ CREATE TABLE `session_devices`
   `created_at` DATETIME NOT NULL,
   `last_seen`  DATETIME NOT NULL,
   FOREIGN KEY (`session_id`) REFERENCES `sessions` (`id`) ON DELETE cascade,
-  FOREIGN KEY (`nid`) REFERENCES `networks` (`id`) ON DELETE cascade
+  FOREIGN KEY (`nid`) REFERENCES `networks` (`id`) ON DELETE cascade,
+  CONSTRAINT unique_session_device UNIQUE (nid, session_id, ip_address, user_agent)
 ) ENGINE = InnoDB;

--- a/persistence/sql/migrations/sql/20220907132836000000_sessions_add_client_fields.mysql.up.sql
+++ b/persistence/sql/migrations/sql/20220907132836000000_sessions_add_client_fields.mysql.up.sql
@@ -8,7 +8,7 @@ CREATE TABLE `session_devices`
   `session_id` char(36) NOT NULL,
   `nid`        char(36) NOT NULL,
   `created_at` DATETIME NOT NULL,
-  `last_seen`  DATETIME NOT NULL,
+  `updated_at`  DATETIME NOT NULL,
   FOREIGN KEY (`session_id`) REFERENCES `sessions` (`id`) ON DELETE cascade,
   FOREIGN KEY (`nid`) REFERENCES `networks` (`id`) ON DELETE cascade,
   CONSTRAINT unique_session_device UNIQUE (nid, session_id, ip_address, user_agent)

--- a/persistence/sql/migrations/sql/20220907132836000000_sessions_add_client_fields.postgres.up.sql
+++ b/persistence/sql/migrations/sql/20220907132836000000_sessions_add_client_fields.postgres.up.sql
@@ -10,5 +10,6 @@ CREATE TABLE "session_devices"
   "created_at" timestamp NOT NULL,
   "last_seen"  timestamp NOT NULL,
   FOREIGN KEY ("session_id") REFERENCES "sessions" ("id") ON DELETE cascade,
-  FOREIGN KEY ("nid") REFERENCES "networks" ("id") ON DELETE cascade
+  FOREIGN KEY ("nid") REFERENCES "networks" ("id") ON DELETE cascade,
+  CONSTRAINT unique_session_device UNIQUE (nid, session_id, ip_address, user_agent)
 );

--- a/persistence/sql/migrations/sql/20220907132836000000_sessions_add_client_fields.postgres.up.sql
+++ b/persistence/sql/migrations/sql/20220907132836000000_sessions_add_client_fields.postgres.up.sql
@@ -8,7 +8,7 @@ CREATE TABLE "session_devices"
   "nid"        UUID      NOT NULL,
   "session_id" UUID      NOT NULL,
   "created_at" timestamp NOT NULL,
-  "last_seen"  timestamp NOT NULL,
+  "updated_at"  timestamp NOT NULL,
   FOREIGN KEY ("session_id") REFERENCES "sessions" ("id") ON DELETE cascade,
   FOREIGN KEY ("nid") REFERENCES "networks" ("id") ON DELETE cascade,
   CONSTRAINT unique_session_device UNIQUE (nid, session_id, ip_address, user_agent)

--- a/persistence/sql/migrations/sql/20220907132836000000_sessions_add_client_fields.sqlite3.up.sql
+++ b/persistence/sql/migrations/sql/20220907132836000000_sessions_add_client_fields.sqlite3.up.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS "session_devices"
   "session_id" UUID      NOT NULL,
   "nid"        UUID      NOT NULL,
   "created_at" timestamp NOT NULL,
-  "last_seen"  timestamp NOT NULL,
+  "updated_at"  timestamp NOT NULL,
   FOREIGN KEY ("session_id") REFERENCES "sessions" ("id") ON DELETE cascade,
   FOREIGN KEY ("nid") REFERENCES "networks" ("id") ON DELETE cascade,
   CONSTRAINT unique_session_device UNIQUE (nid, session_id, ip_address, user_agent)

--- a/persistence/sql/migrations/sql/20220907132836000000_sessions_add_client_fields.sqlite3.up.sql
+++ b/persistence/sql/migrations/sql/20220907132836000000_sessions_add_client_fields.sqlite3.up.sql
@@ -9,5 +9,6 @@ CREATE TABLE IF NOT EXISTS "session_devices"
   "created_at" timestamp NOT NULL,
   "last_seen"  timestamp NOT NULL,
   FOREIGN KEY ("session_id") REFERENCES "sessions" ("id") ON DELETE cascade,
-  FOREIGN KEY ("nid") REFERENCES "networks" ("id") ON DELETE cascade
+  FOREIGN KEY ("nid") REFERENCES "networks" ("id") ON DELETE cascade,
+  CONSTRAINT unique_session_device UNIQUE (nid, session_id, ip_address, user_agent)
 );

--- a/persistence/sql/persister_session.go
+++ b/persistence/sql/persister_session.go
@@ -91,7 +91,7 @@ func (p *Persister) UpsertSession(ctx context.Context, s *session.Session) error
 				return err
 			}
 
-			for i := 0; i < len(s.Devices); i++ {
+			for i := range s.Devices {
 				device := &(s.Devices[i])
 				device.SessionID = s.ID
 				device.NID = s.NID

--- a/persistence/sql/persister_session.go
+++ b/persistence/sql/persister_session.go
@@ -96,8 +96,7 @@ func (p *Persister) UpsertSession(ctx context.Context, s *session.Session) error
 				device.SessionID = s.ID
 				device.NID = s.NID
 
-				err = tx.Create(device)
-				if err != nil {
+				if err := tx.Create(device); err != nil {
 					return err
 				}
 

--- a/session/persistence.go
+++ b/session/persistence.go
@@ -23,9 +23,6 @@ type Persister interface {
 	// GetSession retrieves a session from the store.
 	GetSession(ctx context.Context, sid uuid.UUID) (*Session, error)
 
-	// GetSessionDevices retrieves all the device session history from the store
-	GetSessionDevices(ctx context.Context, sid uuid.UUID) ([]Device, error)
-
 	// ListSessionsByIdentity retrieves sessions for an identity from the store.
 	ListSessionsByIdentity(ctx context.Context, iID uuid.UUID, active *bool, page, perPage int, except uuid.UUID) ([]*Session, error)
 

--- a/session/session.go
+++ b/session/session.go
@@ -57,7 +57,7 @@ type Device struct {
 	CreatedAt time.Time `json:"seen_at" faker:"-" db:"created_at"`
 
 	// Last seen
-	LastSeen time.Time `json:"last_seen" faker:"-" db:"last_seen"`
+	UpdatedAt time.Time `json:"last_seen" faker:"-" db:"updated_at"`
 
 	NID uuid.UUID `json:"-"  faker:"-" db:"nid"`
 }
@@ -231,8 +231,6 @@ func (s *Session) SaveSessionDeviceInformation(r *http.Request) {
 
 	device.ID = x.NewUUID()
 	device.SessionID = s.ID
-	device.CreatedAt = time.Now().UTC()
-	device.LastSeen = time.Now().UTC()
 
 	agent := r.Header["User-Agent"]
 	if len(agent) > 0 {

--- a/session/session.go
+++ b/session/session.go
@@ -119,7 +119,7 @@ type Session struct {
 	Identity *identity.Identity `json:"identity" faker:"identity" db:"-" belongs_to:"identities" fk_id:"IdentityID"`
 
 	// Devices has history of all endpoints where the session was used
-	Devices []Device `json:"devices" faker:"-" db:"-"`
+	Devices []Device `json:"devices" faker:"-" has_many:"session_devices" fk_id:"session_id"`
 
 	// IdentityID is a helper struct field for gobuffalo.pop.
 	IdentityID uuid.UUID `json:"-" faker:"-" db:"identity_id"`

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -99,7 +99,7 @@ func TestSession(t *testing.T) {
 		assert.Equal(t, authAt, s.AuthenticatedAt)
 		assert.Equal(t, 1, len(s.Devices))
 		assert.Equal(t, s.ID.String(), s.Devices[0].SessionID.String())
-		assert.NotNil(t, s.Devices[0].LastSeen)
+		assert.NotNil(t, s.Devices[0].UpdatedAt)
 		assert.NotNil(t, s.Devices[0].CreatedAt)
 		assert.Equal(t, "54.155.246.155", *s.Devices[0].IPAddress)
 		assert.Equal(t, "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36", *s.Devices[0].UserAgent)


### PR DESCRIPTION
This PR fixes the eager query for Session devices and adds the creation of the devices in the Upsert. The update operation for devices doesn't belong with the upsert as at most one device would need an update (Due to change of IP or simply updating the `last_seen` timestamp).

Fixes - https://github.com/ory/kratos/pull/2715#discussion_r970537554