### PR TITLE
fix: quickstart demos

### DIFF
--- a/contrib/quickstart/kratos/cloud/kratos.yml
+++ b/contrib/quickstart/kratos/cloud/kratos.yml
@@ -1,4 +1,4 @@
-version: v0.8.0-alpha.3
+version: v0.11.0
 
 dsn: memory
 

--- a/contrib/quickstart/kratos/email-password/kratos.yml
+++ b/contrib/quickstart/kratos/email-password/kratos.yml
@@ -1,4 +1,4 @@
-version: v0.7.1-alpha.1
+version: v0.11.0
 
 dsn: memory
 

--- a/contrib/quickstart/oathkeeper/access-rules.yml
+++ b/contrib/quickstart/oathkeeper/access-rules.yml
@@ -26,7 +26,7 @@
     preserve_host: true
     url: "http://kratos-selfservice-ui-node:4435"
   match:
-    url: "http://127.0.0.1:4455/<{registration,welcome,recovery,verification,login,error,**.css,**.js,**.png,}>"
+    url: "http://127.0.0.1:4455/<{registration,welcome,recovery,verification,login,error,health/{alive,ready},**.css,**.js,**.png,}>"
     methods:
       - GET
   authenticators:
@@ -44,7 +44,7 @@
     preserve_host: true
     url: "http://kratos-selfservice-ui-node:4435"
   match:
-    url: "http://127.0.0.1:4455/<{debug,dashboard,settings}>"
+    url: "http://127.0.0.1:4455/<{sessions,settings}>"
     methods:
       - GET
   authenticators:

--- a/quickstart-oathkeeper.yml
+++ b/quickstart-oathkeeper.yml
@@ -13,7 +13,7 @@ services:
       - SECURITY_MODE=jwks
 
   oathkeeper:
-    image: oryd/oathkeeper:v0.38
+    image: oryd/oathkeeper:v0.40
     depends_on:
       - kratos
     ports:


### PR DESCRIPTION
Hi there,

I started to play with your quickstart examples and I realised that the Kratos configuration files are targeting very old versions of the tool (e.g. `v0.7.1-alpha.1`), which make them invalid according to your current configuration JSON schema.

This PR upgrades the version numbers in the Kratos configuration files located in `contrib/quickstart`. I also took the liberty to upgrade the Docker image of Oathkeeper in `quickstart-oathkeeper.yml`.

## Related issue(s)

N/A

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

Some of the checklist items are irrelevant for this PR.

## Further Comments

None.
