### PR TITLE
fix: remove unused x-session-cookie parameter

### DIFF
--- a/session/manager_http.go
+++ b/session/manager_http.go
@@ -68,9 +68,8 @@ func (s *ManagerHTTP) UpsertAndIssueCookie(ctx context.Context, w http.ResponseW
 
 func (s *ManagerHTTP) RefreshCookie(ctx context.Context, w http.ResponseWriter, r *http.Request, session *Session) error {
 	// If it is a session token there is nothing to do.
-	cookieHeader := r.Header.Get("X-Session-Cookie")
 	_, cookieErr := r.Cookie(s.cookieName(r.Context()))
-	if len(cookieHeader) == 0 && errors.Is(cookieErr, http.ErrNoCookie) {
+	if errors.Is(cookieErr, http.ErrNoCookie) {
 		return nil
 	}
 
@@ -156,12 +155,6 @@ func getCookieExpiry(s *sessions.Session) *time.Time {
 }
 
 func (s *ManagerHTTP) getCookie(r *http.Request) (*sessions.Session, error) {
-	if cookie := r.Header.Get("X-Session-Cookie"); len(cookie) > 0 {
-		rr := *r
-		r = &rr
-		r.Header = http.Header{"Cookie": []string{s.cookieName(r.Context()) + "=" + cookie}}
-	}
-
 	return s.r.CookieManager(r.Context()).Get(r, s.cookieName(r.Context()))
 }
 


### PR DESCRIPTION
This patch removes the undocumented and experimental `X-Session-Cookie` header from the `/sessions/whoami` endpoint.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [ ] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
