### PR TITLE
feat: add session cache header feature flag

### DIFF
--- a/driver/config/config.go
+++ b/driver/config/config.go
@@ -118,6 +118,7 @@ const (
 	ViperKeySessionPath                                      = "session.cookie.path"
 	ViperKeySessionPersistentCookie                          = "session.cookie.persistent"
 	ViperKeySessionWhoAmIAAL                                 = "session.whoami.required_aal"
+	ViperKeySessionWhoAmICaching                             = "session.whoami.caching"
 	ViperKeySessionRefreshMinTimeLeft                        = "session.earliest_possible_extend"
 	ViperKeyCookieSameSite                                   = "cookies.same_site"
 	ViperKeyCookieDomain                                     = "cookies.domain"
@@ -1249,6 +1250,10 @@ func (p *Config) CookieDomain(ctx context.Context) string {
 
 func (p *Config) SessionWhoAmIAAL(ctx context.Context) string {
 	return p.GetProvider(ctx).String(ViperKeySessionWhoAmIAAL)
+}
+
+func (p *Config) SessionWhoAmICaching(ctx context.Context) bool {
+	return p.GetProvider(ctx).Bool(ViperKeySessionWhoAmICaching)
 }
 
 func (p *Config) SessionRefreshMinTimeLeft(ctx context.Context) time.Duration {

--- a/driver/config/config.go
+++ b/driver/config/config.go
@@ -118,7 +118,7 @@ const (
 	ViperKeySessionPath                                      = "session.cookie.path"
 	ViperKeySessionPersistentCookie                          = "session.cookie.persistent"
 	ViperKeySessionWhoAmIAAL                                 = "session.whoami.required_aal"
-	ViperKeySessionWhoAmICaching                             = "session.whoami.caching"
+	ViperKeySessionWhoAmICaching                             = "feature_flags.cacheable_sessions"
 	ViperKeySessionRefreshMinTimeLeft                        = "session.earliest_possible_extend"
 	ViperKeyCookieSameSite                                   = "cookies.same_site"
 	ViperKeyCookieDomain                                     = "cookies.domain"

--- a/driver/config/config_test.go
+++ b/driver/config/config_test.go
@@ -608,6 +608,10 @@ func TestSession(t *testing.T) {
 	assert.Equal(t, true, p.SessionPersistentCookie(ctx))
 	p.MustSet(ctx, config.ViperKeySessionPersistentCookie, false)
 	assert.Equal(t, false, p.SessionPersistentCookie(ctx))
+
+	assert.Equal(t, false, p.SessionWhoAmICaching(ctx))
+	p.MustSet(ctx, config.ViperKeySessionWhoAmICaching, true)
+	assert.Equal(t, true, p.SessionWhoAmICaching(ctx))
 }
 
 func TestCookies(t *testing.T) {

--- a/driver/config/config_test.go
+++ b/driver/config/config_test.go
@@ -609,9 +609,9 @@ func TestSession(t *testing.T) {
 	p.MustSet(ctx, config.ViperKeySessionPersistentCookie, false)
 	assert.Equal(t, false, p.SessionPersistentCookie(ctx))
 
-	assert.Equal(t, false, p.SessionWhoAmICaching(ctx))
-	p.MustSet(ctx, config.ViperKeySessionWhoAmICaching, true)
 	assert.Equal(t, true, p.SessionWhoAmICaching(ctx))
+	p.MustSet(ctx, config.ViperKeySessionWhoAmICaching, false)
+	assert.Equal(t, false, p.SessionWhoAmICaching(ctx))
 }
 
 func TestCookies(t *testing.T) {

--- a/embedx/config.schema.json
+++ b/embedx/config.schema.json
@@ -2474,6 +2474,17 @@
           }
         }
       }
+    },
+    "feature_flags": {
+      "title": "Feature flags",
+      "properties": {
+        "cacheable_sessions": {
+          "type": "boolean",
+          "title": "Enable Ory Sessions caching",
+          "description": "If enabled allows Ory Sessions to be cached. Only effective in the Ory Network."
+        }
+      },
+      "additionalProperties": false
     }
   },
   "allOf": [

--- a/embedx/config.schema.json
+++ b/embedx/config.schema.json
@@ -2481,7 +2481,8 @@
         "cacheable_sessions": {
           "type": "boolean",
           "title": "Enable Ory Sessions caching",
-          "description": "If enabled allows Ory Sessions to be cached. Only effective in the Ory Network."
+          "description": "If enabled allows Ory Sessions to be cached. Only effective in the Ory Network.",
+          "default": true
         }
       },
       "additionalProperties": false

--- a/session/handler_test.go
+++ b/session/handler_test.go
@@ -199,12 +199,12 @@ func TestSessionWhoAmI(t *testing.T) {
 			}
 		}
 
