### PR TITLE
chore: cli do not pass down root

### DIFF
--- a/.docker/Dockerfile-build
+++ b/.docker/Dockerfile-build
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1-experimental
-FROM golang:1.18-alpine3.16 AS base
+FROM golang:1.19-alpine3.16 AS base
 
 RUN apk --update upgrade && apk --no-cache --update-cache --upgrade --latest add ca-certificates build-base gcc
 

--- a/.docker/Dockerfile-debug
+++ b/.docker/Dockerfile-debug
@@ -1,4 +1,4 @@
-FROM golang:1.18-buster
+FROM golang:1.19-buster
 ENV CGO_ENABLED 1
 
 RUN apt-get update && apt-get install -y --no-install-recommends inotify-tools psmisc

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,7 +77,7 @@ jobs:
           fetch-depth: 2
       - uses: actions/setup-go@v2
         with:
-          go-version: "~1.18"
+          go-version: "1.19"
       - run: go list -json > go.list
       - name: Run nancy
         uses: sonatype-nexus-community/nancy-github-action@v1.0.2
@@ -160,7 +160,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: "~1.18"
+          go-version: "1.19"
       - name: Install selfservice-ui-react-native
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,7 +89,7 @@ jobs:
           GOGC: 100
         with:
           args: --timeout 10m0s
-          version: v1.47.3
+          version: v1.49.0
           skip-go-installation: true
           skip-pkg-cache: true
       - name: Build Kratos

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,15 +1,12 @@
 linters:
   enable:
-    - deadcode
     - errcheck
     - gosimple
     - govet
     - staticcheck
-    - structcheck
     - typecheck
     - unused
     - gosec
-    - varcheck
 #    - golint
     - goimports
   disable:

--- a/cmd/identities/delete.go
+++ b/cmd/identities/delete.go
@@ -10,27 +10,27 @@ import (
 	"github.com/ory/x/cmdx"
 )
 
-func NewDeleteCmd(root *cobra.Command) *cobra.Command {
+func NewDeleteCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete",
 		Short: "Delete resources",
 	}
-	cmd.AddCommand(NewDeleteIdentityCmd(root))
+	cmd.AddCommand(NewDeleteIdentityCmd())
 	cliclient.RegisterClientFlags(cmd.PersistentFlags())
 	cmdx.RegisterFormatFlags(cmd.PersistentFlags())
 	return cmd
 }
 
