### PR TITLE
fix: identity sessions list response includes pagination headers

### DIFF
--- a/session/handler.go
+++ b/session/handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/ory/x/decoderx"
+	"github.com/ory/x/urlx"
 
 	"github.com/ory/herodot"
 
@@ -304,12 +305,13 @@ func (h *Handler) adminListIdentitySessions(w http.ResponseWriter, r *http.Reque
 	}
 
 	page, perPage := x.ParsePagination(r)
-	sess, err := h.r.SessionPersister().ListSessionsByIdentity(r.Context(), iID, active, page, perPage, uuid.Nil, ExpandEverything)
+	sess, total, err := h.r.SessionPersister().ListSessionsByIdentity(r.Context(), iID, active, page, perPage, uuid.Nil, ExpandEverything)
 	if err != nil {
 		h.r.Writer().WriteError(w, r, err)
 		return
 	}
 
+	x.PaginationHeader(w, urlx.AppendPaths(h.r.Config().SelfAdminURL(r.Context()), RouteCollection), total, page, perPage)
 	h.r.Writer().Write(w, r, sess)
 }
 
@@ -448,12 +450,13 @@ func (h *Handler) listSessions(w http.ResponseWriter, r *http.Request, _ httprou
 	}
 
 	page, perPage := x.ParsePagination(r)
-	sess, err := h.r.SessionPersister().ListSessionsByIdentity(r.Context(), s.IdentityID, pointerx.Bool(true), page, perPage, s.ID, ExpandEverything)
+	sess, total, err := h.r.SessionPersister().ListSessionsByIdentity(r.Context(), s.IdentityID, pointerx.Bool(true), page, perPage, s.ID, ExpandEverything)
 	if err != nil {
 		h.r.Writer().WriteError(w, r, err)
 		return
 	}
 
+	x.PaginationHeader(w, urlx.AppendPaths(h.r.Config().SelfAdminURL(r.Context()), RouteCollection), total, page, perPage)
 	h.r.Writer().Write(w, r, sess)
 }
 

--- a/session/handler_test.go
+++ b/session/handler_test.go
@@ -601,9 +601,10 @@ func TestHandlerSelfServiceSessionManagement(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, http.StatusNoContent, res.StatusCode)
 
-		actualOthers, err := reg.SessionPersister().ListSessionsByIdentity(ctx, i.ID, nil, 1, 10, uuid.Nil, ExpandNothing)
+		actualOthers, total, err := reg.SessionPersister().ListSessionsByIdentity(ctx, i.ID, nil, 1, 10, uuid.Nil, ExpandNothing)
 		require.NoError(t, err)
 		require.Len(t, actualOthers, 3)
