### PR TITLE
feat: let the database generate session device IDs

### DIFF
--- a/identity/handler.go
+++ b/identity/handler.go
@@ -737,7 +737,9 @@ func deletCredentialWebAuthFromIdentity(identity *Identity) (*Identity, error) {
 // Delete Credential Parameters
 //
 // swagger:parameters deleteIdentityCredentials
-// nolint:deadcode,unused
+//
+//nolint:deadcode,unused
+//lint:ignore U1000 Used to generate Swagger and OpenAPI definitions
 type deleteIdentityCredentials struct {
 	// ID is the identity's ID.
 	//

--- a/selfservice/hook/session_destroyer.go
+++ b/selfservice/hook/session_destroyer.go
@@ -7,9 +7,6 @@ import (
 	"context"
 	"net/http"
 
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
-
 	"github.com/ory/kratos/selfservice/flow/login"
 	"github.com/ory/kratos/selfservice/flow/recovery"
 	"github.com/ory/kratos/session"
@@ -35,19 +32,19 @@ func NewSessionDestroyer(r sessionDestroyerDependencies) *SessionDestroyer {
 }
 
 func (e *SessionDestroyer) ExecuteLoginPostHook(_ http.ResponseWriter, r *http.Request, _ node.UiNodeGroup, _ *login.Flow, s *session.Session) error {
-	return otelx.WithSpan(r.Context(), "selfservice.hook.ExecuteLoginPostHook", func(ctx context.Context) error {
+	return otelx.WithSpan(r.Context(), "selfservice.hook.SessionDestroyer.ExecuteLoginPostHook", func(ctx context.Context) error {
 		if _, err := e.r.SessionPersister().RevokeSessionsIdentityExcept(ctx, s.Identity.ID, s.ID); err != nil {
 			return err
 		}
 		return nil
-	}, trace.WithAttributes(attribute.String("hook", KeySessionDestroyer)))
+	})
 }
 
 func (e *SessionDestroyer) ExecutePostRecoveryHook(_ http.ResponseWriter, r *http.Request, _ *recovery.Flow, s *session.Session) error {
-	return otelx.WithSpan(r.Context(), "selfservice.hook.ExecutePostRecoveryHook", func(ctx context.Context) error {
+	return otelx.WithSpan(r.Context(), "selfservice.hook.SessionDestroyer.ExecutePostRecoveryHook", func(ctx context.Context) error {
 		if _, err := e.r.SessionPersister().RevokeSessionsIdentityExcept(ctx, s.Identity.ID, s.ID); err != nil {
 			return err
 		}
 		return nil
-	}, trace.WithAttributes(attribute.String("hook", KeySessionDestroyer)))
+	})
 }

--- a/selfservice/hook/session_issuer.go
+++ b/selfservice/hook/session_issuer.go
@@ -9,8 +9,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ory/kratos/selfservice/flow"
 	"github.com/ory/kratos/selfservice/flow/registration"
@@ -42,9 +40,9 @@ func NewSessionIssuer(r sessionIssuerDependencies) *SessionIssuer {
 }
 
 func (e *SessionIssuer) ExecutePostRegistrationPostPersistHook(w http.ResponseWriter, r *http.Request, a *registration.Flow, s *session.Session) error {
-	return otelx.WithSpan(r.Context(), "selfservice.hook.ExecutePostRegistrationPostPersistHook", func(ctx context.Context) error {
+	return otelx.WithSpan(r.Context(), "selfservice.hook.SessionIssuer.ExecutePostRegistrationPostPersistHook", func(ctx context.Context) error {
 		return e.executePostRegistrationPostPersistHook(w, r.WithContext(ctx), a, s)
-	}, trace.WithAttributes(attribute.String("hook", KeySessionIssuer)))
+	})
 }
 
 func (e *SessionIssuer) executePostRegistrationPostPersistHook(w http.ResponseWriter, r *http.Request, a *registration.Flow, s *session.Session) error {

--- a/selfservice/hook/verification.go
+++ b/selfservice/hook/verification.go
@@ -7,9 +7,6 @@ import (
 	"context"
 	"net/http"
 
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
-
 	"github.com/ory/kratos/driver/config"
 	"github.com/ory/kratos/identity"
 	"github.com/ory/kratos/selfservice/flow"
@@ -41,15 +38,15 @@ func NewVerifier(r verifierDependencies) *Verifier {
 }
 
 func (e *Verifier) ExecutePostRegistrationPostPersistHook(_ http.ResponseWriter, r *http.Request, f *registration.Flow, s *session.Session) error {
-	return otelx.WithSpan(r.Context(), "selfservice.hook.ExecutePostRegistrationPostPersistHook", func(ctx context.Context) error {
+	return otelx.WithSpan(r.Context(), "selfservice.hook.Verifier.ExecutePostRegistrationPostPersistHook", func(ctx context.Context) error {
 		return e.do(r.WithContext(ctx), s.Identity, f)
-	}, trace.WithAttributes(attribute.String("hook", "verifier")))
+	})
 }
 
 func (e *Verifier) ExecuteSettingsPostPersistHook(w http.ResponseWriter, r *http.Request, a *settings.Flow, i *identity.Identity) error {
-	return otelx.WithSpan(r.Context(), "selfservice.hook.ExecuteSettingsPostPersistHook", func(ctx context.Context) error {
+	return otelx.WithSpan(r.Context(), "selfservice.hook.Verifier.ExecuteSettingsPostPersistHook", func(ctx context.Context) error {
 		return e.do(r.WithContext(ctx), i, a)
-	}, trace.WithAttributes(attribute.String("hook", "verifier")))
+	})
 }
 
 func (e *Verifier) do(r *http.Request, i *identity.Identity, f flow.Flow) error {

--- a/selfservice/hook/web_hook.go
+++ b/selfservice/hook/web_hook.go
@@ -103,7 +103,7 @@ func NewWebHook(r webHookDependencies, c json.RawMessage) *WebHook {
 }
 
 func (e *WebHook) ExecuteLoginPreHook(_ http.ResponseWriter, req *http.Request, flow *login.Flow) error {
-	return otelx.WithSpan(req.Context(), "selfservice.hook.ExecuteLoginPreHook", func(ctx context.Context) error {
+	return otelx.WithSpan(req.Context(), "selfservice.hook.WebHook.ExecuteLoginPreHook", func(ctx context.Context) error {
 		return e.execute(ctx, &templateContext{
 			Flow:           flow,
 			RequestHeaders: req.Header,
@@ -111,11 +111,11 @@ func (e *WebHook) ExecuteLoginPreHook(_ http.ResponseWriter, req *http.Request, 
 			RequestURL:     x.RequestURL(req).String(),
 			RequestCookies: cookies(req),
 		})
-	}, trace.WithAttributes(attribute.String("hook", KeyWebHook)))
+	})
 }
 
 func (e *WebHook) ExecuteLoginPostHook(_ http.ResponseWriter, req *http.Request, _ node.UiNodeGroup, flow *login.Flow, session *session.Session) error {
-	return otelx.WithSpan(req.Context(), "selfservice.hook.ExecuteLoginPostHook", func(ctx context.Context) error {
+	return otelx.WithSpan(req.Context(), "selfservice.hook.WebHook.ExecuteLoginPostHook", func(ctx context.Context) error {
 		return e.execute(ctx, &templateContext{
 			Flow:           flow,
 			RequestHeaders: req.Header,
@@ -124,11 +124,11 @@ func (e *WebHook) ExecuteLoginPostHook(_ http.ResponseWriter, req *http.Request,
 			RequestCookies: cookies(req),
 			Identity:       session.Identity,
 		})
-	}, trace.WithAttributes(attribute.String("hook", KeyWebHook)))
+	})
 }
 
 func (e *WebHook) ExecuteVerificationPreHook(_ http.ResponseWriter, req *http.Request, flow *verification.Flow) error {
-	return otelx.WithSpan(req.Context(), "selfservice.hook.ExecuteVerificationPreHook", func(ctx context.Context) error {
+	return otelx.WithSpan(req.Context(), "selfservice.hook.WebHook.ExecuteVerificationPreHook", func(ctx context.Context) error {
 		return e.execute(ctx, &templateContext{
 			Flow:           flow,
 			RequestHeaders: req.Header,
@@ -136,11 +136,11 @@ func (e *WebHook) ExecuteVerificationPreHook(_ http.ResponseWriter, req *http.Re
 			RequestURL:     x.RequestURL(req).String(),
 			RequestCookies: cookies(req),
 		})
-	}, trace.WithAttributes(attribute.String("hook", KeyWebHook)))
+	})
 }
 
 func (e *WebHook) ExecutePostVerificationHook(_ http.ResponseWriter, req *http.Request, flow *verification.Flow, id *identity.Identity) error {
-	return otelx.WithSpan(req.Context(), "selfservice.hook.ExecutePostVerificationHook", func(ctx context.Context) error {
+	return otelx.WithSpan(req.Context(), "selfservice.hook.WebHook.ExecutePostVerificationHook", func(ctx context.Context) error {
 		return e.execute(ctx, &templateContext{
 			Flow:           flow,
 			RequestHeaders: req.Header,
@@ -149,11 +149,11 @@ func (e *WebHook) ExecutePostVerificationHook(_ http.ResponseWriter, req *http.R
 			RequestCookies: cookies(req),
 			Identity:       id,
 		})
-	}, trace.WithAttributes(attribute.String("hook", KeyWebHook)))
+	})
 }
 
 func (e *WebHook) ExecuteRecoveryPreHook(_ http.ResponseWriter, req *http.Request, flow *recovery.Flow) error {
-	return otelx.WithSpan(req.Context(), "selfservice.hook.ExecuteRecoveryPreHook", func(ctx context.Context) error {
+	return otelx.WithSpan(req.Context(), "selfservice.hook.WebHook.ExecuteRecoveryPreHook", func(ctx context.Context) error {
 		return e.execute(ctx, &templateContext{
 			Flow:           flow,
 			RequestHeaders: req.Header,
@@ -161,11 +161,11 @@ func (e *WebHook) ExecuteRecoveryPreHook(_ http.ResponseWriter, req *http.Reques
 			RequestCookies: cookies(req),
 			RequestURL:     x.RequestURL(req).String(),
 		})
-	}, trace.WithAttributes(attribute.String("hook", KeyWebHook)))
+	})
 }
 
 func (e *WebHook) ExecutePostRecoveryHook(_ http.ResponseWriter, req *http.Request, flow *recovery.Flow, session *session.Session) error {
-	return otelx.WithSpan(req.Context(), "selfservice.hook.ExecutePostRecoveryHook", func(ctx context.Context) error {
+	return otelx.WithSpan(req.Context(), "selfservice.hook.WebHook.ExecutePostRecoveryHook", func(ctx context.Context) error {
 		return e.execute(ctx, &templateContext{
 			Flow:           flow,
 			RequestHeaders: req.Header,
@@ -174,11 +174,11 @@ func (e *WebHook) ExecutePostRecoveryHook(_ http.ResponseWriter, req *http.Reque
 			RequestCookies: cookies(req),
 			Identity:       session.Identity,
 		})
-	}, trace.WithAttributes(attribute.String("hook", KeyWebHook)))
+	})
 }
 
 func (e *WebHook) ExecuteRegistrationPreHook(_ http.ResponseWriter, req *http.Request, flow *registration.Flow) error {
-	return otelx.WithSpan(req.Context(), "selfservice.hook.ExecuteRegistrationPreHook", func(ctx context.Context) error {
+	return otelx.WithSpan(req.Context(), "selfservice.hook.WebHook.ExecuteRegistrationPreHook", func(ctx context.Context) error {
 		return e.execute(ctx, &templateContext{
 			Flow:           flow,
 			RequestHeaders: req.Header,
@@ -186,14 +186,14 @@ func (e *WebHook) ExecuteRegistrationPreHook(_ http.ResponseWriter, req *http.Re
 			RequestURL:     x.RequestURL(req).String(),
 			RequestCookies: cookies(req),
 		})
-	}, trace.WithAttributes(attribute.String("hook", KeyWebHook)))
+	})
 }
 
 func (e *WebHook) ExecutePostRegistrationPrePersistHook(_ http.ResponseWriter, req *http.Request, flow *registration.Flow, id *identity.Identity) error {
 	if !(gjson.GetBytes(e.conf, "can_interrupt").Bool() || gjson.GetBytes(e.conf, "response.parse").Bool()) {
 		return nil
 	}
-	return otelx.WithSpan(req.Context(), "selfservice.hook.ExecutePostRegistrationPrePersistHook", func(ctx context.Context) error {
+	return otelx.WithSpan(req.Context(), "selfservice.hook.WebHook.ExecutePostRegistrationPrePersistHook", func(ctx context.Context) error {
 		return e.execute(ctx, &templateContext{
 			Flow:           flow,
 			RequestHeaders: req.Header,
@@ -202,14 +202,14 @@ func (e *WebHook) ExecutePostRegistrationPrePersistHook(_ http.ResponseWriter, r
 			RequestCookies: cookies(req),
 			Identity:       id,
 		})
-	}, trace.WithAttributes(attribute.String("hook", KeyWebHook)))
+	})
 }
 
 func (e *WebHook) ExecutePostRegistrationPostPersistHook(_ http.ResponseWriter, req *http.Request, flow *registration.Flow, session *session.Session) error {
 	if gjson.GetBytes(e.conf, "can_interrupt").Bool() || gjson.GetBytes(e.conf, "response.parse").Bool() {
 		return nil
 	}
-	return otelx.WithSpan(req.Context(), "selfservice.hook.ExecutePostRegistrationPostPersistHook", func(ctx context.Context) error {
+	return otelx.WithSpan(req.Context(), "selfservice.hook.WebHook.ExecutePostRegistrationPostPersistHook", func(ctx context.Context) error {
 		return e.execute(ctx, &templateContext{
 			Flow:           flow,
 			RequestHeaders: req.Header,
@@ -218,11 +218,11 @@ func (e *WebHook) ExecutePostRegistrationPostPersistHook(_ http.ResponseWriter, 
 			RequestCookies: cookies(req),
 			Identity:       session.Identity,
 		})
-	}, trace.WithAttributes(attribute.String("hook", KeyWebHook)))
+	})
 }
 
 func (e *WebHook) ExecuteSettingsPreHook(_ http.ResponseWriter, req *http.Request, flow *settings.Flow) error {
-	return otelx.WithSpan(req.Context(), "selfservice.hook.ExecuteSettingsPreHook", func(ctx context.Context) error {
+	return otelx.WithSpan(req.Context(), "selfservice.hook.WebHook.ExecuteSettingsPreHook", func(ctx context.Context) error {
 		return e.execute(ctx, &templateContext{
 			Flow:           flow,
 			RequestHeaders: req.Header,
@@ -230,14 +230,14 @@ func (e *WebHook) ExecuteSettingsPreHook(_ http.ResponseWriter, req *http.Reques
 			RequestURL:     x.RequestURL(req).String(),
 			RequestCookies: cookies(req),
 		})
-	}, trace.WithAttributes(attribute.String("hook", KeyWebHook)))
+	})
 }
 
 func (e *WebHook) ExecuteSettingsPostPersistHook(_ http.ResponseWriter, req *http.Request, flow *settings.Flow, id *identity.Identity) error {
 	if gjson.GetBytes(e.conf, "can_interrupt").Bool() {
 		return nil
 	}
-	return otelx.WithSpan(req.Context(), "selfservice.hook.ExecuteSettingsPostPersistHook", func(ctx context.Context) error {
+	return otelx.WithSpan(req.Context(), "selfservice.hook.WebHook.ExecuteSettingsPostPersistHook", func(ctx context.Context) error {
 		return e.execute(ctx, &templateContext{
 			Flow:           flow,
 			RequestHeaders: req.Header,
@@ -246,14 +246,14 @@ func (e *WebHook) ExecuteSettingsPostPersistHook(_ http.ResponseWriter, req *htt
 			RequestCookies: cookies(req),
 			Identity:       id,
 		})
-	}, trace.WithAttributes(attribute.String("hook", KeyWebHook)))
+	})
 }
 
 func (e *WebHook) ExecuteSettingsPrePersistHook(_ http.ResponseWriter, req *http.Request, flow *settings.Flow, id *identity.Identity) error {
 	if !gjson.GetBytes(e.conf, "can_interrupt").Bool() {
 		return nil
 	}
-	return otelx.WithSpan(req.Context(), "selfservice.hook.ExecuteSettingsPrePersistHook", func(ctx context.Context) error {
+	return otelx.WithSpan(req.Context(), "selfservice.hook.WebHook.ExecuteSettingsPrePersistHook", func(ctx context.Context) error {
 		return e.execute(ctx, &templateContext{
 			Flow:           flow,
 			RequestHeaders: req.Header,
@@ -262,7 +262,7 @@ func (e *WebHook) ExecuteSettingsPrePersistHook(_ http.ResponseWriter, req *http
 			RequestCookies: cookies(req),
 			Identity:       id,
 		})
-	}, trace.WithAttributes(attribute.String("hook", KeyWebHook)))
+	})
 }
 
 func (e *WebHook) execute(ctx context.Context, data *templateContext) error {

--- a/session/session.go
+++ b/session/session.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/ory/herodot"
 	"github.com/ory/kratos/identity"
-	"github.com/ory/kratos/x"
 	"github.com/ory/x/randx"
 )
 
@@ -234,23 +233,21 @@ func (s *Session) Activate(r *http.Request, i *identity.Identity, c lifespanProv
 	s.Identity = i
 	s.IdentityID = i.ID
 
-	s.SaveSessionDeviceInformation(r)
+	s.SetSessionDeviceInformation(r)
 	s.SetAuthenticatorAssuranceLevel()
 	return nil
 }
 
-func (s *Session) SaveSessionDeviceInformation(r *http.Request) {
-	var device Device
-
-	device.ID = x.NewUUID()
-	device.SessionID = s.ID
+func (s *Session) SetSessionDeviceInformation(r *http.Request) {
+	device := Device{
+		SessionID: s.ID,
+		IPAddress: stringsx.GetPointer(httpx.ClientIP(r)),
+	}
 
 	agent := r.Header["User-Agent"]
 	if len(agent) > 0 {
 		device.UserAgent = stringsx.GetPointer(strings.Join(agent, " "))
 	}
-
-	device.IPAddress = stringsx.GetPointer(httpx.ClientIP(r))
 
 	var clientGeoLocation []string
 	if r.Header.Get("Cf-Ipcity") != "" {


### PR DESCRIPTION
This is the same as #3042 but for session devices.

Also renamed some tracing span names in hooks.