### PR TITLE
fix: marshalled session state 

### DIFF
--- a/persistence/sql/migratest/fixtures/session/7458af86-c1d8-401c-978a-8da89133f78b.json
+++ b/persistence/sql/migratest/fixtures/session/7458af86-c1d8-401c-978a-8da89133f78b.json
@@ -1,7 +1,7 @@
 {
   "id": "7458af86-c1d8-401c-978a-8da89133f78b",
   "active": true,
-  "expires_at": "2013-10-07T08:23:19Z",
+  "expires_at": "2080-10-07T08:23:19Z",
   "authenticated_at": "2013-10-07T08:23:19Z",
   "authenticator_assurance_level": "aal2",
   "authentication_methods": [

--- a/persistence/sql/migratest/fixtures/session/7458af86-c1d8-401c-978a-8da89133f98b.json
+++ b/persistence/sql/migratest/fixtures/session/7458af86-c1d8-401c-978a-8da89133f98b.json
@@ -1,6 +1,6 @@
 {
   "id": "7458af86-c1d8-401c-978a-8da89133f98b",
-  "active": true,
+  "active": false,
   "expires_at": "2013-10-07T08:23:19Z",
   "authenticated_at": "2013-10-07T08:23:19Z",
   "authenticator_assurance_level": "aal2",

--- a/persistence/sql/migratest/fixtures/session/dcde5aaa-f789-4d3d-ae1f-76da8d57e67c.json
+++ b/persistence/sql/migratest/fixtures/session/dcde5aaa-f789-4d3d-ae1f-76da8d57e67c.json
@@ -1,6 +1,6 @@
 {
   "id": "dcde5aaa-f789-4d3d-ae1f-76da8d57e67c",
-  "active": true,
+  "active": false,
   "expires_at": "2013-10-07T08:23:19Z",
   "authenticated_at": "2013-10-07T08:23:19Z",
   "authenticator_assurance_level": "aal1",

--- a/persistence/sql/migratest/fixtures/session/f38cdebe-e567-42c9-a562-1bd4dee40998.json
+++ b/persistence/sql/migratest/fixtures/session/f38cdebe-e567-42c9-a562-1bd4dee40998.json
@@ -1,6 +1,6 @@
 {
   "id": "f38cdebe-e567-42c9-a562-1bd4dee40998",
-  "active": true,
+  "active": false,
   "expires_at": "2013-10-07T08:23:19Z",
   "authenticated_at": "2013-10-07T08:23:19Z",
   "authenticator_assurance_level": "aal1",

--- a/persistence/sql/migratest/testdata/20210810153530_testdata.sql
+++ b/persistence/sql/migratest/testdata/20210810153530_testdata.sql
@@ -1,7 +1,7 @@
 INSERT INTO sessions (id, nid, issued_at, expires_at, authenticated_at, created_at, updated_at, token, identity_id,
                       active, logout_token, aal, authentication_methods)
 VALUES ('7458af86-c1d8-401c-978a-8da89133f78b', '884f556e-eb3a-4b9f-bee3-11345642c6c0', '2013-10-07 08:23:19',
-        '2013-10-07 08:23:19', '2013-10-07 08:23:19', '2013-10-07 08:23:19', '2013-10-07 08:23:19',
+        '2080-10-07 08:23:19', '2013-10-07 08:23:19', '2013-10-07 08:23:19', '2013-10-07 08:23:19',
         'eVwBt7UAAAAVwBt7UWPw', '5ff66179-c240-4703-b0d8-494592cefff5', true, '123eVwBt7UAAAeVwBt7UWPw', 'aal2',
         '[{"method":"password"},{"method":"totp"}]');
 

--- a/session/session.go
+++ b/session/session.go
@@ -148,6 +148,17 @@ func (s Session) TableName(ctx context.Context) string {
 	return "sessions"
 }
 
+func (s Session) MarshalJSON() ([]byte, error) {
+	type sl Session
+	s.Active = s.IsActive()
+
+	result, err := json.Marshal(sl(s))
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 func (s *Session) CompletedLoginFor(method identity.CredentialsType, aal identity.AuthenticatorAssuranceLevel) {
 	s.AMR = append(s.AMR, AuthenticationMethod{Method: method, AAL: aal, CompletedAt: time.Now().UTC()})
 }


### PR DESCRIPTION
- Use `.isActive()` eval for state 

## Related issue(s)


## Checklist

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [ ] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).