+		require.Equal(t, int64(3), total)
 
 		for _, s := range actualOthers {
 			if s.ID == others[0].ID {

--- a/session/handler_test.go
+++ b/session/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -472,6 +473,61 @@ func TestHandlerAdminSessionManagement(t *testing.T) {
 		require.Equal(t, http.StatusNotFound, res.StatusCode)
 	})
 
+	t.Run("case=should return pagination headers on list response", func(t *testing.T) {
+		client := testhelpers.NewClientWithCookies(t)
+		i := identity.NewIdentity("")
+		require.NoError(t, reg.IdentityManager().Create(ctx, i))
+
+		numSessions := 5
+		numSessionsActive := 2
+
+		sess := make([]Session, numSessions)
+		for j := range sess {
+			require.NoError(t, faker.FakeData(&sess[j]))
+			sess[j].Identity = i
+			if j < numSessionsActive {
+				sess[j].Active = true
+			} else {
+				sess[j].Active = false
+			}
+			require.NoError(t, reg.SessionPersister().UpsertSession(ctx, &sess[j]))
+		}
+
+		for _, tc := range []struct {
+			activeOnly         string
+			expectedTotalCount int
+		}{
+			{
+				activeOnly:         "true",
+				expectedTotalCount: numSessionsActive,
+			},
+			{
+				activeOnly:         "false",
+				expectedTotalCount: numSessions - numSessionsActive,
+			},
+			{
+				activeOnly:         "",
+				expectedTotalCount: numSessions,
+			},
+		} {
+			t.Run(fmt.Sprintf("active=%#v", tc.activeOnly), func(t *testing.T) {
+				reqURL := ts.URL + "/admin/identities/" + i.ID.String() + "/sessions"
+				if tc.activeOnly != "" {
+					reqURL += "?active=" + tc.activeOnly
+				}
+				req, _ := http.NewRequest("GET", reqURL, nil)
+				res, err := client.Do(req)
+				require.NoError(t, err)
+				require.Equal(t, http.StatusOK, res.StatusCode)
+
+				totalCount, err := strconv.Atoi(res.Header.Get("X-Total-Count"))
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedTotalCount, totalCount)
+				require.NotEqual(t, "", res.Header.Get("Link"))
+			})
+		}
+	})
+
 	t.Run("case=should respect active on list", func(t *testing.T) {
 		client := testhelpers.NewClientWithCookies(t)
 		i := identity.NewIdentity("")
@@ -558,6 +614,36 @@ func TestHandlerSelfServiceSessionManagement(t *testing.T) {
 			return client, i, <-sess
 		}
 	}
+
+	t.Run("case=list should return pagination headers", func(t *testing.T) {
+		client, i, _ := setup(t)
+
+		numSessions := 5
+		numSessionsActive := 2
+
+		sess := make([]Session, numSessions)
+		for j := range sess {
+			require.NoError(t, faker.FakeData(&sess[j]))
+			sess[j].Identity = i
+			if j < numSessionsActive {
+				sess[j].Active = true
+			} else {
+				sess[j].Active = false
+			}
+			require.NoError(t, reg.SessionPersister().UpsertSession(ctx, &sess[j]))
+		}
+
+		reqURL := ts.URL + "/sessions"
+		req, _ := http.NewRequest("GET", reqURL, nil)
+		res, err := client.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		totalCount, err := strconv.Atoi(res.Header.Get("X-Total-Count"))
+		require.NoError(t, err)
+		require.Equal(t, numSessionsActive, totalCount)
+		require.NotEqual(t, "", res.Header.Get("Link"))
+	})
 
 	t.Run("case=should return 200 and number after invalidating all other sessions", func(t *testing.T) {
 		client, i, currSess := setup(t)

--- a/session/persistence.go
+++ b/session/persistence.go
@@ -16,7 +16,7 @@ type Persister interface {
 	GetSession(ctx context.Context, sid uuid.UUID, expandables Expandables) (*Session, error)
 
 	// ListSessionsByIdentity retrieves sessions for an identity from the store.
-	ListSessionsByIdentity(ctx context.Context, iID uuid.UUID, active *bool, page, perPage int, except uuid.UUID, expandables Expandables) ([]*Session, error)
+	ListSessionsByIdentity(ctx context.Context, iID uuid.UUID, active *bool, page, perPage int, except uuid.UUID, expandables Expandables) ([]*Session, int64, error)
 
 	// UpsertSession inserts or updates a session into / in the store.
 	UpsertSession(ctx context.Context, s *Session) error

--- a/session/test/persistence.go
+++ b/session/test/persistence.go
@@ -178,10 +178,11 @@ func TestPersister(ctx context.Context, conf *config.Config, p interface {
 					},
 				} {
 					t.Run("case="+tc.desc, func(t *testing.T) {
-						actual, err := p.ListSessionsByIdentity(ctx, i.ID, tc.active, 1, 10, tc.except, session.ExpandEverything)
+						actual, total, err := p.ListSessionsByIdentity(ctx, i.ID, tc.active, 1, 10, tc.except, session.ExpandEverything)
 						require.NoError(t, err)
 
 						require.Equal(t, len(tc.expected), len(actual))
+						require.Equal(t, int64(len(tc.expected)), total)
 						for _, es := range tc.expected {
 							found := false
 							for _, as := range actual {
@@ -197,8 +198,9 @@ func TestPersister(ctx context.Context, conf *config.Config, p interface {
 
 				t.Run("other network", func(t *testing.T) {
 					_, other := testhelpers.NewNetwork(t, ctx, p)
-					actual, err := other.ListSessionsByIdentity(ctx, i.ID, nil, 1, 10, uuid.Nil, session.ExpandNothing)
+					actual, total, err := other.ListSessionsByIdentity(ctx, i.ID, nil, 1, 10, uuid.Nil, session.ExpandNothing)
 					require.NoError(t, err)
+					require.Equal(t, int64(0), total)
 					assert.Len(t, actual, 0)
 				})
 			})
@@ -322,9 +324,10 @@ func TestPersister(ctx context.Context, conf *config.Config, p interface {
 			require.NoError(t, err)
 			assert.Equal(t, 1, n)
 
-			actual, err := p.ListSessionsByIdentity(ctx, sessions[0].IdentityID, nil, 1, 10, uuid.Nil, session.ExpandNothing)
+			actual, total, err := p.ListSessionsByIdentity(ctx, sessions[0].IdentityID, nil, 1, 10, uuid.Nil, session.ExpandNothing)
 			require.NoError(t, err)
 			require.Len(t, actual, 2)
+			require.Equal(t, int64(2), total)
 
 			if actual[0].ID == sessions[0].ID {
 				assert.True(t, actual[0].Active)
@@ -335,9 +338,10 @@ func TestPersister(ctx context.Context, conf *config.Config, p interface {
 				assert.False(t, actual[0].Active)
 			}
 
-			otherIdentitiesSessions, err := p.ListSessionsByIdentity(ctx, sessions[2].IdentityID, nil, 1, 10, uuid.Nil, session.ExpandNothing)
+			otherIdentitiesSessions, total, err := p.ListSessionsByIdentity(ctx, sessions[2].IdentityID, nil, 1, 10, uuid.Nil, session.ExpandNothing)
 			require.NoError(t, err)
 			require.Len(t, actual, 2)
+			require.Equal(t, int64(2), total)
 
 			for _, s := range otherIdentitiesSessions {
 				assert.True(t, s.Active)
@@ -369,9 +373,10 @@ func TestPersister(ctx context.Context, conf *config.Config, p interface {
 
 			require.NoError(t, p.RevokeSession(ctx, sessions[0].IdentityID, sessions[0].ID))
 
-			actual, err := p.ListSessionsByIdentity(ctx, sessions[0].IdentityID, nil, 1, 10, uuid.Nil, session.ExpandNothing)
+			actual, total, err := p.ListSessionsByIdentity(ctx, sessions[0].IdentityID, nil, 1, 10, uuid.Nil, session.ExpandNothing)
 			require.NoError(t, err)
 			require.Len(t, actual, 2)
+			require.Equal(t, int64(2), total)
 
 			if actual[0].ID == sessions[0].ID {
 				assert.False(t, actual[0].Active)


### PR DESCRIPTION
This resolves issue #2762

This resolves the issue of missing pagination headers in the response to the `/admin/identities/{id}/sessions` endpoint by adding a `CountSessionsByIdentity` function to the `persistence` module, and then using that new function within the api handler to get the total records count needed for calling the `x.PaginationHeader` function.

The `CountSessionsByIdentity` function is scoped to the provided Identity ID, and respects the `active` query parameter if it was present. 


Changelog entry:

```
Fixed adminListIdentitySessions endpoint response missing pagination headers
```

## Related issue(s)

This PR resolves the following ticket, which I just opened a short bit ago to comply with the Contributions guide. That ticket details the issue more thoroughly, including the steps for reproducing the issue.

#2762


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature. **(not applicable, I think)**
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](https://github.com/ory/docs).
  (This is checked because technically this change fixes compliance with the existing documentation

## Further Comments

I opened this PR pretty quickly after opening the linked issue, even though no feedback has been provided on said issue. After digging through the code, I was pretty confident that this omission is actually a bug and not an intentional design decision. It only took a few minutes to track through the codebase to make the necessary changes, so I figured it was worth opening the PR before receiving feedback on the issue 🤷 
