### PR TITLE
fix: pagination uses created_at sort as well

### DIFF
--- a/persistence/sql/persister_courier.go
+++ b/persistence/sql/persister_courier.go
@@ -52,6 +52,7 @@ func (p *Persister) ListMessages(ctx context.Context, filter courier.ListCourier
 
 	opts = append(opts, keysetpagination.WithDefaultToken(new(courier.Message).DefaultPageToken()))
 	opts = append(opts, keysetpagination.WithDefaultSize(10))
+	opts = append(opts, keysetpagination.WithMaxSize(paginationMaxItemsSize))
 	opts = append(opts, keysetpagination.WithColumn("created_at", "DESC"))
 	paginator := keysetpagination.GetPaginator(opts...)
 

--- a/persistence/sql/persister_session.go
+++ b/persistence/sql/persister_session.go
@@ -79,6 +79,7 @@ func (p *Persister) ListSessions(ctx context.Context, active *bool, paginatorOpt
 	paginatorOpts = append(paginatorOpts, keysetpagination.WithDefaultSize(paginationDefaultItemsSize))
 	paginatorOpts = append(paginatorOpts, keysetpagination.WithMaxSize(paginationMaxItemsSize))
 	paginatorOpts = append(paginatorOpts, keysetpagination.WithDefaultToken(new(session.Session).DefaultPageToken()))
+	paginatorOpts = append(paginatorOpts, keysetpagination.WithColumn("created_at", "DESC"))
 	paginator := keysetpagination.GetPaginator(paginatorOpts...)
 
 	if err := p.Transaction(ctx, func(ctx context.Context, c *pop.Connection) error {

--- a/session/handler.go
+++ b/session/handler.go
@@ -338,7 +338,7 @@ func (h *Handler) adminListSessions(w http.ResponseWriter, r *http.Request, ps h
 	}
 
 	// Parse request pagination parameters
-	opts, err := keysetpagination.Parse(r.URL.Query(), keysetpagination.NewStringPageToken)
+	opts, err := keysetpagination.Parse(r.URL.Query(), keysetpagination.NewMapPageToken)
 	if err != nil {
 		h.r.Writer().WriteError(w, r, herodot.ErrBadRequest.WithError("could not parse parameter page_size"))
 		return

--- a/session/handler_test.go
+++ b/session/handler_test.go
@@ -537,12 +537,14 @@ func TestHandlerAdminSessionManagement(t *testing.T) {
 		})
 
 		t.Run("list sessions", func(t *testing.T) {
+			expectedPageToken := s.DefaultPageToken().Encode()
+
 			req, _ := http.NewRequest("GET", ts.URL+"/admin/sessions/", nil)
 			res, err := client.Do(req)
 			require.NoError(t, err)
 			assert.Equal(t, http.StatusOK, res.StatusCode)
 			assert.Equal(t, "1", res.Header.Get("X-Total-Count"))
-			assert.Equal(t, "</admin/sessions?page_size=250&page_token=00000000-0000-0000-0000-000000000000>; rel=\"first\"", res.Header.Get("Link"))
+			assert.Equal(t, "</admin/sessions?page_size=250&page_token="+expectedPageToken+">; rel=\"first\"", res.Header.Get("Link"))
 
 			var sessions []Session
 			require.NoError(t, json.NewDecoder(res.Body).Decode(&sessions))
@@ -585,12 +587,14 @@ func TestHandlerAdminSessionManagement(t *testing.T) {
 				},
 			} {
 				t.Run(fmt.Sprintf("description=%s", tc.description), func(t *testing.T) {
+					expectedPageToken := s.DefaultPageToken().Encode()
+
 					req, _ := http.NewRequest("GET", ts.URL+"/admin/sessions?"+tc.expand, nil)
 					res, err := client.Do(req)
 					require.NoError(t, err)
 					assert.Equal(t, http.StatusOK, res.StatusCode)
 					assert.Equal(t, "1", res.Header.Get("X-Total-Count"))
-					assert.Equal(t, "</admin/sessions?"+tc.expand+"page_size=250&page_token=00000000-0000-0000-0000-000000000000>; rel=\"first\"", res.Header.Get("Link"))
+					assert.Equal(t, "</admin/sessions?"+tc.expand+"page_size=250&page_token="+expectedPageToken+">; rel=\"first\"", res.Header.Get("Link"))
 
 					body := ioutilx.MustReadAll(res.Body)
 					assert.Equal(t, s.ID.String(), gjson.GetBytes(body, "0.id").String())

--- a/session/session.go
+++ b/session/session.go
@@ -142,7 +142,7 @@ type Session struct {
 }
 
 // The format we need to use in the Page tokens, as it's the only format that is understood by all DBs
-const dbFormat = "2006-01-02 15:04:05.99999+07:00"
+const dbFormat = "2006-01-02 15:04:05.99999"
 
 func (s Session) PageToken() keysetpagination.PageToken {
 	return keysetpagination.MapPageToken{

--- a/session/session.go
+++ b/session/session.go
@@ -141,12 +141,21 @@ type Session struct {
 	NID   uuid.UUID `json:"-"  faker:"-" db:"nid"`
 }
 
+// The format we need to use in the Page tokens, as it's the only format that is understood by all DBs
+const dbFormat = "2006-01-02 15:04:05.99999+07:00"
+
 func (s Session) PageToken() keysetpagination.PageToken {
-	return keysetpagination.StringPageToken(s.ID.String())
+	return keysetpagination.MapPageToken{
+		"id":         s.ID.String(),
+		"created_at": s.CreatedAt.Format(dbFormat),
+	}
 }
 
 func (s Session) DefaultPageToken() keysetpagination.PageToken {
-	return keysetpagination.StringPageToken(uuid.Nil.String())
+	return keysetpagination.MapPageToken{
+		"id":         uuid.Nil.String(),
+		"created_at": time.Date(2200, 12, 31, 23, 59, 59, 0, time.UTC).Format(dbFormat),
+	}
 }
 
 func (s Session) TableName(ctx context.Context) string {

--- a/session/test/persistence.go
+++ b/session/test/persistence.go
@@ -288,7 +288,7 @@ func TestPersister(ctx context.Context, conf *config.Config, p interface {
 					require.Equal(t, len(tc.expected), len(actual))
 					require.Equal(t, int64(len(tc.expected)), total)
 					assert.Equal(t, true, nextPage.IsLast())
-					assert.Equal(t, uuid.Nil.String(), nextPage.Token().Encode())
+					assert.Equal(t, actual[len(actual)-1].DefaultPageToken().Encode(), nextPage.Token().Encode())
 					assert.Equal(t, 250, nextPage.Size())
 					for _, es := range tc.expected {
 						found := false
@@ -312,7 +312,7 @@ func TestPersister(ctx context.Context, conf *config.Config, p interface {
 				require.Equal(t, 6, len(actual))
 				require.Equal(t, int64(6), total)
 				assert.Equal(t, true, page.IsLast())
-				assert.Equal(t, uuid.Nil.String(), page.Token().Encode())
+				assert.Equal(t, actual[len(actual)-1].DefaultPageToken().Encode(), page.Token().Encode())
 				assert.Equal(t, 250, page.Size())
 			})
 
@@ -325,7 +325,7 @@ func TestPersister(ctx context.Context, conf *config.Config, p interface {
 				assert.Len(t, firstPageItems, 3)
 
 				assert.Equal(t, false, page1.IsLast())
-				assert.Equal(t, firstPageItems[len(firstPageItems)-1].ID.String(), page1.Token().Encode())
+				assert.Equal(t, firstPageItems[len(firstPageItems)-1].PageToken().Encode(), page1.Token().Encode())
 				assert.Equal(t, 3, page1.Size())
 
 				// Validate secondPageItems page


### PR DESCRIPTION
## Changes

- Use `mappagetoken` that allows for ordered lists with encoded token