### PR TITLE
fix: TOTP invalid code and/or 500 error

### DIFF
--- a/selfservice/flow/settings/hook.go
+++ b/selfservice/flow/settings/hook.go
@@ -242,6 +242,7 @@ func (e *HookExecutor) PostSettingsHook(w http.ResponseWriter, r *http.Request, 
 	ctxUpdate.Flow.UI = newFlow.UI
 	ctxUpdate.Flow.UI.ResetMessages()
 	ctxUpdate.Flow.UI.AddMessage(node.DefaultGroup, text.NewInfoSelfServiceSettingsUpdateSuccess())
+	ctxUpdate.Flow.InternalContext = newFlow.InternalContext
 	if err := e.d.SettingsFlowPersister().UpdateSettingsFlow(r.Context(), ctxUpdate.Flow); err != nil {
 		return err
 	}

--- a/selfservice/strategy/lookup/settings_test.go
+++ b/selfservice/strategy/lookup/settings_test.go
@@ -475,7 +475,7 @@ func TestCompleteSettings(t *testing.T) {
 
 					actualFlow, err := reg.SettingsFlowPersister().GetSettingsFlow(context.Background(), uuid.FromStringOrNil(f.Id))
 					require.NoError(t, err)
-					assert.Equal(t, "{}", gjson.GetBytes(actualFlow.InternalContext, flow.PrefixInternalContextKey(identity.CredentialsTypeLookup, lookup.InternalContextKeyRegenerated)).Raw)
+					assert.Empty(t, gjson.GetBytes(actualFlow.InternalContext, flow.PrefixInternalContextKey(identity.CredentialsTypeLookup, lookup.InternalContextKeyRegenerated)).Raw)
 				}
 
 				t.Run("type=api", func(t *testing.T) {

--- a/selfservice/strategy/webauthn/settings_test.go
+++ b/selfservice/strategy/webauthn/settings_test.go
@@ -344,7 +344,8 @@ func TestCompleteSettings(t *testing.T) {
 
 			actualFlow, err := reg.SettingsFlowPersister().GetSettingsFlow(context.Background(), uuid.FromStringOrNil(f.Id))
 			require.NoError(t, err)
-			assert.Empty(t, gjson.GetBytes(actualFlow.InternalContext, flow.PrefixInternalContextKey(identity.CredentialsTypeWebAuthn, webauthn.InternalContextKeySessionData)))
+			// new session data has been generated
+			assert.NotEqual(t, settingsFixtureSuccessInternalContext, gjson.GetBytes(actualFlow.InternalContext, flow.PrefixInternalContextKey(identity.CredentialsTypeWebAuthn, webauthn.InternalContextKeySessionData)))
 
 			testhelpers.EnsureAAL(t, browserClient, publicTS, "aal2", string(identity.CredentialsTypeWebAuthn))
 		}

--- a/test/e2e/cypress/integration/profiles/mfa/totp.spec.ts
+++ b/test/e2e/cypress/integration/profiles/mfa/totp.spec.ts
@@ -6,7 +6,7 @@ import { authenticator } from "otplib"
 import { routes as react } from "../../../helpers/react"
 import { routes as express } from "../../../helpers/express"
 
-context("2FA lookup secrets", () => {
+context("2FA TOTP", () => {
   ;[
     {
       login: react.login,
@@ -243,6 +243,21 @@ context("2FA lookup secrets", () => {
           expectAal: "aal2",
           expectMethods: ["password", "totp", "totp", "totp", "totp"],
         })
+
+        // The React app keeps using the same flow. The following scenario used to be broken,
+        // because the internal context wasn't populated properly in the flow after settings were saved.
+        cy.visit(settings)
+        cy.get('*[name="totp_unlink"]').click()
+        cy.expectSettingsSaved()
+
+        cy.get('[data-testid="node/text/totp_secret_key/text"]').then(($e) => {
+          secret = $e.text().trim()
+        })
+        cy.get('input[name="totp_code"]').then(($e) => {
+          cy.wrap($e).type(authenticator.generate(secret))
+        })
+        cy.get('*[name="method"][value="totp"]').click()
+        cy.expectSettingsSaved()
       })
 
       it("should not show totp as an option if not configured", () => {
@@ -273,6 +288,27 @@ context("2FA lookup secrets", () => {
           "contain.text",
           "The provided authentication code is invalid, please try again.",
         )
+      })
+
+      // The React app keeps using the same flow. The following scenario used to be broken,
+      // because the internal context wasn't populated properly in the flow after settings were saved.
+      it.only("should allow changing other settings and then setting up totp", () => {
+        cy.visit(settings)
+        cy.get('input[name="traits.website"]')
+          .clear()
+          .type("https://some-website.com")
+        cy.get('*[name="method"][value="profile"]').click()
+        cy.expectSettingsSaved()
+
+        let secret
+        cy.get('[data-testid="node/text/totp_secret_key/text"]').then(($e) => {
+          secret = $e.text().trim()
+        })
+        cy.get('input[name="totp_code"]').then(($e) => {
+          cy.wrap($e).type(authenticator.generate(secret))
+        })
+        cy.get('*[name="method"][value="totp"]').click()
+        cy.expectSettingsSaved()
       })
     })
   })


### PR DESCRIPTION
Fixes a 500 error if TOTP is removed and then re-added in the same flow.

It also fixes another related bug, that can be reproduced with https://github.com/ory/kratos-selfservice-ui-react-nextjs:
1. go to settings
2. change your name (or email, or whatever)
3. try to set up TOTP
4. "invalid code"

The reason is that because the `InternalContext` is not reset properly in `PostSettingsHook`, the flow will have a new QR code and secret key (`UI` is reset), but the internal context will keep the old TOTP secret.

In the case of the original issue, `InternalContextKeyURL` is deleted from `InternalContext` when TOTP is removed, and since it's not set properly in `PostSettingsHook`, when we try to re-add TOTP, we get 500, because `InternalContextKeyURL` is missing.

## Related issue(s)

https://github.com/ory/kratos/issues/2680

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

WebAuthn is most likely affected by the same bug, but I didn't any tests there. I wasn't able to run WebAuthn tests locally, because of this error:
```
cy.task('resetCRI') failed with the following error:

The 'task' event has not been registered in the plugins file. You must register it before using cy.task()
```