-		t.Run("cache enabled", func(t *testing.T) {
-			run(t, true)
-		})
-
 		t.Run("cache disabled", func(t *testing.T) {
 			run(t, false)
+		})
+
+		t.Run("cache enabled", func(t *testing.T) {
+			run(t, true)
 		})
 	})
 

--- a/session/handler_test.go
+++ b/session/handler_test.go
@@ -147,44 +147,65 @@ func TestSessionWhoAmI(t *testing.T) {
 	})
 
 	t.Run("case=http methods", func(t *testing.T) {
-		client := testhelpers.NewClientWithCookies(t)
+		run := func(t *testing.T, cacheEnabled bool) {
+			conf.MustSet(ctx, config.ViperKeySessionWhoAmICaching, cacheEnabled)
+			client := testhelpers.NewClientWithCookies(t)
 
-		// No cookie yet -> 401
-		res, err := client.Get(ts.URL + RouteWhoami)
-		require.NoError(t, err)
-		assertNoCSRFCookieInResponse(t, ts, client, res) // Test that no CSRF cookie is ever set here.
-		assert.NotEmpty(t, res.Header.Get("Ory-Session-Cache-For"))
+			// No cookie yet -> 401
+			res, err := client.Get(ts.URL + RouteWhoami)
+			require.NoError(t, err)
+			assertNoCSRFCookieInResponse(t, ts, client, res) // Test that no CSRF cookie is ever set here.
 
-		// Set cookie
-		reg.CSRFHandler().IgnorePath("/set")
-		testhelpers.MockHydrateCookieClient(t, client, ts.URL+"/set")
-
-		// Cookie set -> 200 (GET)
-		for _, method := range []string{
-			"GET",
-			"POST",
-			"PUT",
-			"DELETE",
-		} {
-			t.Run("http_method="+method, func(t *testing.T) {
-				req, err := http.NewRequest(method, ts.URL+RouteWhoami, nil)
-				require.NoError(t, err)
-
-				res, err = client.Do(req)
-				require.NoError(t, err)
-				body, err := io.ReadAll(res.Body)
-				require.NoError(t, err)
-				assertNoCSRFCookieInResponse(t, ts, client, res) // Test that no CSRF cookie is ever set here.
-
-				assert.EqualValues(t, http.StatusOK, res.StatusCode)
-				assert.NotEmpty(t, res.Header.Get("X-Kratos-Authenticated-Identity-Id"))
+			if cacheEnabled {
 				assert.NotEmpty(t, res.Header.Get("Ory-Session-Cache-For"))
+			} else {
+				assert.Empty(t, res.Header.Get("Ory-Session-Cache-For"))
+			}
 
-				assert.Empty(t, gjson.GetBytes(body, "identity.credentials"))
-				assert.Equal(t, "mp", gjson.GetBytes(body, "identity.metadata_public.public").String(), "%s", body)
-				assert.False(t, gjson.GetBytes(body, "identity.metadata_admin").Exists())
-			})
+			// Set cookie
+			reg.CSRFHandler().IgnorePath("/set")
+			testhelpers.MockHydrateCookieClient(t, client, ts.URL+"/set")
+
+			// Cookie set -> 200 (GET)
+			for _, method := range []string{
+				"GET",
+				"POST",
+				"PUT",
+				"DELETE",
+			} {
+				t.Run("http_method="+method, func(t *testing.T) {
+					req, err := http.NewRequest(method, ts.URL+RouteWhoami, nil)
+					require.NoError(t, err)
+
+					res, err = client.Do(req)
+					require.NoError(t, err)
+					body, err := io.ReadAll(res.Body)
+					require.NoError(t, err)
+					assertNoCSRFCookieInResponse(t, ts, client, res) // Test that no CSRF cookie is ever set here.
+
+					assert.EqualValues(t, http.StatusOK, res.StatusCode)
+					assert.NotEmpty(t, res.Header.Get("X-Kratos-Authenticated-Identity-Id"))
+
+					if cacheEnabled {
+						assert.NotEmpty(t, res.Header.Get("Ory-Session-Cache-For"))
+					} else {
+						assert.Empty(t, res.Header.Get("Ory-Session-Cache-For"))
+					}
+
+					assert.Empty(t, gjson.GetBytes(body, "identity.credentials"))
+					assert.Equal(t, "mp", gjson.GetBytes(body, "identity.metadata_public.public").String(), "%s", body)
+					assert.False(t, gjson.GetBytes(body, "identity.metadata_admin").Exists())
+				})
+			}
 		}
+
+		t.Run("cache enabled", func(t *testing.T) {
+			run(t, true)
+		})
+
+		t.Run("cache disabled", func(t *testing.T) {
+			run(t, false)
+		})
 	})
 
 	/*


### PR DESCRIPTION
- Added config key `session.whoami.caching` with default being disabled
- Set cache headers based on configuration

## Related issue(s)

https://github.com/ory-corp/cloud/issues/3283

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

