### PR TITLE
feat: added Econt as OIDC Provider

### DIFF
--- a/.schemastore/config.schema.json
+++ b/.schemastore/config.schema.json
@@ -382,7 +382,8 @@
             "spotify",
             "netid",
             "dingtalk",
-            "patreon"
+            "patreon",
+            "econt"
           ],
           "examples": [
             "google"

--- a/embedx/config.schema.json
+++ b/embedx/config.schema.json
@@ -382,7 +382,8 @@
             "spotify",
             "netid",
             "dingtalk",
-            "patreon"
+            "patreon",
+            "econt"
           ],
           "examples": [
             "google"

--- a/selfservice/strategy/oidc/provider_config.go
+++ b/selfservice/strategy/oidc/provider_config.go
@@ -37,6 +37,7 @@ type Configuration struct {
 	// - netid
 	// - dingtalk
 	// - patreon
+	// - econt
 	Provider string `json:"provider"`
 
 	// Label represents an optional label which can be used in the UI generation.
@@ -164,6 +165,8 @@ func (c ConfigurationCollection) Provider(id string, reg dependencies) (Provider
 				return NewProviderDingTalk(&p, reg), nil
 			case addProviderName("patreon"):
 				return NewProviderPatreon(&p, reg), nil
+			case addProviderName("econt"):
+				return NewProviderEcont(&p, reg), nil
 			}
 			return nil, errors.Errorf("provider type %s is not supported, supported are: %v", p.Provider, providerNames)
 		}

--- a/selfservice/strategy/oidc/provider_econt.go
+++ b/selfservice/strategy/oidc/provider_econt.go
@@ -22,11 +22,10 @@ import (
 )
 
 type EcontIdentityResponse struct {
-	Issuer    string `json:"iss,omitempty"`
-	Subject   string `json:"sub,omitempty"`
-	Name      string `json:"name,omitempty"`
-	Username  string `json:"user_name,omitempty"`
-	AccountId int    `json:"account_id,omitempty"`
+	Issuer   string `json:"iss,omitempty"`
+	Subject  string `json:"sub,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Username string `json:"user_name,omitempty"`
 }
 
 type ProviderEcont struct {
@@ -150,9 +149,11 @@ func (g *ProviderEcont) Claims(ctx context.Context, exchange *oauth2.Token, quer
 
 	req, err := retryablehttp.NewRequest("GET", u.String(), nil)
 
-	q := req.URL.Query()
-	q.Add("access_token", exchange.AccessToken)
-	req.URL.RawQuery = q.Encode()
+	if req != nil {
+		q := req.URL.Query()
+		q.Add("access_token", exchange.AccessToken)
+		req.URL.RawQuery = q.Encode()
+	}
 
 	if err != nil {
 		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
@@ -171,6 +172,7 @@ func (g *ProviderEcont) Claims(ctx context.Context, exchange *oauth2.Token, quer
 		Issuer:  "https://login.econt.com/",
 		Subject: data.Username,
 		Email:   data.Username,
+		Name:    data.Name,
 	}
 	return claims, nil
 }

--- a/selfservice/strategy/oidc/provider_econt.go
+++ b/selfservice/strategy/oidc/provider_econt.go
@@ -1,0 +1,184 @@
+// Copyright © 2023 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package oidc
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+
+	"github.com/ory/x/httpx"
+
+	"github.com/pkg/errors"
+	"golang.org/x/oauth2"
+
+	"github.com/ory/herodot"
+)
+
+type EcontIdentityResponse struct {
+	Issuer    string `json:"iss,omitempty"`
+	Subject   string `json:"sub,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Username  string `json:"user_name,omitempty"`
+	AccountId int    `json:"account_id,omitempty"`
+}
+
+type ProviderEcont struct {
+	*ProviderGenericOIDC
+}
+
+func NewProviderEcont(
+	config *Configuration,
+	reg dependencies,
+) *ProviderEcont {
+	return &ProviderEcont{
+		ProviderGenericOIDC: &ProviderGenericOIDC{
+			config: config,
+			reg:    reg,
+		},
+	}
+}
+
+func (g *ProviderEcont) oauth2(ctx context.Context) (*oauth2.Config, error) {
+	endpoint, err := g.endpoint()
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+
+	authUrl := *endpoint
+	tokenUrl := *endpoint
+
+	authUrl.Path = path.Join(authUrl.Path, "/oauth2/auth")
+	tokenUrl.Path = path.Join(tokenUrl.Path, "/oauth2/token")
+
+	return &oauth2.Config{
+		ClientID:     g.config.ClientID,
+		ClientSecret: g.config.ClientSecret,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  authUrl.String(),
+			TokenURL: tokenUrl.String(),
+		},
+		Scopes:      g.config.Scope,
+		RedirectURL: g.config.Redir(g.reg.Config().OIDCRedirectURIBase(ctx)),
+	}, nil
+}
+
+func (g *ProviderEcont) OAuth2(ctx context.Context) (*oauth2.Config, error) {
+	return g.oauth2(ctx)
+}
+
+func (g *ProviderEcont) Exchange(ctx context.Context, code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
+	conf, err := g.OAuth2(ctx)
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+
+	pTokenParams := &struct {
+		ClientId     string `json:"client_id"`
+		ClientSecret string `json:"client_secret"`
+		Code         string `json:"code"`
+		GrantType    string `json:"grant_type"`
+	}{conf.ClientID, conf.ClientSecret, code, "authorization_code"}
+	bs, err := json.Marshal(pTokenParams)
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+
+	r := strings.NewReader(string(bs))
+	client := g.reg.HTTPClient(ctx, httpx.ResilientClientDisallowInternalIPs())
+
+	req, err := retryablehttp.NewRequest("POST", conf.Endpoint.TokenURL, r)
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+
+	req.Header.Add("Content-Type", "application/json;charset=UTF-8")
+
+	q := req.URL.Query()
+
+	q.Add("grant_type", "authorization_code")
+	q.Add("code", code)
+	q.Add("client_id", conf.ClientID)
+	q.Add("client_secret", conf.ClientSecret)
+
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+	defer resp.Body.Close()
+
+	var dToken struct {
+		AccessToken  string `json:"access_token"`
+		TokenType    string `json:"token_type"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresIn    int32  `json:"expires_in"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&dToken); err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+
+	token := &oauth2.Token{
+		AccessToken:  dToken.AccessToken,
+		TokenType:    dToken.TokenType,
+		RefreshToken: dToken.RefreshToken,
+		Expiry:       time.Unix(time.Now().Unix()+int64(dToken.ExpiresIn), 0),
+	}
+	return token, nil
+}
+
+func (g *ProviderEcont) Claims(ctx context.Context, exchange *oauth2.Token, query url.Values) (*Claims, error) {
+	o, err := g.OAuth2(ctx)
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+	client := g.reg.HTTPClient(ctx, httpx.ResilientClientDisallowInternalIPs(), httpx.ResilientClientWithClient(o.Client(ctx, exchange)))
+
+	u, err := g.endpoint()
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+	u.Path = path.Join(u.Path, "/oauth2/profile")
+
+	req, err := retryablehttp.NewRequest("GET", u.String(), nil)
+
+	q := req.URL.Query()
+	q.Add("access_token", exchange.AccessToken)
+	req.URL.RawQuery = q.Encode()
+
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+	defer resp.Body.Close()
+
+	data := EcontIdentityResponse{}
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+	claims := &Claims{
+		Issuer:  "https://login.econt.com/",
+		Subject: data.Username,
+		Email:   data.Username,
+	}
+	return claims, nil
+}
+
+func (g *ProviderEcont) endpoint() (*url.URL, error) {
+	var e = "https://login.econt.com" // defaultEndpoint
+	if len(g.config.IssuerURL) > 0 {
+		e = g.config.IssuerURL
+	}
+	return url.Parse(e)
+}


### PR DESCRIPTION
This PR is intending to implement another OIDC provider for **Econt** a Bulgarian common provider to Kratos since Econt has non-standard paths to its auth and token endpoints.

## Related issue(s)

There is no issue as this is just a new OIDC provider.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [ ] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

I added econt as OIDC Provider, as we already have it implemented in our project and it would be good to not have a kratos-fork for it.
