### PR TITLE
fix: implement offline scope in the way google expects

### DIFF
--- a/selfservice/strategy/oidc/provider_generic_oidc.go
+++ b/selfservice/strategy/oidc/provider_generic_oidc.go
@@ -51,7 +51,7 @@ func (g *ProviderGenericOIDC) provider(ctx context.Context) (*gooidc.Provider, e
 
 func (g *ProviderGenericOIDC) oauth2ConfigFromEndpoint(ctx context.Context, endpoint oauth2.Endpoint) *oauth2.Config {
 	scope := g.config.Scope
-	if stringslice.Has(scope, gooidc.ScopeOpenID) {
+	if !stringslice.Has(scope, gooidc.ScopeOpenID) {
 		scope = append(scope, gooidc.ScopeOpenID)
 	}
 

--- a/selfservice/strategy/oidc/provider_generic_oidc.go
+++ b/selfservice/strategy/oidc/provider_generic_oidc.go
@@ -51,7 +51,7 @@ func (g *ProviderGenericOIDC) provider(ctx context.Context) (*gooidc.Provider, e
 
 func (g *ProviderGenericOIDC) oauth2ConfigFromEndpoint(ctx context.Context, endpoint oauth2.Endpoint) *oauth2.Config {
 	scope := g.config.Scope
-	if !stringslice.Has(scope, gooidc.ScopeOpenID) {
+	if stringslice.Has(scope, gooidc.ScopeOpenID) {
 		scope = append(scope, gooidc.ScopeOpenID)
 	}
 

--- a/selfservice/strategy/oidc/provider_google.go
+++ b/selfservice/strategy/oidc/provider_google.go
@@ -5,9 +5,11 @@ package oidc
 
 import (
 	"context"
+
 	gooidc "github.com/coreos/go-oidc"
-	"github.com/ory/x/stringslice"
 	"golang.org/x/oauth2"
+
+	"github.com/ory/x/stringslice"
 )
 
 type ProviderGoogle struct {

--- a/selfservice/strategy/oidc/provider_google.go
+++ b/selfservice/strategy/oidc/provider_google.go
@@ -44,6 +44,16 @@ func (g *ProviderGoogle) oauth2ConfigFromEndpoint(ctx context.Context, endpoint 
 	}
 }
 
+func (g *ProviderGenericOIDC) OAuth2(ctx context.Context) (*oauth2.Config, error) {
+	p, err := g.provider(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint := p.Endpoint()
+	return g.oauth2ConfigFromEndpoint(ctx, endpoint), nil
+}
+
 func (g *ProviderGoogle) AuthCodeURLOptions(r ider) []oauth2.AuthCodeOption {
 	var options []oauth2.AuthCodeOption
 	scope := g.config.Scope

--- a/selfservice/strategy/oidc/provider_google.go
+++ b/selfservice/strategy/oidc/provider_google.go
@@ -3,6 +3,13 @@
 
 package oidc
 
+import (
+	"context"
+	gooidc "github.com/coreos/go-oidc"
+	"github.com/ory/x/stringslice"
+	"golang.org/x/oauth2"
+)
+
 type ProviderGoogle struct {
 	*ProviderGenericOIDC
 }
@@ -18,4 +25,37 @@ func NewProviderGoogle(
 			reg:    reg,
 		},
 	}
+}
+
+func (g *ProviderGoogle) oauth2ConfigFromEndpoint(ctx context.Context, endpoint oauth2.Endpoint) *oauth2.Config {
+	scope := g.config.Scope
+	if !stringslice.Has(scope, gooidc.ScopeOpenID) {
+		scope = append(scope, gooidc.ScopeOpenID)
+	}
+
+	return &oauth2.Config{
+		ClientID:     g.config.ClientID,
+		ClientSecret: g.config.ClientSecret,
+		Endpoint:     endpoint,
+		Scopes:       stringslice.Filter(scope, func(s string) bool { return s == gooidc.ScopeOfflineAccess }),
+		RedirectURL:  g.config.Redir(g.reg.Config().OIDCRedirectURIBase(ctx)),
+	}
+}
+
+func (g *ProviderGoogle) AuthCodeURLOptions(r ider) []oauth2.AuthCodeOption {
+	var options []oauth2.AuthCodeOption
+	scope := g.config.Scope
+
+	if isForced(r) {
+		options = append(options, oauth2.SetAuthURLParam("prompt", "login"))
+	}
+	if len(g.config.RequestedClaims) != 0 {
+		options = append(options, oauth2.SetAuthURLParam("claims", string(g.config.RequestedClaims)))
+	}
+
+	if !stringslice.Has(scope, gooidc.ScopeOfflineAccess) {
+		options = append(options, oauth2.AccessTypeOffline)
+	}
+
+	return options
 }

--- a/selfservice/strategy/oidc/provider_google.go
+++ b/selfservice/strategy/oidc/provider_google.go
@@ -35,11 +35,13 @@ func (g *ProviderGoogle) oauth2ConfigFromEndpoint(ctx context.Context, endpoint 
 		scope = append(scope, gooidc.ScopeOpenID)
 	}
 
+	scope = stringslice.Filter(scope, func(s string) bool { return s == gooidc.ScopeOfflineAccess })
+
 	return &oauth2.Config{
 		ClientID:     g.config.ClientID,
 		ClientSecret: g.config.ClientSecret,
 		Endpoint:     endpoint,
-		Scopes:       stringslice.Filter(scope, func(s string) bool { return s == gooidc.ScopeOfflineAccess }),
+		Scopes:       scope,
 		RedirectURL:  g.config.Redir(g.reg.Config().OIDCRedirectURIBase(ctx)),
 	}
 }
@@ -65,7 +67,7 @@ func (g *ProviderGoogle) AuthCodeURLOptions(r ider) []oauth2.AuthCodeOption {
 		options = append(options, oauth2.SetAuthURLParam("claims", string(g.config.RequestedClaims)))
 	}
 
-	if !stringslice.Has(scope, gooidc.ScopeOfflineAccess) {
+	if stringslice.Has(scope, gooidc.ScopeOfflineAccess) {
 		options = append(options, oauth2.AccessTypeOffline)
 	}
 

--- a/selfservice/strategy/oidc/provider_google.go
+++ b/selfservice/strategy/oidc/provider_google.go
@@ -57,15 +57,8 @@ func (g *ProviderGoogle) OAuth2(ctx context.Context) (*oauth2.Config, error) {
 }
 
 func (g *ProviderGoogle) AuthCodeURLOptions(r ider) []oauth2.AuthCodeOption {
-	var options []oauth2.AuthCodeOption
 	scope := g.config.Scope
-
-	if isForced(r) {
-		options = append(options, oauth2.SetAuthURLParam("prompt", "login"))
-	}
-	if len(g.config.RequestedClaims) != 0 {
-		options = append(options, oauth2.SetAuthURLParam("claims", string(g.config.RequestedClaims)))
-	}
+	options := g.ProviderGenericOIDC.AuthCodeURLOptions(r)
 
 	if stringslice.Has(scope, gooidc.ScopeOfflineAccess) {
 		options = append(options, oauth2.AccessTypeOffline)

--- a/selfservice/strategy/oidc/provider_google.go
+++ b/selfservice/strategy/oidc/provider_google.go
@@ -44,7 +44,7 @@ func (g *ProviderGoogle) oauth2ConfigFromEndpoint(ctx context.Context, endpoint 
 	}
 }
 
-func (g *ProviderGenericOIDC) OAuth2(ctx context.Context) (*oauth2.Config, error) {
+func (g *ProviderGoogle) OAuth2(ctx context.Context) (*oauth2.Config, error) {
 	p, err := g.provider(ctx)
 	if err != nil {
 		return nil, err

--- a/selfservice/strategy/oidc/provider_google_test.go
+++ b/selfservice/strategy/oidc/provider_google_test.go
@@ -1,14 +1,19 @@
+// Copyright © 2023 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
 package oidc_test
 
 import (
 	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/oauth2"
+
 	"github.com/ory/kratos/internal"
 	"github.com/ory/kratos/selfservice/flow/login"
 	"github.com/ory/kratos/selfservice/strategy/oidc"
 	"github.com/ory/kratos/x"
-	"github.com/stretchr/testify/assert"
-	"golang.org/x/oauth2"
-	"testing"
 )
 
 func TestProviderGoogle_Scope(t *testing.T) {

--- a/selfservice/strategy/oidc/provider_google_test.go
+++ b/selfservice/strategy/oidc/provider_google_test.go
@@ -1,0 +1,50 @@
+package oidc_test
+
+import (
+	"context"
+	"github.com/ory/kratos/internal"
+	"github.com/ory/kratos/selfservice/flow/login"
+	"github.com/ory/kratos/selfservice/strategy/oidc"
+	"github.com/ory/kratos/x"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/oauth2"
+	"testing"
+)
+
+func TestProviderGoogle_Scope(t *testing.T) {
+	_, reg := internal.NewFastRegistryWithMocks(t)
+
+	p := oidc.NewProviderGoogle(&oidc.Configuration{
+		Provider:        "google",
+		ID:              "valid",
+		ClientID:        "client",
+		ClientSecret:    "secret",
+		Mapper:          "file://./stub/hydra.schema.json",
+		RequestedClaims: nil,
+		Scope:           []string{"email", "profile", "offline_access"},
+	}, reg)
+
+	c, _ := p.OAuth2(context.Background())
+	assert.NotContains(t, c.Scopes, "offline_access")
+}
+
+func TestProviderGoogle_AccessType(t *testing.T) {
+	_, reg := internal.NewFastRegistryWithMocks(t)
+
+	p := oidc.NewProviderGoogle(&oidc.Configuration{
+		Provider:        "google",
+		ID:              "valid",
+		ClientID:        "client",
+		ClientSecret:    "secret",
+		Mapper:          "file://./stub/hydra.schema.json",
+		RequestedClaims: nil,
+		Scope:           []string{"email", "profile", "offline_access"},
+	}, reg)
+
+	r := &login.Flow{
+		ID: x.NewUUID(),
+	}
+
+	options := p.AuthCodeURLOptions(r)
+	assert.Contains(t, options, oauth2.AccessTypeOffline)
+}


### PR DESCRIPTION
google doesn't implements offline access as a scope but instead as a special uri parameter

this PR adapts the code such that if the offline_access scope is requested, it gets transformed into the parameter
access_type=offline