### PR TITLE
fix: missing usage to recovery_code_invalid template

### DIFF
--- a/courier/email_templates.go
+++ b/courier/email_templates.go
@@ -69,6 +69,18 @@ func NewEmailTemplateFromMessage(d template.Dependencies, msg Message) (EmailTem
 			return nil, err
 		}
 		return email.NewRecoveryValid(d, &t), nil
+	case TypeRecoveryCodeInvalid:
+		var t email.RecoveryCodeInvalidModel
+		if err := json.Unmarshal(msg.TemplateData, &t); err != nil {
+			return nil, err
+		}
+		return email.NewRecoveryCodeInvalid(d, &t), nil
+	case TypeRecoveryCodeValid:
+		var t email.RecoveryCodeValidModel
+		if err := json.Unmarshal(msg.TemplateData, &t); err != nil {
+			return nil, err
+		}
+		return email.NewRecoveryCodeValid(d, &t), nil
 	case TypeVerificationInvalid:
 		var t email.VerificationInvalidModel
 		if err := json.Unmarshal(msg.TemplateData, &t); err != nil {

--- a/courier/email_templates_test.go
+++ b/courier/email_templates_test.go
@@ -36,6 +36,8 @@ func TestNewEmailTemplateFromMessage(t *testing.T) {
 	for tmplType, expectedTmpl := range map[courier.TemplateType]courier.EmailTemplate{
 		courier.TypeRecoveryInvalid:     email.NewRecoveryInvalid(reg, &email.RecoveryInvalidModel{To: "foo"}),
 		courier.TypeRecoveryValid:       email.NewRecoveryValid(reg, &email.RecoveryValidModel{To: "bar", RecoveryURL: "http://foo.bar"}),
+		courier.TypeRecoveryCodeValid:   email.NewRecoveryCodeValid(reg, &email.RecoveryCodeValidModel{To: "bar", RecoveryCode: "12345678"}),
+		courier.TypeRecoveryCodeInvalid: email.NewRecoveryCodeInvalid(reg, &email.RecoveryCodeInvalidModel{To: "bar"}),
 		courier.TypeVerificationInvalid: email.NewVerificationInvalid(reg, &email.VerificationInvalidModel{To: "baz"}),
 		courier.TypeVerificationValid:   email.NewVerificationValid(reg, &email.VerificationValidModel{To: "faz", VerificationURL: "http://bar.foo"}),
 		courier.TypeTestStub:            email.NewTestStub(reg, &email.TestStubModel{To: "far", Subject: "test subject", Body: "test body"}),

--- a/selfservice/strategy/code/sender.go
+++ b/selfservice/strategy/code/sender.go
@@ -60,7 +60,7 @@ func (s *RecoveryCodeSender) SendRecoveryCode(ctx context.Context, r *http.Reque
 
 	address, err := s.deps.IdentityPool().FindRecoveryAddressByValue(ctx, identity.RecoveryAddressTypeEmail, to)
 	if err != nil {
-		if err := s.send(ctx, string(via), email.NewRecoveryInvalid(s.deps, &email.RecoveryInvalidModel{To: to})); err != nil {
+		if err := s.send(ctx, string(via), email.NewRecoveryCodeInvalid(s.deps, &email.RecoveryCodeInvalidModel{To: to})); err != nil {
 			return err
 		}
 		return ErrUnknownAddress

--- a/test/e2e/cypress/integration/profiles/recovery/code/errors.spec.ts
+++ b/test/e2e/cypress/integration/profiles/recovery/code/errors.spec.ts
@@ -1,4 +1,4 @@
-import { extractRecoveryCode, appPrefix, gen } from "../../../../helpers"
+import { extractRecoveryCode, appPrefix, gen, email } from "../../../../helpers"
 import { routes as react } from "../../../../helpers/react"
 import { routes as express } from "../../../../helpers/express"
 
@@ -162,7 +162,7 @@ context("Account Recovery Errors", () => {
         cy.get('[name="method"][value="code"]').should("exist")
       })
 
-      it("invalid remote recovery email template", () => {
+      it("remote recovery email template (recovery_code_valid)", () => {
         cy.remoteCourierRecoveryCodeTemplates()
         const identity = gen.identityWithWebsite()
         cy.registerApi(identity)
@@ -176,7 +176,24 @@ context("Account Recovery Errors", () => {
 
         cy.getMail().then((mail) => {
           expect(mail.body).to.include(
-            "this is a remote invalid recovery template",
+            "recovery_code_valid REMOTE TEMPLATE",
+          )
+        })
+      })
+
+      it("remote recovery email template (recovery_code_invalid)", () => {
+        cy.remoteCourierRecoveryCodeTemplates()
+        cy.visit(recovery)
+        cy.get(appPrefix(app) + "input[name='email']").type(email())
+        cy.get("button[value='code']").click()
+        cy.get('[data-testid="ui/message/1060003"]').should(
+          "have.text",
+          "An email containing a recovery code has been sent to the email address you provided.",
+        )
+
+        cy.getMail().then((mail) => {
+          expect(mail.body).to.include(
+            "recovery_code_invalid REMOTE TEMPLATE",
           )
         })
       })

--- a/test/e2e/cypress/integration/profiles/recovery/code/errors.spec.ts
+++ b/test/e2e/cypress/integration/profiles/recovery/code/errors.spec.ts
@@ -175,9 +175,7 @@ context("Account Recovery Errors", () => {
         )
 
         cy.getMail().then((mail) => {
-          expect(mail.body).to.include(
-            "recovery_code_valid REMOTE TEMPLATE",
-          )
+          expect(mail.body).to.include("recovery_code_valid REMOTE TEMPLATE")
         })
       })
 
@@ -192,9 +190,7 @@ context("Account Recovery Errors", () => {
         )
 
         cy.getMail().then((mail) => {
-          expect(mail.body).to.include(
-            "recovery_code_invalid REMOTE TEMPLATE",
-          )
+          expect(mail.body).to.include("recovery_code_invalid REMOTE TEMPLATE")
         })
       })
     })

--- a/test/e2e/cypress/support/commands.ts
+++ b/test/e2e/cypress/support/commands.ts
@@ -682,21 +682,47 @@ Cypress.Commands.add("remoteCourierRecoveryCodeTemplates", ({} = {}) => {
         invalid: {
           email: {
             body: {
-              html: "base64://SGksCgp0aGlzIGlzIGEgcmVtb3RlIGludmFsaWQgcmVjb3ZlcnkgdGVtcGxhdGU=",
+              html: "base64://cmVjb3ZlcnlfY29kZV9pbnZhbGlkIFJFTU9URSBURU1QTEFURSBIVE1M", // only
               plaintext:
-                "base64://SGksCgp0aGlzIGlzIGEgcmVtb3RlIGludmFsaWQgcmVjb3ZlcnkgdGVtcGxhdGU=",
+                "base64://cmVjb3ZlcnlfY29kZV9pbnZhbGlkIFJFTU9URSBURU1QTEFURSBUWFQ=",
             },
-            subject: "base64://QWNjb3VudCBBY2Nlc3MgQXR0ZW1wdGVk",
+            subject:
+              "base64://cmVjb3ZlcnlfY29kZV9pbnZhbGlkIFJFTU9URSBURU1QTEFURSBTVUJKRUNU",
           },
         },
         valid: {
           email: {
             body: {
-              html: "base64://SGksCgp0aGlzIGlzIGEgcmVtb3RlIGludmFsaWQgcmVjb3ZlcnkgdGVtcGxhdGUKcGxlYXNlIHJlY292ZXIgYWNjZXNzIHRvIHlvdXIgYWNjb3VudCBieSBlbnRlcmluZyB0aGUgZm9sbG93aW5nIGNvZGU6Cgp7eyAuUmVjb3ZlcnlDb2RlIH19Cg==",
+              html: "base://cmVjb3ZlcnlfY29kZV92YWxpZCBSRU1PVEUgVEVNUExBVEUgSFRNTA==",
               plaintext:
-                "base64://SGksCgp0aGlzIGlzIGEgcmVtb3RlIGludmFsaWQgcmVjb3ZlcnkgdGVtcGxhdGUKcGxlYXNlIHJlY292ZXIgYWNjZXNzIHRvIHlvdXIgYWNjb3VudCBieSBlbnRlcmluZyB0aGUgZm9sbG93aW5nIGNvZGU6Cgp7eyAuUmVjb3ZlcnlDb2RlIH19Cg==",
+                "base64://cmVjb3ZlcnlfY29kZV92YWxpZCBSRU1PVEUgVEVNUExBVEUgVFhU",
             },
-            subject: "base64://UmVjb3ZlciBhY2Nlc3MgdG8geW91ciBhY2NvdW50",
+            subject:
+              "base64://cmVjb3ZlcnlfY29kZV92YWxpZCBSRU1PVEUgVEVNUExBVEUgU1VCSkVDVA==",
+          },
+        },
+      },
+    }
+    return config
+  })
+})
+
+Cypress.Commands.add("resetCourierTemplates", (type) => {
+  updateConfigFile((config) => {
+    config.courier.templates = {
+      [type]: {
+        invalid: {
+          email: {
+            body: {},
+            subject: "",
+          },
+        },
+        valid: {
+          email: {
+            body: {
+              body: {},
+              subject: "",
+            },
           },
         },
       },

--- a/test/e2e/cypress/support/index.d.ts
+++ b/test/e2e/cypress/support/index.d.ts
@@ -184,6 +184,11 @@ declare global {
       remoteCourierRecoveryTemplates(): Chainable<void>
 
       /**
+       * Resets the remote courier templates for the given template type to their default values
+       */
+      resetCourierTemplates(type: "recovery_code" | "recovery" | "verification"): Chainable<void>
+
+      /**
        * Change the courier recovery code invalid and valid templates to remote base64 strings
        */
       remoteCourierRecoveryCodeTemplates(): Chainable<void>

--- a/test/e2e/cypress/support/index.d.ts
+++ b/test/e2e/cypress/support/index.d.ts
@@ -186,7 +186,9 @@ declare global {
       /**
        * Resets the remote courier templates for the given template type to their default values
        */
-      resetCourierTemplates(type: "recovery_code" | "recovery" | "verification"): Chainable<void>
+      resetCourierTemplates(
+        type: "recovery_code" | "recovery" | "verification",
+      ): Chainable<void>
 
       /**
        * Change the courier recovery code invalid and valid templates to remote base64 strings


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

This PR fixes the usage of the wrong template when trying to recover a not registered account. Also clarifies the tests to reflect this case. 

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [ ] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
