### PR TITLE
fix: ui node input attributes key added

### DIFF
--- a/selfservice/strategy/code/strategy_recovery.go
+++ b/selfservice/strategy/code/strategy_recovery.go
@@ -545,7 +545,12 @@ func (s *Strategy) recoveryHandleFormSubmission(w http.ResponseWriter, r *http.R
 	f.Active = sqlxx.NullString(s.RecoveryNodeGroup())
 	f.State = recovery.StateEmailSent
 	f.UI.Messages.Set(text.NewRecoveryEmailWithCodeSent())
-	f.UI.Nodes.Append(node.NewInputField("code", nil, node.CodeGroup, node.InputAttributeTypeText, node.WithRequiredInputAttribute).
+	f.UI.Nodes.Append(node.NewInputField("code", nil, node.CodeGroup, node.InputAttributeTypeText, node.WithInputAttributes(func(a *node.InputAttributes) {
+		a.Required = true
+		// Unique key for React to make sure input field is refreshed
+		a.Key = "recoveryKey"
+		a.Pattern = "[0-9]+"
+	})).
 		WithMetaLabel(text.NewInfoNodeLabelVerifyOTP()),
 	)
 	f.UI.Nodes.Append(node.NewInputField("method", s.RecoveryNodeGroup(), node.CodeGroup, node.InputAttributeTypeHidden))

--- a/selfservice/strategy/code/strategy_recovery.go
+++ b/selfservice/strategy/code/strategy_recovery.go
@@ -547,8 +547,6 @@ func (s *Strategy) recoveryHandleFormSubmission(w http.ResponseWriter, r *http.R
 	f.UI.Messages.Set(text.NewRecoveryEmailWithCodeSent())
 	f.UI.Nodes.Append(node.NewInputField("code", nil, node.CodeGroup, node.InputAttributeTypeText, node.WithInputAttributes(func(a *node.InputAttributes) {
 		a.Required = true
-		// Unique key for React to make sure input field is refreshed
-		a.Key = "recoveryKey"
 		a.Pattern = "[0-9]+"
 	})).
 		WithMetaLabel(text.NewInfoNodeLabelVerifyOTP()),

--- a/ui/node/attributes.go
+++ b/ui/node/attributes.go
@@ -98,6 +98,9 @@ type InputAttributes struct {
 	//
 	// required: true
 	NodeType string `json:"node_type"`
+
+	// React key property to make input field unique to prevent element sharing when that can cause problems
+	Key string `json:"key,omitempty"`
 }
 
 // ImageAttributes represents the attributes of an image node.

--- a/ui/node/attributes.go
+++ b/ui/node/attributes.go
@@ -98,9 +98,6 @@ type InputAttributes struct {
 	//
 	// required: true
 	NodeType string `json:"node_type"`
-
-	// React key property to make input field unique to prevent element sharing when that can cause problems
-	Key string `json:"key,omitempty"`
 }
 
 // ImageAttributes represents the attributes of an image node.


### PR DESCRIPTION
`Pattern` for UI to show error when code field has other characters than numeric.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)
[Elements issue 78](https://github.com/ory/elements/issues/78)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
