### PR TITLE
fix: return_to used if specified

### DIFF
--- a/selfservice/flow/error_test.go
+++ b/selfservice/flow/error_test.go
@@ -66,8 +66,12 @@ func (t *testFlow) GetRequestURL() string {
 	return t.RequestURL
 }
 
+func (t *testFlow) GetReturnTo() *url.URL {
+	return nil
+}
+
 func (t *testFlow) AppendTo(url *url.URL) *url.URL {
-	return AppendFlowTo(url, t.ID)
+	return AppendFlowTo(url, t.ID, TypeLogin)
 }
 
 func (t *testFlow) GetUI() *container.Container {

--- a/selfservice/flow/flow.go
+++ b/selfservice/flow/flow.go
@@ -19,8 +19,8 @@ import (
 	"github.com/ory/x/urlx"
 )
 
-func AppendFlowTo(src *url.URL, id uuid.UUID) *url.URL {
-	return urlx.CopyWithQuery(src, url.Values{"flow": {id.String()}})
+func AppendFlowTo(src *url.URL, id uuid.UUID, flowType FlowType) *url.URL {
+	return urlx.CopyWithQuery(src, url.Values{"flow": {id.String()}, "type": {string(flowType)}})
 }
 
 func GetFlowID(r *http.Request) (uuid.UUID, error) {
@@ -35,6 +35,7 @@ type Flow interface {
 	GetID() uuid.UUID
 	GetType() Type
 	GetRequestURL() string
+	GetReturnTo() *url.URL
 	AppendTo(*url.URL) *url.URL
 	GetUI() *container.Container
 }

--- a/selfservice/flow/login/error.go
+++ b/selfservice/flow/login/error.go
@@ -92,6 +92,10 @@ func (s *ErrorHandler) WriteFlowError(w http.ResponseWriter, r *http.Request, f 
 		if f.Type == flow.TypeAPI || x.IsJSONRequest(r) {
 			s.d.Writer().WriteError(w, r, expired)
 		} else {
+			if expired.GetFlow().GetReturnTo() != nil {
+				http.Redirect(w, r, expired.GetFlow().AppendTo(f.GetReturnTo()).String(), http.StatusSeeOther)
+				return
+			}
 			http.Redirect(w, r, expired.GetFlow().AppendTo(s.d.Config().SelfServiceFlowLoginUI(r.Context())).String(), http.StatusSeeOther)
 		}
 		return
@@ -114,6 +118,10 @@ func (s *ErrorHandler) WriteFlowError(w http.ResponseWriter, r *http.Request, f 
 	}
 
 	if f.Type == flow.TypeBrowser && !x.IsJSONRequest(r) {
+		if f.GetReturnTo() != nil {
+			http.Redirect(w, r, f.AppendTo(f.GetReturnTo()).String(), http.StatusSeeOther)
+			return
+		}
 		http.Redirect(w, r, f.AppendTo(s.d.Config().SelfServiceFlowLoginUI(r.Context())).String(), http.StatusSeeOther)
 		return
 	}

--- a/selfservice/flow/recovery/error.go
+++ b/selfservice/flow/recovery/error.go
@@ -102,6 +102,10 @@ func (s *ErrorHandler) WriteFlowError(
 			http.Redirect(w, r, urlx.CopyWithQuery(urlx.AppendPaths(s.d.Config().SelfPublicURL(r.Context()),
 				RouteGetFlow), url.Values{"id": {a.ID.String()}}).String(), http.StatusSeeOther)
 		} else {
+			if a.GetReturnTo() != nil {
+				http.Redirect(w, r, a.AppendTo(f.GetReturnTo()).String(), http.StatusSeeOther)
+				return
+			}
 			http.Redirect(w, r, a.AppendTo(s.d.Config().SelfServiceFlowRecoveryUI(r.Context())).String(), http.StatusSeeOther)
 		}
 		return
@@ -120,6 +124,10 @@ func (s *ErrorHandler) WriteFlowError(
 	}
 
 	if f.Type == flow.TypeBrowser && !x.IsJSONRequest(r) {
+		if f.GetReturnTo() != nil {
+			http.Redirect(w, r, f.AppendTo(f.GetReturnTo()).String(), http.StatusSeeOther)
+			return
+		}
 		http.Redirect(w, r, f.AppendTo(s.d.Config().SelfServiceFlowRecoveryUI(r.Context())).String(), http.StatusSeeOther)
 		return
 	}

--- a/selfservice/flow/registration/error.go
+++ b/selfservice/flow/registration/error.go
@@ -90,6 +90,10 @@ func (s *ErrorHandler) WriteFlowError(
 		if f.Type == flow.TypeAPI || x.IsJSONRequest(r) {
 			s.d.Writer().WriteError(w, r, expired)
 		} else {
+			if expired.GetFlow().GetReturnTo() != nil {
+				http.Redirect(w, r, expired.GetFlow().AppendTo(f.GetReturnTo()).String(), http.StatusSeeOther)
+				return
+			}
 			http.Redirect(w, r, expired.GetFlow().AppendTo(s.d.Config().SelfServiceFlowRegistrationUI(r.Context())).String(), http.StatusSeeOther)
 		}
 		return
@@ -118,6 +122,10 @@ func (s *ErrorHandler) WriteFlowError(
 	}
 
 	if f.Type == flow.TypeBrowser && !x.IsJSONRequest(r) {
+		if f.GetReturnTo() != nil {
+			http.Redirect(w, r, f.AppendTo(f.GetReturnTo()).String(), http.StatusSeeOther)
+			return
+		}
 		http.Redirect(w, r, f.AppendTo(s.d.Config().SelfServiceFlowRegistrationUI(r.Context())).String(), http.StatusFound)
 		return
 	}

--- a/selfservice/flow/settings/error.go
+++ b/selfservice/flow/settings/error.go
@@ -171,6 +171,10 @@ func (s *ErrorHandler) WriteFlowError(
 		if f.Type == flow.TypeAPI || x.IsJSONRequest(r) {
 			s.d.Writer().WriteError(w, r, expired)
 		} else {
+			if expired.GetFlow().GetReturnTo() != nil {
+				http.Redirect(w, r, expired.GetFlow().AppendTo(f.GetReturnTo()).String(), http.StatusSeeOther)
+				return
+			}
 			http.Redirect(w, r, expired.GetFlow().AppendTo(s.d.Config().SelfServiceFlowSettingsUI(r.Context())).String(), http.StatusSeeOther)
 		}
 		return
@@ -180,6 +184,10 @@ func (s *ErrorHandler) WriteFlowError(
 		if shouldRespondWithJSON {
 			s.d.Writer().Write(w, r, f)
 		} else {
+			if f.GetReturnTo() != nil {
+				http.Redirect(w, r, f.AppendTo(f.GetReturnTo()).String(), http.StatusSeeOther)
+				return
+			}
 			http.Redirect(w, r, f.AppendTo(s.d.Config().SelfServiceFlowSettingsUI(r.Context())).String(), http.StatusSeeOther)
 		}
 		return
@@ -220,6 +228,10 @@ func (s *ErrorHandler) WriteFlowError(
 	}
 
 	if f.Type == flow.TypeBrowser && !x.IsJSONRequest(r) {
+		if f.GetReturnTo() != nil {
+			http.Redirect(w, r, f.AppendTo(f.GetReturnTo()).String(), http.StatusSeeOther)
+			return
+		}
 		http.Redirect(w, r, f.AppendTo(s.d.Config().SelfServiceFlowSettingsUI(r.Context())).String(), http.StatusSeeOther)
 		return
 	}

--- a/selfservice/flow/type.go
+++ b/selfservice/flow/type.go
@@ -3,11 +3,11 @@
 
 package flow
 
-// Type is the flow type.
+// Type is the flow client type.
 //
-// The flow type can either be `api` or `browser`.
+// The flow client type can either be `api` or `browser`.
 //
-// swagger:model selfServiceFlowType
+// swagger:model selfServiceFlowClientType
 type Type string
 
 const (
@@ -22,3 +22,18 @@ func (t Type) IsBrowser() bool {
 func (t Type) IsAPI() bool {
 	return t == TypeAPI
 }
+
+// Type is the flow type.
+//
+// The flow type can be `login`, `recovery`, `registration`, `settings`, `verification`.
+//
+// swagger:model selfServiceFlowType
+type FlowType string
+
+const (
+	TypeLogin        FlowType = "login"
+	TypeRecovery     FlowType = "recovery"
+	TypeRegistration FlowType = "registration"
+	TypeSettings     FlowType = "settings"
+	TypeVerification FlowType = "verification"
+)

--- a/selfservice/flow/verification/error.go
+++ b/selfservice/flow/verification/error.go
@@ -101,6 +101,10 @@ func (s *ErrorHandler) WriteFlowError(
 			http.Redirect(w, r, urlx.CopyWithQuery(urlx.AppendPaths(s.d.Config().SelfPublicURL(r.Context()),
 				RouteGetFlow), url.Values{"id": {a.ID.String()}}).String(), http.StatusSeeOther)
 		} else {
+			if a.GetReturnTo() != nil {
+				http.Redirect(w, r, a.AppendTo(f.GetReturnTo()).String(), http.StatusSeeOther)
+				return
+			}
 			http.Redirect(w, r, a.AppendTo(s.d.Config().SelfServiceFlowVerificationUI(r.Context())).String(), http.StatusSeeOther)
 		}
 		return
@@ -118,6 +122,10 @@ func (s *ErrorHandler) WriteFlowError(
 	}
 
 	if f.Type == flow.TypeBrowser && !x.IsJSONRequest(r) {
+		if f.GetReturnTo() != nil {
+			http.Redirect(w, r, f.AppendTo(f.GetReturnTo()).String(), http.StatusSeeOther)
+			return
+		}
 		http.Redirect(w, r, f.AppendTo(s.d.Config().SelfServiceFlowVerificationUI(r.Context())).String(), http.StatusSeeOther)
 		return
 	}

--- a/selfservice/strategy/code/strategy_recovery.go
+++ b/selfservice/strategy/code/strategy_recovery.go
@@ -537,7 +537,7 @@ func (s *Strategy) recoveryHandleFormSubmission(w http.ResponseWriter, r *http.R
 	// re-initialize the UI with a "clean" new state
 	f.UI = &container.Container{
 		Method: "POST",
-		Action: flow.AppendFlowTo(urlx.AppendPaths(s.deps.Config().SelfPublicURL(r.Context()), recovery.RouteSubmitFlow), f.ID).String(),
+		Action: flow.AppendFlowTo(urlx.AppendPaths(s.deps.Config().SelfPublicURL(r.Context()), recovery.RouteSubmitFlow), f.ID, flow.TypeRecovery).String(),
 	}
 
 	f.UI.SetCSRF(s.deps.GenerateCSRFToken(r))

--- a/selfservice/strategy/code/strategy_verification.go
+++ b/selfservice/strategy/code/strategy_verification.go
@@ -177,7 +177,7 @@ func (s *Strategy) createVerificationCodeForm(action string, code *string, email
 }
 
 func (s *Strategy) handleLinkClick(w http.ResponseWriter, r *http.Request, f *verification.Flow, code string) error {
-	f.UI = s.createVerificationCodeForm(flow.AppendFlowTo(urlx.AppendPaths(s.deps.Config().SelfPublicURL(r.Context()), verification.RouteSubmitFlow), f.ID).String(), &code, nil)
+	f.UI = s.createVerificationCodeForm(flow.AppendFlowTo(urlx.AppendPaths(s.deps.Config().SelfPublicURL(r.Context()), verification.RouteSubmitFlow), f.ID, flow.TypeVerification).String(), &code, nil)
 
 	// In the verification flow, we can't enforce CSRF if the flow is opened from an email, so we initialize the CSRF
 	// token here, so all subsequent interactions are protected
@@ -228,7 +228,7 @@ func (s *Strategy) verificationHandleFormSubmission(w http.ResponseWriter, r *ht
 
 	f.State = verification.StateEmailSent
 
-	f.UI = s.createVerificationCodeForm(flow.AppendFlowTo(urlx.AppendPaths(s.deps.Config().SelfPublicURL(r.Context()), verification.RouteSubmitFlow), f.ID).String(), nil, &body.Email)
+	f.UI = s.createVerificationCodeForm(flow.AppendFlowTo(urlx.AppendPaths(s.deps.Config().SelfPublicURL(r.Context()), verification.RouteSubmitFlow), f.ID, flow.TypeVerification).String(), nil, &body.Email)
 	f.UI.Messages.Set(text.NewVerificationEmailWithCodeSent())
 	f.UI.SetCSRF(s.deps.GenerateCSRFToken(r))
 


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->
The goal of this pull request is to make minimal changes that allow Kratos to support multiple browser applications on separate domains to handle their own login/logout/etc UI. This is done by using the return_to URL if specified to redirect the user and returning an additional flow type (login/registration/...) during error condition in order for the application to inform the user of the error situation. 

This means that there can be two browser applications on separate subdomains, app1.example.com and app2.example.com (white listed in the Kratos allowed_return_urls config). Each application would add its URL with the return_to parameter during flow creation to inform Kratos of which application initiated the flow. After the execution of the flow Kratos will redirect the user to the application that initiated the flow if the ReturnTo property was specified otherwise use the default urls from the Kratos configuration.

If a flow execution ends with an error the user will be redirected back to the application with both the flow id and flow type, allowing the application to query Kratos for the error message to inform the user. 

By returning the flow type Kratos no longer forces the application to have separate routes for each flow.


## Related issue(s)

Based on the discussion from [Issue: 3106](https://github.com/ory/kratos/issues/3106)
<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
