### PR TITLE
fix: #2711 include metadata_admin in admin identity list response

### DIFF
--- a/identity/handler.go
+++ b/identity/handler.go
@@ -135,8 +135,14 @@ func (h *Handler) list(w http.ResponseWriter, r *http.Request, _ httprouter.Para
 		return
 	}
 
+	// Identities using the marshaler for including metadata_admin
+	isam := make([]WithAdminMetadataInJSON, len(is))
+	for i, identity := range is {
+		isam[i] = WithAdminMetadataInJSON(identity)
+	}
+
 	x.PaginationHeader(w, urlx.AppendPaths(h.r.Config().SelfAdminURL(r.Context()), RouteCollection), total, page, itemsPerPage)
-	h.r.Writer().Write(w, r, is)
+	h.r.Writer().Write(w, r, isam)
 }
 
 // swagger:parameters adminGetIdentity

--- a/identity/handler_test.go
+++ b/identity/handler_test.go
@@ -939,7 +939,9 @@ func TestHandler(t *testing.T) {
 		for name, ts := range map[string]*httptest.Server{"public": publicTS, "admin": adminTS} {
 			t.Run("endpoint="+name, func(t *testing.T) {
 				res := get(t, ts, "/identities", http.StatusOK)
-				assert.Empty(t, res.Get("0.credentials").String(), "%s", res.Raw)
+				assert.False(t, res.Get("0.credentials").Exists(), "credentials config should be omitted: %s", res.Raw)
+				assert.True(t, res.Get("0.metadata_public").Exists(), "metadata_public config should be included: %s", res.Raw)
+				assert.True(t, res.Get("0.metadata_admin").Exists(), "metadata_admin config should be included: %s", res.Raw)
 				assert.EqualValues(t, "baz", res.Get(`#(traits.bar=="baz").traits.bar`).String(), "%s", res.Raw)
 			})
 		}

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -319,6 +319,14 @@ func (i *Identity) UnmarshalJSON(b []byte) error {
 	return err
 }
 
+type WithAdminMetadataInJSON Identity
+
+func (i WithAdminMetadataInJSON) MarshalJSON() ([]byte, error) {
+	type localIdentity Identity
+	i.Credentials = nil
+	return json.Marshal(localIdentity(i))
+}
+
 type WithCredentialsAndAdminMetadataInJSON Identity
 
 func (i WithCredentialsAndAdminMetadataInJSON) MarshalJSON() ([]byte, error) {

--- a/identity/identity_test.go
+++ b/identity/identity_test.go
@@ -169,6 +169,15 @@ func TestMarshalIdentityWithCredentialsWhenCredentialsNil(t *testing.T) {
 	assert.False(t, gjson.Get(b.String(), "credentials").Exists())
 }
 
+func TestMarshalIdentityWithAdminMetadata(t *testing.T) {
+	i := NewIdentity(config.DefaultIdentityTraitsSchemaID)
+	i.MetadataAdmin = []byte(`{"some":"metadata"}`)
+
+	var b bytes.Buffer
+	require.Nil(t, json.NewEncoder(&b).Encode(WithAdminMetadataInJSON(*i)))
+	assert.Equal(t, "metadata", gjson.GetBytes(i.MetadataAdmin, "some").String(), "Original metadata_admin should not be touched by marshalling")
+}
+
 func TestMarshalIdentityWithCredentialsMetadata(t *testing.T) {
 	i := NewIdentity(config.DefaultIdentityTraitsSchemaID)
 	credentials := map[CredentialsType]Credentials{
@@ -188,7 +197,7 @@ func TestMarshalIdentityWithCredentialsMetadata(t *testing.T) {
 
 	assert.JSONEq(t, "{\"password\":{\"type\":\"password\",\"identifiers\":null,\"updated_at\":\"0001-01-01T00:00:00Z\",\"created_at\":\"0001-01-01T00:00:00Z\",\"version\":0}}", credentialsInJson.Raw)
 	assert.Equal(t, credentials, i.Credentials, "Original credentials should not be touched by marshalling")
-	assert.Equal(t, "metadata", gjson.GetBytes(i.MetadataAdmin, "some").String(), "Original credentials should not be touched by marshalling")
+	assert.Equal(t, "metadata", gjson.GetBytes(i.MetadataAdmin, "some").String(), "Original metadata_admin should not be touched by marshalling")
 }
 
 func TestMarshalIdentityWithAll(t *testing.T) {


### PR DESCRIPTION
The admin identities list response now includes `metadata_admin` property within the returned identities.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

https://github.com/ory/kratos/issues/2711

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).
      _(n/a: This fix makes the implementation compliant with existing docs)_

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
