### PR TITLE
feat: drop unused index

### DIFF
--- a/persistence/sql/migrations/sql/20230216142104000000_session_devices_index_drop.cockroach.down.sql
+++ b/persistence/sql/migrations/sql/20230216142104000000_session_devices_index_drop.cockroach.down.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX IF NOT EXISTS unique_session_device ON session_devices (nid, session_id, ip_address, user_agent);

--- a/persistence/sql/migrations/sql/20230216142104000000_session_devices_index_drop.cockroach.up.sql
+++ b/persistence/sql/migrations/sql/20230216142104000000_session_devices_index_drop.cockroach.up.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS session_devices@unique_session_device CASCADE;

--- a/persistence/sql/migrations/sql/20230216142104000000_session_devices_index_drop.down.sql
+++ b/persistence/sql/migrations/sql/20230216142104000000_session_devices_index_drop.down.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX IF NOT EXISTS unique_session_device ON session_devices (nid, session_id, ip_address, user_agent);

--- a/persistence/sql/migrations/sql/20230216142104000000_session_devices_index_drop.mysql.down.sql
+++ b/persistence/sql/migrations/sql/20230216142104000000_session_devices_index_drop.mysql.down.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX unique_session_device ON session_devices (nid, session_id, ip_address, user_agent);

--- a/persistence/sql/migrations/sql/20230216142104000000_session_devices_index_drop.mysql.up.sql
+++ b/persistence/sql/migrations/sql/20230216142104000000_session_devices_index_drop.mysql.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE session_devices DROP FOREIGN KEY session_devices_ibfk_2;
+ALTER TABLE session_devices DROP INDEX unique_session_device;
+ALTER TABLE session_devices ADD CONSTRAINT session_devices_ibfk_2 FOREIGN KEY (nid) REFERENCES networks(id) ON DELETE CASCADE;

--- a/persistence/sql/migrations/sql/20230216142104000000_session_devices_index_drop.up.sql
+++ b/persistence/sql/migrations/sql/20230216142104000000_session_devices_index_drop.up.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS session_devices.unique_session_device;


### PR DESCRIPTION
This index doesn't serve a real purpose and is interfering with the multi-region rollout.