### PR TITLE
fix: code strategy only set one submit field on verification

### DIFF
--- a/selfservice/strategy/code/.snapshots/TestVerification-description=should_set_all_the_correct_verification_payloads_after_submission.json
+++ b/selfservice/strategy/code/.snapshots/TestVerification-description=should_set_all_the_correct_verification_payloads_after_submission.json
@@ -35,25 +35,6 @@
     "type": "input",
     "group": "code",
     "attributes": {
-      "name": "method",
-      "type": "submit",
-      "value": "code",
-      "disabled": false,
-      "node_type": "input"
-    },
-    "messages": [],
-    "meta": {
-      "label": {
-        "id": 1070005,
-        "text": "Submit",
-        "type": "info"
-      }
-    }
-  },
-  {
-    "type": "input",
-    "group": "code",
-    "attributes": {
       "name": "email",
       "type": "submit",
       "value": "test@ory.sh",

--- a/selfservice/strategy/code/strategy_verification.go
+++ b/selfservice/strategy/code/strategy_verification.go
@@ -157,19 +157,19 @@ func (s *Strategy) createVerificationCodeForm(action string, code *string, email
 			NewInputField("code", code, node.CodeGroup, node.InputAttributeTypeText, node.WithRequiredInputAttribute).
 			WithMetaLabel(text.NewInfoNodeLabelVerifyOTP()),
 	)
-	c.Nodes.Append(
-		node.NewInputField("method", s.VerificationNodeGroup(), node.CodeGroup, node.InputAttributeTypeHidden),
-	)
-
-	c.Nodes.Append(
-		node.NewInputField("method", s.VerificationStrategyID(), node.CodeGroup, node.InputAttributeTypeSubmit).
-			WithMetaLabel(text.NewInfoNodeLabelSubmit()),
-	)
 
 	if email != nil {
 		c.Nodes.Append(
+			node.NewInputField("method", s.VerificationStrategyID(), node.CodeGroup, node.InputAttributeTypeHidden),
+		)
+		c.Nodes.Append(
 			node.NewInputField("email", email, node.CodeGroup, node.InputAttributeTypeSubmit).
 				WithMetaLabel(text.NewInfoNodeResendOTP()),
+		)
+	} else {
+		c.Nodes.Append(
+			node.NewInputField("method", s.VerificationStrategyID(), node.CodeGroup, node.InputAttributeTypeSubmit).
+				WithMetaLabel(text.NewInfoNodeLabelSubmit()),
 		)
 	}
 

--- a/selfservice/strategy/code/strategy_verification_test.go
+++ b/selfservice/strategy/code/strategy_verification_test.go
@@ -108,7 +108,7 @@ func TestVerification(t *testing.T) {
 		body := expectSuccess(t, nil, false, false, func(v url.Values) {
 			v.Set("email", "test@ory.sh")
 		})
-		testhelpers.SnapshotTExcept(t, json.RawMessage(gjson.Get(body, "ui.nodes").String()), []string{"4.attributes.value"})
+		testhelpers.SnapshotTExcept(t, json.RawMessage(gjson.Get(body, "ui.nodes").String()), []string{"3.attributes.value"})
 	})
 
 	t.Run("description=should set all the correct verification payloads", func(t *testing.T) {


### PR DESCRIPTION
Fixes the rendered UI on code verification flows.

## Related issue(s)
#3146 

## Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments
The function `Strategy.createVerificationCodeForm` is used when either you update a verification flow with email or when you use a magic link. In the case of the magic link the email is unknown, and therefore the submit is not included.

I could not get the testing system working on my machine, so I could not verify that my changing the tests is correct.