-func NewDeleteIdentityCmd(root *cobra.Command) *cobra.Command {
+func NewDeleteIdentityCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "identity id-0 [id-1] [id-2] [id-n]",
 		Short: "Delete one or more identities by their ID(s)",
 		Long: fmt.Sprintf(`This command deletes one or more identities by ID. To delete an identity by some selector, e.g. the recovery email address, use the list command in combination with jq.
 
 %s`, clihelpers.WarningJQIsComplicated),
-		Example: fmt.Sprintf(`To delete the identity with the recovery email address "foo@bar.com", run:
+		Example: `To delete the identity with the recovery email address "foo@bar.com", run:
 
-	%[1]s delete identity $(%[1]s list identities --format json | jq -r 'map(select(.recovery_addresses[].value == "foo@bar.com")) | .[].id')`, root.Use),
+	{{ .CommandPath }} $({{ .Root.Name }} list identities --format json | jq -r 'map(select(.recovery_addresses[].value == "foo@bar.com")) | .[].id')`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := cliclient.NewClient(cmd)

--- a/cmd/identities/delete_test.go
+++ b/cmd/identities/delete_test.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/tidwall/gjson"
 
-	"github.com/spf13/cobra"
-
 	"github.com/ory/kratos/cmd/identities"
 
 	"github.com/stretchr/testify/assert"
@@ -22,7 +20,7 @@ import (
 )
 
 func TestDeleteCmd(t *testing.T) {
-	c := identities.NewDeleteIdentityCmd(new(cobra.Command))
+	c := identities.NewDeleteIdentityCmd()
 	reg := setup(t, c)
 
 	t.Run("case=deletes successfully", func(t *testing.T) {

--- a/cmd/identities/get.go
+++ b/cmd/identities/get.go
@@ -19,18 +19,18 @@ const (
 	FlagIncludeCreds = "include-credentials"
 )
 
-func NewGetCmd(root *cobra.Command) *cobra.Command {
+func NewGetCmd() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "get",
 		Short: "Get resources",
 	}
-	cmd.AddCommand(NewGetIdentityCmd(root))
+	cmd.AddCommand(NewGetIdentityCmd())
 	cliclient.RegisterClientFlags(cmd.PersistentFlags())
 	cmdx.RegisterFormatFlags(cmd.PersistentFlags())
 	return cmd
 }
 
-func NewGetIdentityCmd(root *cobra.Command) *cobra.Command {
+func NewGetIdentityCmd() *cobra.Command {
 	var (
 		includeCreds []string
 	)
@@ -41,9 +41,9 @@ func NewGetIdentityCmd(root *cobra.Command) *cobra.Command {
 		Long: fmt.Sprintf(`This command gets all the details about an identity. To get an identity by some selector, e.g. the recovery email address, use the list command in combination with jq.
 
 %s`, clihelpers.WarningJQIsComplicated),
-		Example: fmt.Sprintf(`To get the identities with the recovery email address at the domain "ory.sh", run:
+		Example: `To get the identities with the recovery email address at the domain "ory.sh", run:
 
-	%s get identity $(%[1]s ls identities --format json | jq -r 'map(select(.recovery_addresses[].value | endswith("@ory.sh"))) | .[].id')`, root.Use),
+	{{ .CommandPath }} $({{ .Root.Name }} ls identities --format json | jq -r 'map(select(.recovery_addresses[].value | endswith("@ory.sh"))) | .[].id')`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := cliclient.NewClient(cmd)

--- a/cmd/identities/get_test.go
+++ b/cmd/identities/get_test.go
@@ -6,8 +6,6 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/spf13/cobra"
-
 	"github.com/ory/kratos/cmd/identities"
 	"github.com/ory/x/assertx"
 
@@ -21,7 +19,7 @@ import (
 )
 
 func TestGetCmd(t *testing.T) {
-	c := identities.NewGetIdentityCmd(new(cobra.Command))
+	c := identities.NewGetIdentityCmd()
 	reg := setup(t, c)
 
 	t.Run("case=gets a single identity", func(t *testing.T) {

--- a/cmd/identities/import.go
+++ b/cmd/identities/import.go
@@ -13,23 +13,23 @@ import (
 	"github.com/ory/kratos/cmd/cliclient"
 )
 
-func NewImportCmd(root *cobra.Command) *cobra.Command {
+func NewImportCmd() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "import",
 		Short: "Import resources",
 	}
-	cmd.AddCommand(NewImportIdentitiesCmd(root))
+	cmd.AddCommand(NewImportIdentitiesCmd())
 	cliclient.RegisterClientFlags(cmd.PersistentFlags())
 	cmdx.RegisterFormatFlags(cmd.PersistentFlags())
 	return cmd
 }
 
 // NewImportIdentitiesCmd represents the import command
-func NewImportIdentitiesCmd(root *cobra.Command) *cobra.Command {
+func NewImportIdentitiesCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "identities file-1.json [file-2.json] [file-3.json] [file-n.json]",
 		Short: "Import one or more identities from files or STD_IN",
-		Example: fmt.Sprintf(`Create an example identity:
+		Example: `Create an example identity:
 
 	cat > ./file.json <<EOF
 	{
@@ -40,11 +40,11 @@ func NewImportIdentitiesCmd(root *cobra.Command) *cobra.Command {
 	}
 	EOF
 
-	%[1]s import identities file.json
+	{{ .CommandPath }} file.json
 
 Alternatively:
 
-	cat file.json | %[1]s import identities`, root.Use),
+	cat file.json | {{ .CommandPath }}`,
 		Long: `Import identities from files or STD_IN.
 
 Files can contain only a single or an array of identities. The validity of files can be tested beforehand using "... identities validate".`,

--- a/cmd/identities/import_test.go
+++ b/cmd/identities/import_test.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/spf13/cobra"
-
 	"github.com/ory/kratos/cmd/identities"
 
 	"github.com/gofrs/uuid"
@@ -21,7 +19,7 @@ import (
 )
 
 func TestImportCmd(t *testing.T) {
-	c := identities.NewImportIdentitiesCmd(new(cobra.Command))
+	c := identities.NewImportIdentitiesCmd()
 	reg := setup(t, c)
 
 	t.Run("case=imports a new identity from file", func(t *testing.T) {

--- a/cmd/identities/list.go
+++ b/cmd/identities/list.go
@@ -1,32 +1,30 @@
 package identities
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"github.com/ory/kratos/cmd/cliclient"
 	"github.com/ory/x/cmdx"
 )
 
-func NewListCmd(root *cobra.Command) *cobra.Command {
+func NewListCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List resources",
 	}
-	c.AddCommand(NewListIdentitiesCmd(root))
+	c.AddCommand(NewListIdentitiesCmd())
 	cliclient.RegisterClientFlags(c.PersistentFlags())
 	cmdx.RegisterFormatFlags(c.PersistentFlags())
 	return c
 }
 
-func NewListIdentitiesCmd(root *cobra.Command) *cobra.Command {
+func NewListIdentitiesCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "identities [<page> <per-page>]",
 		Short:   "List identities",
 		Long:    "List identities (paginated)",
-		Example: fmt.Sprintf("%[1]s ls identities 100 1", root.Use),
+		Example: "{{ .CommandPath }} 100 1",
 		Args:    cmdx.ZeroOrTwoArgs,
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/identities/list_test.go
+++ b/cmd/identities/list_test.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/spf13/cobra"
-
 	"github.com/ory/kratos/cmd/identities"
 
 	"github.com/ory/x/cmdx"
@@ -18,7 +16,7 @@ import (
 )
 
 func TestListCmd(t *testing.T) {
-	c := identities.NewListIdentitiesCmd(new(cobra.Command))
+	c := identities.NewListIdentitiesCmd()
 	reg := setup(t, c)
 	require.NoError(t, c.Flags().Set(cmdx.FlagQuiet, "true"))
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,19 +23,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// RootCmd represents the base command when called without any subcommands
 func NewRootCmd() (cmd *cobra.Command) {
 	cmd = &cobra.Command{
 		Use: "kratos",
 	}
+	cmdx.EnableUsageTemplating(cmd)
+
 	courier.RegisterCommandRecursive(cmd, nil, nil)
-	cmd.AddCommand(identities.NewGetCmd(cmd))
-	cmd.AddCommand(identities.NewDeleteCmd(cmd))
+	cmd.AddCommand(identities.NewGetCmd())
+	cmd.AddCommand(identities.NewDeleteCmd())
 	cmd.AddCommand(jsonnet.NewFormatCmd())
 	hashers.RegisterCommandRecursive(cmd)
-	cmd.AddCommand(identities.NewImportCmd(cmd))
+	cmd.AddCommand(identities.NewImportCmd())
 	cmd.AddCommand(jsonnet.NewLintCmd())
-	cmd.AddCommand(identities.NewListCmd(cmd))
+	cmd.AddCommand(identities.NewListCmd())
 	migrate.RegisterCommandRecursive(cmd)
 	serve.RegisterCommandRecursive(cmd, nil, nil)
 	cleanup.RegisterCommandRecursive(cmd)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,11 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/ory/x/cmdx"
+)
+
+func TestUsageStrings(t *testing.T) {
+	cmdx.AssertUsageTemplates(t, NewRootCmd())
+}

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/go-errors/errors v1.0.1
 	github.com/go-openapi/strfmt v0.21.3
 	github.com/go-playground/validator/v10 v10.4.1
-	github.com/go-swagger/go-swagger v0.30.0
+	github.com/go-swagger/go-swagger v0.30.3
 	github.com/gobuffalo/fizz v1.14.2
 	github.com/gobuffalo/httptest v1.0.2
 	github.com/gobuffalo/pop/v6 v6.0.6
@@ -76,7 +76,7 @@ require (
 	github.com/ory/kratos-client-go v0.6.3-alpha.1
 	github.com/ory/mail/v3 v3.0.0
 	github.com/ory/nosurf v1.2.7
-	github.com/ory/x v0.0.474
+	github.com/ory/x v0.0.480
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.3.0
@@ -93,7 +93,7 @@ require (
 	github.com/zmb3/spotify/v2 v2.0.0
 	go.opentelemetry.io/otel v1.9.0
 	go.opentelemetry.io/otel/trace v1.9.0
-	golang.org/x/crypto v0.0.0-20220817201139-bc19a97f63c8
+	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90
 	golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b
 	golang.org/x/oauth2 v0.0.0-20220822191816-0ebed06d0094
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ory/kratos
 
-go 1.18
+go 1.19
 
 replace (
 	github.com/bradleyjkemp/cupaloy/v2 => github.com/aeneasr/cupaloy/v2 v2.6.1-0.20210924214125-3dfdd01210a3

--- a/go.sum
+++ b/go.sum
@@ -639,8 +639,8 @@ github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LB
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-stack/stack v1.8.1 h1:ntEHSVwIt7PNXNpgPmVfMrNhLtgjlmnZha2kOpuRiDw=
 github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP3XYfe4=
-github.com/go-swagger/go-swagger v0.30.0 h1:HakSyutD7Ek9ndkR8Fxy6WAoQtgu7UcAmZCTa6SzawA=
-github.com/go-swagger/go-swagger v0.30.0/go.mod h1:GhZVX/KIBM4VpGp4P7AJOIrlTuBeRVPS+j9kk6rFmfY=
+github.com/go-swagger/go-swagger v0.30.3 h1:HuzvdMRed/9Q8vmzVcfNBQByZVtT79DNZxZ18OprdoI=
+github.com/go-swagger/go-swagger v0.30.3/go.mod h1:neDPes8r8PCz2JPvHRDj8BTULLh4VJUt7n6MpQqxhHM=
 github.com/go-swagger/scan-repo-boundary v0.0.0-20180623220736-973b3573c013 h1:l9rI6sNaZgNC0LnF3MiE+qTmyBA/tZAg1rtyrGbUMK0=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
@@ -1381,8 +1381,8 @@ github.com/ory/sessions v1.2.2-0.20220110165800-b09c17334dc2 h1:zm6sDvHy/U9XrGpi
 github.com/ory/sessions v1.2.2-0.20220110165800-b09c17334dc2/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/ory/viper v1.7.5 h1:+xVdq7SU3e1vNaCsk/ixsfxE4zylk1TJUiJrY647jUE=
 github.com/ory/viper v1.7.5/go.mod h1:ypOuyJmEUb3oENywQZRgeAMwqgOyDqwboO1tj3DjTaM=
-github.com/ory/x v0.0.474 h1:AZT+RGoKw33hOxUiSi3x2/mD0POmMKEB/lYpJpJPlrw=
-github.com/ory/x v0.0.474/go.mod h1:w2gwqgw3XqKTxW8wURVxUFI2NuDyIC2rGxvEsnBJqjs=
+github.com/ory/x v0.0.480 h1:IAflszUfmpy/bVnd8gxIgKuL9pL1oLjytxqCmAMC14o=
+github.com/ory/x v0.0.480/go.mod h1:w2gwqgw3XqKTxW8wURVxUFI2NuDyIC2rGxvEsnBJqjs=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
 github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
@@ -1879,8 +1879,8 @@ golang.org/x/crypto v0.0.0-20210920023735-84f357641f63/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220517005047-85d78b3ac167/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.0.0-20220817201139-bc19a97f63c8 h1:GIAS/yBem/gq2MUqgNIzUHW7cJMmx3TGZOrnyYaNQ6c=
-golang.org/x/crypto v0.0.0-20220817201139-bc19a97f63c8/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 h1:Y/gsMcFOcR+6S6f3YeMKl5g+dZMEWqcz5Czj/GWYbkM=
+golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/test/e2e/mock/webhook/Dockerfile
+++ b/test/e2e/mock/webhook/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine AS build
+FROM golang:1.19-alpine AS build
 
 WORKDIR /build
 


### PR DESCRIPTION
#2770 with passing tests :wink: 

----

golangci-lint warned:
```
$ golangci-lint run
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [linters context] structcheck is disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649. 
```

Because we already have `unused` enabled, it was just a matter of removing the deprecated ones.