### PR TITLE
fix: remove skip network init option parameter

### DIFF
--- a/cmd/cliclient/cleanup.go
+++ b/cmd/cliclient/cleanup.go
@@ -51,7 +51,7 @@ func (h *CleanupHandler) CleanupSQL(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "An error occurred initializing cleanup")
 	}
 
-	err = d.Init(cmd.Context(), &contextx.Default{}, driver.SkipNetworkInit)
+	err = d.Init(cmd.Context(), &contextx.Default{})
 	if err != nil {
 		return errors.Wrap(err, "An error occurred initializing cleanup")
 	}


### PR DESCRIPTION
Remove the option parameter that prevents network init. The delete queries cannot handle `nil` values for `nid`.