### PR TITLE
feat: add admin get api for session

### DIFF
--- a/internal/httpclient/README.md
+++ b/internal/httpclient/README.md
@@ -93,6 +93,7 @@ Class | Method | HTTP request | Description
 *V0alpha2Api* | [**AdminDeleteIdentitySessions**](docs/V0alpha2Api.md#admindeleteidentitysessions) | **Delete** /admin/identities/{id}/sessions | Delete &amp; Invalidate an Identity&#39;s Sessions
 *V0alpha2Api* | [**AdminExtendSession**](docs/V0alpha2Api.md#adminextendsession) | **Patch** /admin/sessions/{id}/extend | Extend a Session
 *V0alpha2Api* | [**AdminGetIdentity**](docs/V0alpha2Api.md#admingetidentity) | **Get** /admin/identities/{id} | Get an Identity
+*V0alpha2Api* | [**AdminGetSession**](docs/V0alpha2Api.md#admingetsession) | **Get** /admin/sessions/{id} | This endpoint returns the session object with expandables specified.
 *V0alpha2Api* | [**AdminListCourierMessages**](docs/V0alpha2Api.md#adminlistcouriermessages) | **Get** /admin/courier/messages | List Messages
 *V0alpha2Api* | [**AdminListIdentities**](docs/V0alpha2Api.md#adminlistidentities) | **Get** /admin/identities | List Identities
 *V0alpha2Api* | [**AdminListIdentitySessions**](docs/V0alpha2Api.md#adminlistidentitysessions) | **Get** /admin/identities/{id}/sessions | List an Identity&#39;s Sessions

--- a/internal/httpclient/api/openapi.yaml
+++ b/internal/httpclient/api/openapi.yaml
@@ -759,10 +759,10 @@ paths:
         name: expand
         required: false
         schema:
-          enum:
-          - identity
-          - devices
           items:
+            enum:
+            - Devices
+            - Identity
             type: string
           type: array
         style: form

--- a/internal/httpclient/api/openapi.yaml
+++ b/internal/httpclient/api/openapi.yaml
@@ -700,8 +700,8 @@ paths:
         required: false
         schema:
           enum:
-          - Identity
-          - Devices
+          - identity
+          - devices
           items:
             type: string
           type: array
@@ -760,8 +760,8 @@ paths:
         required: false
         schema:
           enum:
-          - Identity
-          - Devices
+          - identity
+          - devices
           items:
             type: string
           type: array

--- a/internal/httpclient/api/openapi.yaml
+++ b/internal/httpclient/api/openapi.yaml
@@ -690,6 +690,22 @@ paths:
         schema:
           type: boolean
         style: form
+      - description: |-
+          ExpandOptions is a query parameter encoded list of all properties that must be expanded in the Session.
+          Example - ?expand=Identity&expand=Devices
+          If no value is provided, the expandable properties are skipped.
+        explode: true
+        in: query
+        name: expand
+        required: false
+        schema:
+          enum:
+          - Identity
+          - Devices
+          items:
+            type: string
+          type: array
+        style: form
       responses:
         "200":
           content:
@@ -724,6 +740,62 @@ paths:
       security:
       - oryAccessToken: []
       summary: This endpoint returns all sessions that exist.
+      tags:
+      - v0alpha2
+  /admin/sessions/{id}:
+    get:
+      description: |-
+        This endpoint is useful for:
+
+        Getting a session object with all specified expandables that exist in an administrative context.
+      operationId: adminGetSession
+      parameters:
+      - description: |-
+          ExpandOptions is a query parameter encoded list of all properties that must be expanded in the Session.
+          Example - ?expand=Identity&expand=Devices
+          If no value is provided, the expandable properties are skipped.
+        explode: true
+        in: query
+        name: expand
+        required: false
+        schema:
+          enum:
+          - Identity
+          - Devices
+          items:
+            type: string
+          type: array
+        style: form
+      - description: ID is the session's ID.
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+        style: simple
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/session'
+          description: session
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/jsonError'
+          description: jsonError
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/jsonError'
+          description: jsonError
+      security:
+      - oryAccessToken: []
+      summary: This endpoint returns the session object with expandables specified.
       tags:
       - v0alpha2
   /admin/sessions/{id}/extend:

--- a/internal/httpclient/api/openapi.yaml
+++ b/internal/httpclient/api/openapi.yaml
@@ -699,10 +699,10 @@ paths:
         name: expand
         required: false
         schema:
-          enum:
-          - identity
-          - devices
           items:
+            enum:
+            - Devices
+            - Identity
             type: string
           type: array
         style: form

--- a/internal/httpclient/api_v0alpha2.go
+++ b/internal/httpclient/api_v0alpha2.go
@@ -142,6 +142,23 @@ type V0alpha2Api interface {
 	AdminGetIdentityExecute(r V0alpha2ApiApiAdminGetIdentityRequest) (*Identity, *http.Response, error)
 
 	/*
+			 * AdminGetSession This endpoint returns the session object with expandables specified.
+			 * This endpoint is useful for:
+
+		Getting a session object with all specified expandables that exist in an administrative context.
+			 * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 * @param id ID is the session's ID.
+			 * @return V0alpha2ApiApiAdminGetSessionRequest
+	*/
+	AdminGetSession(ctx context.Context, id string) V0alpha2ApiApiAdminGetSessionRequest
+
+	/*
+	 * AdminGetSessionExecute executes the request
+	 * @return Session
+	 */
+	AdminGetSessionExecute(r V0alpha2ApiApiAdminGetSessionRequest) (*Session, *http.Response, error)
+
+	/*
 	 * AdminListCourierMessages List Messages
 	 * Lists all messages by given status and recipient.
 	 * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -2199,6 +2216,161 @@ func (a *V0alpha2ApiService) AdminGetIdentityExecute(r V0alpha2ApiApiAdminGetIde
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
+type V0alpha2ApiApiAdminGetSessionRequest struct {
+	ctx        context.Context
+	ApiService V0alpha2Api
+	id         string
+	expand     *[]string
+}
+
+func (r V0alpha2ApiApiAdminGetSessionRequest) Expand(expand []string) V0alpha2ApiApiAdminGetSessionRequest {
+	r.expand = &expand
+	return r
+}
+
+func (r V0alpha2ApiApiAdminGetSessionRequest) Execute() (*Session, *http.Response, error) {
+	return r.ApiService.AdminGetSessionExecute(r)
+}
+
+/*
+  - AdminGetSession This endpoint returns the session object with expandables specified.
+  - This endpoint is useful for:
+
+Getting a session object with all specified expandables that exist in an administrative context.
+  - @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+  - @param id ID is the session's ID.
+  - @return V0alpha2ApiApiAdminGetSessionRequest
+*/
+func (a *V0alpha2ApiService) AdminGetSession(ctx context.Context, id string) V0alpha2ApiApiAdminGetSessionRequest {
+	return V0alpha2ApiApiAdminGetSessionRequest{
+		ApiService: a,
+		ctx:        ctx,
+		id:         id,
+	}
+}
+
+/*
+ * Execute executes the request
+ * @return Session
+ */
+func (a *V0alpha2ApiService) AdminGetSessionExecute(r V0alpha2ApiApiAdminGetSessionRequest) (*Session, *http.Response, error) {
+	var (
+		localVarHTTPMethod   = http.MethodGet
+		localVarPostBody     interface{}
+		localVarFormFileName string
+		localVarFileName     string
+		localVarFileBytes    []byte
+		localVarReturnValue  *Session
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "V0alpha2ApiService.AdminGetSession")
+	if err != nil {
+		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/admin/sessions/{id}"
+	localVarPath = strings.Replace(localVarPath, "{"+"id"+"}", url.PathEscape(parameterToString(r.id, "")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	if r.expand != nil {
+		t := *r.expand
+		if reflect.TypeOf(t).Kind() == reflect.Slice {
+			s := reflect.ValueOf(t)
+			for i := 0; i < s.Len(); i++ {
+				localVarQueryParams.Add("expand", parameterToString(s.Index(i), "multi"))
+			}
+		} else {
+			localVarQueryParams.Add("expand", parameterToString(t, "multi"))
+		}
+	}
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	if r.ctx != nil {
+		// API Key Authentication
+		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
+			if apiKey, ok := auth["oryAccessToken"]; ok {
+				var key string
+				if apiKey.Prefix != "" {
+					key = apiKey.Prefix + " " + apiKey.Key
+				} else {
+					key = apiKey.Key
+				}
+				localVarHeaderParams["Authorization"] = key
+			}
+		}
+	}
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 400 {
+			var v JsonError
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		var v JsonError
+		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+		if err != nil {
+			newErr.error = err.Error()
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		newErr.model = v
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: err.Error(),
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHTTPResponse, nil
+}
+
 type V0alpha2ApiApiAdminListCourierMessagesRequest struct {
 	ctx        context.Context
 	ApiService V0alpha2Api
@@ -2688,6 +2860,7 @@ type V0alpha2ApiApiAdminListSessionsRequest struct {
 	pageSize   *int64
 	pageToken  *string
 	active     *bool
+	expand     *[]string
 }
 
 func (r V0alpha2ApiApiAdminListSessionsRequest) PageSize(pageSize int64) V0alpha2ApiApiAdminListSessionsRequest {
@@ -2700,6 +2873,10 @@ func (r V0alpha2ApiApiAdminListSessionsRequest) PageToken(pageToken string) V0al
 }
 func (r V0alpha2ApiApiAdminListSessionsRequest) Active(active bool) V0alpha2ApiApiAdminListSessionsRequest {
 	r.active = &active
+	return r
+}
+func (r V0alpha2ApiApiAdminListSessionsRequest) Expand(expand []string) V0alpha2ApiApiAdminListSessionsRequest {
+	r.expand = &expand
 	return r
 }
 
@@ -2755,6 +2932,17 @@ func (a *V0alpha2ApiService) AdminListSessionsExecute(r V0alpha2ApiApiAdminListS
 	}
 	if r.active != nil {
 		localVarQueryParams.Add("active", parameterToString(*r.active, ""))
+	}
+	if r.expand != nil {
+		t := *r.expand
+		if reflect.TypeOf(t).Kind() == reflect.Slice {
+			s := reflect.ValueOf(t)
+			for i := 0; i < s.Len(); i++ {
+				localVarQueryParams.Add("expand", parameterToString(s.Index(i), "multi"))
+			}
+		} else {
+			localVarQueryParams.Add("expand", parameterToString(t, "multi"))
+		}
 	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}

--- a/internal/httpclient/docs/V0alpha2Api.md
+++ b/internal/httpclient/docs/V0alpha2Api.md
@@ -840,7 +840,7 @@ func main() {
     pageSize := int64(789) // int64 | Items per Page  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.sh/docs/ecosystem/api-design#pagination). (optional) (default to 250)
     pageToken := "pageToken_example" // string | Next Page Token  The next page token. For details on pagination please head over to the [pagination documentation](https://www.ory.sh/docs/ecosystem/api-design#pagination). (optional)
     active := true // bool | Active is a boolean flag that filters out sessions based on the state. If no value is provided, all sessions are returned. (optional)
-    expand := []string{"Inner_example"} // []string | ExpandOptions is a query parameter encoded list of all properties that must be expanded in the Session. Example - ?expand=Identity&expand=Devices If no value is provided, the expandable properties are skipped. (optional)
+    expand := []string{"Expand_example"} // []string | ExpandOptions is a query parameter encoded list of all properties that must be expanded in the Session. Example - ?expand=Identity&expand=Devices If no value is provided, the expandable properties are skipped. (optional)
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)

--- a/internal/httpclient/docs/V0alpha2Api.md
+++ b/internal/httpclient/docs/V0alpha2Api.md
@@ -550,7 +550,7 @@ import (
 
 func main() {
     id := "id_example" // string | ID is the session's ID.
-    expand := []string{"Inner_example"} // []string | ExpandOptions is a query parameter encoded list of all properties that must be expanded in the Session. Example - ?expand=Identity&expand=Devices If no value is provided, the expandable properties are skipped. (optional)
+    expand := []string{"Expand_example"} // []string | ExpandOptions is a query parameter encoded list of all properties that must be expanded in the Session. Example - ?expand=Identity&expand=Devices If no value is provided, the expandable properties are skipped. (optional)
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)

--- a/internal/httpclient/docs/V0alpha2Api.md
+++ b/internal/httpclient/docs/V0alpha2Api.md
@@ -11,6 +11,7 @@ Method | HTTP request | Description
 [**AdminDeleteIdentitySessions**](V0alpha2Api.md#AdminDeleteIdentitySessions) | **Delete** /admin/identities/{id}/sessions | Delete &amp; Invalidate an Identity&#39;s Sessions
 [**AdminExtendSession**](V0alpha2Api.md#AdminExtendSession) | **Patch** /admin/sessions/{id}/extend | Extend a Session
 [**AdminGetIdentity**](V0alpha2Api.md#AdminGetIdentity) | **Get** /admin/identities/{id} | Get an Identity
+[**AdminGetSession**](V0alpha2Api.md#AdminGetSession) | **Get** /admin/sessions/{id} | This endpoint returns the session object with expandables specified.
 [**AdminListCourierMessages**](V0alpha2Api.md#AdminListCourierMessages) | **Get** /admin/courier/messages | List Messages
 [**AdminListIdentities**](V0alpha2Api.md#AdminListIdentities) | **Get** /admin/identities | List Identities
 [**AdminListIdentitySessions**](V0alpha2Api.md#AdminListIdentitySessions) | **Get** /admin/identities/{id}/sessions | List an Identity&#39;s Sessions
@@ -527,6 +528,78 @@ Name | Type | Description  | Notes
 [[Back to README]](../README.md)
 
 
+## AdminGetSession
+
+> Session AdminGetSession(ctx, id).Expand(expand).Execute()
+
+This endpoint returns the session object with expandables specified.
+
+
+
+### Example
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "os"
+    openapiclient "./openapi"
+)
+
+func main() {
+    id := "id_example" // string | ID is the session's ID.
+    expand := []string{"Inner_example"} // []string | ExpandOptions is a query parameter encoded list of all properties that must be expanded in the Session. Example - ?expand=Identity&expand=Devices If no value is provided, the expandable properties are skipped. (optional)
+
+    configuration := openapiclient.NewConfiguration()
+    apiClient := openapiclient.NewAPIClient(configuration)
+    resp, r, err := apiClient.V0alpha2Api.AdminGetSession(context.Background(), id).Expand(expand).Execute()
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "Error when calling `V0alpha2Api.AdminGetSession``: %v\n", err)
+        fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+    }
+    // response from `AdminGetSession`: Session
+    fmt.Fprintf(os.Stdout, "Response from `V0alpha2Api.AdminGetSession`: %v\n", resp)
+}
+```
+
+### Path Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+**id** | **string** | ID is the session&#39;s ID. | 
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiAdminGetSessionRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
+ **expand** | **[]string** | ExpandOptions is a query parameter encoded list of all properties that must be expanded in the Session. Example - ?expand&#x3D;Identity&amp;expand&#x3D;Devices If no value is provided, the expandable properties are skipped. | 
+
+### Return type
+
+[**Session**](Session.md)
+
+### Authorization
+
+[oryAccessToken](../README.md#oryAccessToken)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
 ## AdminListCourierMessages
 
 > []Message AdminListCourierMessages(ctx).PerPage(perPage).Page(page).Status(status).Recipient(recipient).Execute()
@@ -745,7 +818,7 @@ Name | Type | Description  | Notes
 
 ## AdminListSessions
 
-> []Session AdminListSessions(ctx).PageSize(pageSize).PageToken(pageToken).Active(active).Execute()
+> []Session AdminListSessions(ctx).PageSize(pageSize).PageToken(pageToken).Active(active).Expand(expand).Execute()
 
 This endpoint returns all sessions that exist.
 
@@ -767,10 +840,11 @@ func main() {
     pageSize := int64(789) // int64 | Items per Page  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.sh/docs/ecosystem/api-design#pagination). (optional) (default to 250)
     pageToken := "pageToken_example" // string | Next Page Token  The next page token. For details on pagination please head over to the [pagination documentation](https://www.ory.sh/docs/ecosystem/api-design#pagination). (optional)
     active := true // bool | Active is a boolean flag that filters out sessions based on the state. If no value is provided, all sessions are returned. (optional)
+    expand := []string{"Inner_example"} // []string | ExpandOptions is a query parameter encoded list of all properties that must be expanded in the Session. Example - ?expand=Identity&expand=Devices If no value is provided, the expandable properties are skipped. (optional)
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)
-    resp, r, err := apiClient.V0alpha2Api.AdminListSessions(context.Background()).PageSize(pageSize).PageToken(pageToken).Active(active).Execute()
+    resp, r, err := apiClient.V0alpha2Api.AdminListSessions(context.Background()).PageSize(pageSize).PageToken(pageToken).Active(active).Expand(expand).Execute()
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `V0alpha2Api.AdminListSessions``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
@@ -794,6 +868,7 @@ Name | Type | Description  | Notes
  **pageSize** | **int64** | Items per Page  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.sh/docs/ecosystem/api-design#pagination). | [default to 250]
  **pageToken** | **string** | Next Page Token  The next page token. For details on pagination please head over to the [pagination documentation](https://www.ory.sh/docs/ecosystem/api-design#pagination). | 
  **active** | **bool** | Active is a boolean flag that filters out sessions based on the state. If no value is provided, all sessions are returned. | 
+ **expand** | **[]string** | ExpandOptions is a query parameter encoded list of all properties that must be expanded in the Session. Example - ?expand&#x3D;Identity&amp;expand&#x3D;Devices If no value is provided, the expandable properties are skipped. | 
 
 ### Return type
 

--- a/persistence/sql/persister_session.go
+++ b/persistence/sql/persister_session.go
@@ -36,7 +36,8 @@ func (p *Persister) GetSession(ctx context.Context, sid uuid.UUID, expandables s
 	nid := p.NetworkID(ctx)
 
 	q := p.GetConnection(ctx).Q()
-	if len(expandables) > 0 {
+	// if len(expandables) > 0 {
+	if expandables.Has(session.ExpandSessionDevices) {
 		q = q.Eager(expandables.ToEager()...)
 	}
 
@@ -75,7 +76,9 @@ func (p *Persister) ListSessions(ctx context.Context, active *bool, paginatorOpt
 		if active != nil {
 			q = q.Where("active = ?", *active)
 		}
-		if len(expandables) > 0 {
+
+		// if len(expandables) > 0 {
+		if expandables.Has(session.ExpandSessionDevices) {
 			q = q.Eager(expandables.ToEager()...)
 		}
 

--- a/session/expand.go
+++ b/session/expand.go
@@ -1,7 +1,21 @@
 package session
 
+import "strings"
+
 // Expandable controls what fields to expand for sessions.
 type Expandable string
+
+const (
+	// ExpandSessionDevices expands devices related to the session
+	ExpandSessionDevices Expandable = "Devices"
+	// ExpandSessionIdentity expands Identity related to the session
+	ExpandSessionIdentity Expandable = "Identity"
+)
+
+var expandablesMap = map[string]Expandable{
+	"devices":  ExpandSessionDevices,
+	"identity": ExpandSessionIdentity,
+}
 
 // Expandables is a list of Expandable values.
 type Expandables []Expandable
@@ -33,12 +47,10 @@ func (e Expandables) Has(search Expandable) bool {
 	return false
 }
 
-const (
-	// ExpandSessionDevices expands devices related to the session
-	ExpandSessionDevices Expandable = "Devices"
-	// ExpandSessionIdentity expands Identity related to the session
-	ExpandSessionIdentity Expandable = "Identity"
-)
+func ParseExpandable(in string) (Expandable, bool) {
+	e, ok := expandablesMap[strings.ToLower(in)]
+	return e, ok
+}
 
 // ExpandNothing expands nothing
 var ExpandNothing []Expandable

--- a/session/expand.go
+++ b/session/expand.go
@@ -3,6 +3,7 @@ package session
 import "strings"
 
 // Expandable controls what fields to expand for sessions.
+// swagger:enum Expandable
 type Expandable string
 
 const (

--- a/session/handler.go
+++ b/session/handler.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/ory/x/pagination/keysetpagination"
@@ -344,7 +343,7 @@ func (h *Handler) adminListSessions(w http.ResponseWriter, r *http.Request, ps h
 
 	var expandables Expandables
 	if urlValues.Has("expand") {
-		es := strings.Split(urlValues.Get("expand"), ",")
+		es := urlValues["expand"]
 		for _, e := range es {
 			expand, ok := ParseExpandable(e)
 			if !ok {

--- a/session/handler.go
+++ b/session/handler.go
@@ -277,7 +277,9 @@ type adminListSessionsRequest struct {
 	// in: query
 	Active bool `json:"active"`
 
-	// ExpandOptions is a comma seperated list of all properties that must be expanded in the Session. If no value is provided, the expandable properties are skipped.
+	// ExpandOptions is a query parameter encoded list of all properties that must be expanded in the Session.
+	// Example - ?expand=Identity&expand=Devices
+	// If no value is provided, the expandable properties are skipped.
 	//
 	// enum: Identity,Devices
 	// required: false
@@ -372,7 +374,9 @@ func (h *Handler) adminListSessions(w http.ResponseWriter, r *http.Request, ps h
 // swagger:parameters adminGetSession
 // nolint:deadcode,unused
 type adminGetSessionRequest struct {
-	// ExpandOptions is a comma seperated list of all properties that must be expanded in the Session. If no value is provided, the expandable properties are skipped.
+	// ExpandOptions is a query parameter encoded list of all properties that must be expanded in the Session.
+	// Example - ?expand=Identity&expand=Devices
+	// If no value is provided, the expandable properties are skipped.
 	//
 	// enum: Identity,Devices
 	// required: false

--- a/session/handler.go
+++ b/session/handler.go
@@ -344,8 +344,7 @@ func (h *Handler) adminListSessions(w http.ResponseWriter, r *http.Request, ps h
 	}
 
 	var expandables Expandables
-	if urlValues.Has("expand") {
-		es := urlValues["expand"]
+	if es, ok := urlValues["expand"]; ok {
 		for _, e := range es {
 			expand, ok := ParseExpandable(e)
 			if !ok {
@@ -423,8 +422,7 @@ func (h *Handler) adminGetSession(w http.ResponseWriter, r *http.Request, ps htt
 	var expandables Expandables
 
 	urlValues := r.URL.Query()
-	if urlValues.Has("expand") {
-		es := urlValues["expand"]
+	if es, ok := urlValues["expand"]; ok {
 		for _, e := range es {
 			expand, ok := ParseExpandable(e)
 			if !ok {

--- a/session/handler.go
+++ b/session/handler.go
@@ -349,7 +349,7 @@ func (h *Handler) adminListSessions(w http.ResponseWriter, r *http.Request, ps h
 		for _, e := range es {
 			expand, ok := ParseExpandable(e)
 			if !ok {
-				h.r.Writer().WriteError(w, r, herodot.ErrBadRequest.WithError("could not parse expand option").WithDebug("could not parse expand option"))
+				h.r.Writer().WriteError(w, r, errors.WithStack(herodot.ErrBadRequest.WithReasonf("Could not parse expand option: %s", e)))
 				return
 			}
 			expandables = append(expandables, expand)

--- a/session/handler.go
+++ b/session/handler.go
@@ -359,6 +359,12 @@ type adminGetSessionRequest struct {
 	// required: false
 	// in: query
 	ExpandOptions Expandables `json:"expand"`
+
+	// ID is the identity's ID.
+	//
+	// required: true
+	// in: path
+	ID string `json:"id"`
 }
 
 // swagger:route GET /admin/sessions/{id} v0alpha2 adminGetSession

--- a/session/handler.go
+++ b/session/handler.go
@@ -427,7 +427,7 @@ func (h *Handler) adminGetSession(w http.ResponseWriter, r *http.Request, ps htt
 		for _, e := range es {
 			expand, ok := ParseExpandable(e)
 			if !ok {
-				h.r.Writer().WriteError(w, r, herodot.ErrBadRequest.WithError("could not parse expand option").WithDebug("could not parse expand option"))
+				h.r.Writer().WriteError(w, r, errors.WithStack(herodot.ErrBadRequest.WithReasonf("Could not parse expand option: %s", e))))
 				return
 			}
 			expandables = append(expandables, expand)

--- a/session/handler.go
+++ b/session/handler.go
@@ -377,10 +377,9 @@ type adminGetSessionRequest struct {
 	// Example - ?expand=Identity&expand=Devices
 	// If no value is provided, the expandable properties are skipped.
 	//
-	// enum: identity,devices
 	// required: false
 	// in: query
-	ExpandOptions []string `json:"expand"`
+	ExpandOptions []Expandable `json:"expand"`
 
 	// ID is the session's ID.
 	//

--- a/session/handler.go
+++ b/session/handler.go
@@ -281,7 +281,7 @@ type adminListSessionsRequest struct {
 	// Example - ?expand=Identity&expand=Devices
 	// If no value is provided, the expandable properties are skipped.
 	//
-	// enum: Identity,Devices
+	// enum: identity,devices
 	// required: false
 	// in: query
 	ExpandOptions []string `json:"expand"`
@@ -378,7 +378,7 @@ type adminGetSessionRequest struct {
 	// Example - ?expand=Identity&expand=Devices
 	// If no value is provided, the expandable properties are skipped.
 	//
-	// enum: Identity,Devices
+	// enum: identity,devices
 	// required: false
 	// in: query
 	ExpandOptions []string `json:"expand"`

--- a/session/handler.go
+++ b/session/handler.go
@@ -425,7 +425,7 @@ func (h *Handler) adminGetSession(w http.ResponseWriter, r *http.Request, ps htt
 		for _, e := range es {
 			expand, ok := ParseExpandable(e)
 			if !ok {
-				h.r.Writer().WriteError(w, r, errors.WithStack(herodot.ErrBadRequest.WithReasonf("Could not parse expand option: %s", e))))
+				h.r.Writer().WriteError(w, r, errors.WithStack(herodot.ErrBadRequest.WithReasonf("Could not parse expand option: %s", e)))
 				return
 			}
 			expandables = append(expandables, expand)

--- a/session/handler.go
+++ b/session/handler.go
@@ -281,10 +281,9 @@ type adminListSessionsRequest struct {
 	// Example - ?expand=Identity&expand=Devices
 	// If no value is provided, the expandable properties are skipped.
 	//
-	// enum: identity,devices
 	// required: false
 	// in: query
-	ExpandOptions []string `json:"expand"`
+	ExpandOptions []Expandable `json:"expand"`
 }
 
 // Session List Response

--- a/session/handler.go
+++ b/session/handler.go
@@ -383,7 +383,7 @@ type adminGetSessionRequest struct {
 func (h *Handler) adminGetSession(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	if ps.ByName("id") == "whoami" {
 		// for /admin/sessions/whoami redirect to the public route
-		x.RedirectToPublicRoute(h.r)
+		x.RedirectToPublicRoute(h.r)(w, r, ps)
 		return
 	}
 

--- a/session/handler.go
+++ b/session/handler.go
@@ -403,9 +403,7 @@ type adminGetSessionRequest struct {
 //	Responses:
 //	  200: session
 //	  400: jsonError
-//	  401: jsonError
-//	  404: jsonError
-//	  500: jsonError
+//	  default: jsonError
 func (h *Handler) adminGetSession(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	if ps.ByName("id") == "whoami" {
 		// for /admin/sessions/whoami redirect to the public route

--- a/session/handler.go
+++ b/session/handler.go
@@ -280,10 +280,10 @@ type adminListSessionsRequest struct {
 
 	// ExpandOptions is a comma seperated list of all properties that must be expanded in the Session. If no value is provided, the expandable properties are skipped.
 	//
-	// enum: ["Identity","Devices"]
+	// enum: Identity,Devices
 	// required: false
 	// in: query
-	ExpandOptions string `json:"expand"`
+	ExpandOptions []string `json:"expand"`
 }
 
 // Session List Response
@@ -375,10 +375,10 @@ func (h *Handler) adminListSessions(w http.ResponseWriter, r *http.Request, ps h
 type adminGetSessionRequest struct {
 	// ExpandOptions is a comma seperated list of all properties that must be expanded in the Session. If no value is provided, the expandable properties are skipped.
 	//
-	// enum: ["Identity","Devices"]
+	// enum: Identity,Devices
 	// required: false
 	// in: query
-	ExpandOptions string `json:"expand"`
+	ExpandOptions []string `json:"expand"`
 
 	// ID is the session's ID.
 	//

--- a/session/handler.go
+++ b/session/handler.go
@@ -278,12 +278,12 @@ type adminListSessionsRequest struct {
 	// in: query
 	Active bool `json:"active"`
 
-	// ExpandOptions is a list of all properties that must be expanded in the Session. If no value is provided, the expandable properties are skipped.
+	// ExpandOptions is a comma seperated list of all properties that must be expanded in the Session. If no value is provided, the expandable properties are skipped.
 	//
-	// enum: Identity,Devices
+	// enum: ["Identity","Devices"]
 	// required: false
 	// in: query
-	ExpandOptions Expandables `json:"expand"`
+	ExpandOptions string `json:"expand"`
 }
 
 // Session List Response
@@ -373,14 +373,14 @@ func (h *Handler) adminListSessions(w http.ResponseWriter, r *http.Request, ps h
 // swagger:parameters adminGetSession
 // nolint:deadcode,unused
 type adminGetSessionRequest struct {
-	// ExpandOptions is a list of all properties that must be expanded in the Session. If no value is provided, the expandable properties are skipped.
+	// ExpandOptions is a comma seperated list of all properties that must be expanded in the Session. If no value is provided, the expandable properties are skipped.
 	//
-	// enum: Identity,Devices
+	// enum: ["Identity","Devices"]
 	// required: false
 	// in: query
-	ExpandOptions Expandables `json:"expand"`
+	ExpandOptions string `json:"expand"`
 
-	// ID is the identity's ID.
+	// ID is the session's ID.
 	//
 	// required: true
 	// in: path

--- a/session/handler.go
+++ b/session/handler.go
@@ -421,7 +421,7 @@ func (h *Handler) adminGetSession(w http.ResponseWriter, r *http.Request, ps htt
 
 	urlValues := r.URL.Query()
 	if urlValues.Has("expand") {
-		es := strings.Split(urlValues.Get("expand"), ",")
+		es := urlValues["expand"]
 		for _, e := range es {
 			expand, ok := ParseExpandable(e)
 			if !ok {

--- a/session/handler_test.go
+++ b/session/handler_test.go
@@ -458,6 +458,19 @@ func TestHandlerAdminSessionManagement(t *testing.T) {
 			assert.Equal(t, http.StatusBadRequest, res.StatusCode)
 		})
 
+		t.Run("case=should redirect to public for whoami", func(t *testing.T) {
+			client := testhelpers.NewHTTPClientWithSessionToken(t, reg, s)
+			client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			}
+
+			req := x.NewTestHTTPRequest(t, "GET", ts.URL+"/admin/sessions/whoami", nil)
+			res, err := client.Do(req)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusTemporaryRedirect, res.StatusCode)
+			require.Equal(t, ts.URL+"/sessions/whoami", res.Header.Get("Location"))
+		})
+
 		t.Run("should list sessions", func(t *testing.T) {
 			req, _ := http.NewRequest("GET", ts.URL+"/admin/sessions/", nil)
 			res, err := client.Do(req)

--- a/session/handler_test.go
+++ b/session/handler_test.go
@@ -483,6 +483,25 @@ func TestHandlerAdminSessionManagement(t *testing.T) {
 			require.NoError(t, json.NewDecoder(res.Body).Decode(&sessions))
 			require.Len(t, sessions, 1)
 			assert.Equal(t, s.ID, sessions[0].ID)
+			assert.Empty(t, sessions[0].Identity)
+			assert.Empty(t, sessions[0].Devices)
+		})
+
+		t.Run("should list sessions expand identity", func(t *testing.T) {
+			req, _ := http.NewRequest("GET", ts.URL+"/admin/sessions/?expand=identity", nil)
+			res, err := client.Do(req)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusOK, res.StatusCode)
+			assert.Equal(t, "1", res.Header.Get("X-Total-Count"))
+			assert.Equal(t, "</admin/sessions?expand=identity&page_size=250&page_token=00000000-0000-0000-0000-000000000000>; rel=\"first\"", res.Header.Get("Link"))
+
+			var sessions []Session
+			require.NoError(t, json.NewDecoder(res.Body).Decode(&sessions))
+			require.Len(t, sessions, 1)
+			assert.Equal(t, s.ID, sessions[0].ID)
+			assert.NotNil(t, sessions[0].Identity)
+			assert.Equal(t, s.Identity.ID.String(), sessions[0].Identity.ID.String())
+			assert.Empty(t, sessions[0].Devices)
 		})
 
 		t.Run("should list sessions for an identity", func(t *testing.T) {

--- a/spec/api.json
+++ b/spec/api.json
@@ -3688,11 +3688,11 @@
             "in": "query",
             "name": "expand",
             "schema": {
-              "enum": [
-                "identity",
-                "devices"
-              ],
               "items": {
+                "enum": [
+                  "Devices",
+                  "Identity"
+                ],
                 "type": "string"
               },
               "type": "array"

--- a/spec/api.json
+++ b/spec/api.json
@@ -3682,6 +3682,21 @@
             "schema": {
               "type": "boolean"
             }
+          },
+          {
+            "description": "ExpandOptions is a query parameter encoded list of all properties that must be expanded in the Session.\nExample - ?expand=Identity\u0026expand=Devices\nIf no value is provided, the expandable properties are skipped.",
+            "in": "query",
+            "name": "expand",
+            "schema": {
+              "enum": [
+                "Identity",
+                "Devices"
+              ],
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
           }
         ],
         "responses": {
@@ -3742,6 +3757,79 @@
           }
         ],
         "summary": "This endpoint returns all sessions that exist.",
+        "tags": [
+          "v0alpha2"
+        ]
+      }
+    },
+    "/admin/sessions/{id}": {
+      "get": {
+        "description": "This endpoint is useful for:\n\nGetting a session object with all specified expandables that exist in an administrative context.",
+        "operationId": "adminGetSession",
+        "parameters": [
+          {
+            "description": "ExpandOptions is a query parameter encoded list of all properties that must be expanded in the Session.\nExample - ?expand=Identity\u0026expand=Devices\nIf no value is provided, the expandable properties are skipped.",
+            "in": "query",
+            "name": "expand",
+            "schema": {
+              "enum": [
+                "Identity",
+                "Devices"
+              ],
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "ID is the session's ID.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/session"
+                }
+              }
+            },
+            "description": "session"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/jsonError"
+                }
+              }
+            },
+            "description": "jsonError"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/jsonError"
+                }
+              }
+            },
+            "description": "jsonError"
+          }
+        },
+        "security": [
+          {
+            "oryAccessToken": []
+          }
+        ],
+        "summary": "This endpoint returns the session object with expandables specified.",
         "tags": [
           "v0alpha2"
         ]

--- a/spec/api.json
+++ b/spec/api.json
@@ -3689,8 +3689,8 @@
             "name": "expand",
             "schema": {
               "enum": [
-                "Identity",
-                "Devices"
+                "identity",
+                "devices"
               ],
               "items": {
                 "type": "string"
@@ -3773,8 +3773,8 @@
             "name": "expand",
             "schema": {
               "enum": [
-                "Identity",
-                "Devices"
+                "identity",
+                "devices"
               ],
               "items": {
                 "type": "string"

--- a/spec/api.json
+++ b/spec/api.json
@@ -3772,11 +3772,11 @@
             "in": "query",
             "name": "expand",
             "schema": {
-              "enum": [
-                "identity",
-                "devices"
-              ],
               "items": {
+                "enum": [
+                  "Devices",
+                  "Identity"
+                ],
                 "type": "string"
               },
               "type": "array"

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -771,12 +771,12 @@
             "in": "query"
           },
           {
-            "enum": [
-              "identity",
-              "devices"
-            ],
             "type": "array",
             "items": {
+              "enum": [
+                "Devices",
+                "Identity"
+              ],
               "type": "string"
             },
             "description": "ExpandOptions is a query parameter encoded list of all properties that must be expanded in the Session.\nExample - ?expand=Identity\u0026expand=Devices\nIf no value is provided, the expandable properties are skipped.",

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -769,6 +769,19 @@
             "description": "Active is a boolean flag that filters out sessions based on the state. If no value is provided, all sessions are returned.",
             "name": "active",
             "in": "query"
+          },
+          {
+            "enum": [
+              "Identity",
+              "Devices"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "ExpandOptions is a query parameter encoded list of all properties that must be expanded in the Session.\nExample - ?expand=Identity\u0026expand=Devices\nIf no value is provided, the expandable properties are skipped.",
+            "name": "expand",
+            "in": "query"
           }
         ],
         "responses": {
@@ -797,6 +810,67 @@
             }
           },
           "500": {
+            "description": "jsonError",
+            "schema": {
+              "$ref": "#/definitions/jsonError"
+            }
+          }
+        }
+      }
+    },
+    "/admin/sessions/{id}": {
+      "get": {
+        "security": [
+          {
+            "oryAccessToken": []
+          }
+        ],
+        "description": "This endpoint is useful for:\n\nGetting a session object with all specified expandables that exist in an administrative context.",
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "v0alpha2"
+        ],
+        "summary": "This endpoint returns the session object with expandables specified.",
+        "operationId": "adminGetSession",
+        "parameters": [
+          {
+            "enum": [
+              "Identity",
+              "Devices"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "ExpandOptions is a query parameter encoded list of all properties that must be expanded in the Session.\nExample - ?expand=Identity\u0026expand=Devices\nIf no value is provided, the expandable properties are skipped.",
+            "name": "expand",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "ID is the session's ID.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "session",
+            "schema": {
+              "$ref": "#/definitions/session"
+            }
+          },
+          "400": {
+            "description": "jsonError",
+            "schema": {
+              "$ref": "#/definitions/jsonError"
+            }
+          },
+          "default": {
             "description": "jsonError",
             "schema": {
               "$ref": "#/definitions/jsonError"

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -772,8 +772,8 @@
           },
           {
             "enum": [
-              "Identity",
-              "Devices"
+              "identity",
+              "devices"
             ],
             "type": "array",
             "items": {
@@ -838,8 +838,8 @@
         "parameters": [
           {
             "enum": [
-              "Identity",
-              "Devices"
+              "identity",
+              "devices"
             ],
             "type": "array",
             "items": {

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -837,12 +837,12 @@
         "operationId": "adminGetSession",
         "parameters": [
           {
-            "enum": [
-              "identity",
-              "devices"
-            ],
             "type": "array",
             "items": {
+              "enum": [
+                "Devices",
+                "Identity"
+              ],
               "type": "string"
             },
             "description": "ExpandOptions is a query parameter encoded list of all properties that must be expanded in the Session.\nExample - ?expand=Identity\u0026expand=Devices\nIf no value is provided, the expandable properties are skipped.",


### PR DESCRIPTION
## Changes
- Adding an API to get session with expand options
- Refactor Session Listing to add expand options to query params and default to expand nothing

## Related issue(s)

https://github.com/ory-corp/cloud/issues/2007

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](https://github.com/ory/docs).
