### PR TITLE
chore: dont format auto-generated files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,8 @@ quickstart-dev:
 # Formats the code
 .PHONY: format
 format: .bin/goimports node_modules
+		# workaround because goimports doesn't allow ignoring folders yet, see https://github.com/golang/go/issues/42965
+		find . -type f -name '*.go' -not -path './internal/httpclient/*' | xargs .bin/goimports -w --local github.com/ory
 		goimports -w -local github.com/ory .
 		npm exec -- prettier --write 'test/e2e/**/*{.ts,.js}'
 		npm exec -- prettier --write '.github'


### PR DESCRIPTION
Goimports doesn't provide a built-in mechanism to ignore certain directories. See https://github.com/golang/go/issues/42965. This creates a workaround that is still fast enough.

## Related issue(s)

https://github.com/ory-corp/general/issues/735

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](https://github.com/ory/docs).
