### PR TITLE
chore: remove listx dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ export VCS_REF            := $(shell git rev-parse HEAD)
 export QUICKSTART_OPTIONS ?= ""
 
 GO_DEPENDENCIES = github.com/ory/go-acc \
-				  github.com/ory/x/tools/listx \
 				  github.com/golang/mock/mockgen \
 				  github.com/go-swagger/go-swagger/cmd/swagger \
 				  golang.org/x/tools/cmd/goimports \

--- a/go_mod_indirect_pins.go
+++ b/go_mod_indirect_pins.go
@@ -12,7 +12,6 @@ import (
 	_ "github.com/gobuffalo/fizz"
 
 	_ "github.com/ory/go-acc"
-	_ "github.com/ory/x/tools/listx"
 
 	_ "github.com/jteeuwen/go-bindata"
 


### PR DESCRIPTION
listx doesn't seem to be used anywhere in this repo. Looking at https://github.com/ory/x/blob/master/tools/listx/main.go, it seem replacable with `find -f -name "*.go" -not -path "./vendor/"`. Given that there isn't a vendor folder anymore, this seems obsolete altogether.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).
