### PR TITLE
feat: refactor credentials fetching

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/go-swagger/go-swagger v0.30.3
 	github.com/gobuffalo/fizz v1.14.4
 	github.com/gobuffalo/httptest v1.5.2
-	github.com/gobuffalo/pop/v6 v6.1.2-0.20230124165254-ec9229dbf7d7
+	github.com/gobuffalo/pop/v6 v6.1.2-0.20230318123913-c85387acc9a0
 	github.com/gofrs/uuid v4.3.1+incompatible
 	github.com/golang-jwt/jwt/v4 v4.1.0
 	github.com/golang/gddo v0.0.0-20190904175337-72a348e765d2

--- a/go.sum
+++ b/go.sum
@@ -501,8 +501,8 @@ github.com/gobuffalo/packr/v2 v2.2.0/go.mod h1:CaAwI0GPIAv+5wKLtv8Afwl+Cm78K/I/V
 github.com/gobuffalo/plush/v4 v4.1.16/go.mod h1:6t7swVsarJ8qSLw1qyAH/KbrcSTwdun2ASEQkOznakg=
 github.com/gobuffalo/plush/v4 v4.1.18 h1:bnPjdMTEUQHqj9TNX2Ck3mxEXYZa+0nrFMNM07kpX9g=
 github.com/gobuffalo/plush/v4 v4.1.18/go.mod h1:xi2tJIhFI4UdzIL8sxZtzGYOd2xbBpcFbLZlIPGGZhU=
-github.com/gobuffalo/pop/v6 v6.1.2-0.20230124165254-ec9229dbf7d7 h1:lwf/5cRw46IrLrhZnCg8J9NKgskkwMPuVvEOc2Wy72I=
-github.com/gobuffalo/pop/v6 v6.1.2-0.20230124165254-ec9229dbf7d7/go.mod h1:1n7jAmI1i7fxuXPZjZb0VBPQDbksRtCoFnrDV5IsvaI=
+github.com/gobuffalo/pop/v6 v6.1.2-0.20230318123913-c85387acc9a0 h1:+LF3Enal3HZ+rFmaLZfBRNHKqtnoA0d8jk0Iio8InZM=
+github.com/gobuffalo/pop/v6 v6.1.2-0.20230318123913-c85387acc9a0/go.mod h1:1n7jAmI1i7fxuXPZjZb0VBPQDbksRtCoFnrDV5IsvaI=
 github.com/gobuffalo/syncx v0.0.0-20190224160051-33c29581e754/go.mod h1:HhnNqWY95UYwwW3uSASeV7vtgYkT2t16hJgV3AEPUpw=
 github.com/gobuffalo/tags/v3 v3.1.4 h1:X/ydLLPhgXV4h04Hp2xlbI2oc5MDaa7eub6zw8oHjsM=
 github.com/gobuffalo/tags/v3 v3.1.4/go.mod h1:ArRNo3ErlHO8BtdA0REaZxijuWnWzF6PUXngmMXd2I0=

--- a/identity/expandables.go
+++ b/identity/expandables.go
@@ -9,11 +9,9 @@ type Expandable = sqlxx.Expandable
 type Expandables = sqlxx.Expandables
 
 const (
-	ExpandFieldVerifiableAddresses   Expandable = "VerifiableAddresses"
-	ExpandFieldRecoveryAddresses     Expandable = "RecoveryAddresses"
-	ExpandFieldCredentials           Expandable = "InternalCredentials"
-	ExpandFieldCredentialType        Expandable = "InternalCredentials.IdentityCredentialType"
-	ExpandFieldCredentialIdentifiers Expandable = "InternalCredentials.CredentialIdentifiers"
+	ExpandFieldVerifiableAddresses Expandable = "VerifiableAddresses"
+	ExpandFieldRecoveryAddresses   Expandable = "RecoveryAddresses"
+	ExpandFieldCredentials         Expandable = "Credentials"
 )
 
 // ExpandNothing expands nothing
@@ -31,8 +29,6 @@ var ExpandDefault = Expandables{
 // ExpandCredentials expands the identity's credentials.
 var ExpandCredentials = Expandables{
 	ExpandFieldCredentials,
-	ExpandFieldCredentialType,
-	ExpandFieldCredentialIdentifiers,
 }
 
 // ExpandEverything expands all the fields of an identity.
@@ -40,6 +36,4 @@ var ExpandEverything = Expandables{
 	ExpandFieldVerifiableAddresses,
 	ExpandFieldRecoveryAddresses,
 	ExpandFieldCredentials,
-	ExpandFieldCredentialType,
-	ExpandFieldCredentialIdentifiers,
 }

--- a/identity/test/pool.go
+++ b/identity/test/pool.go
@@ -123,7 +123,6 @@ func TestPool(ctx context.Context, conf *config.Config, p persistence.Persister,
 					assert.Empty(t, actual.RecoveryAddresses)
 					assert.Empty(t, actual.VerifiableAddresses)
 					assert.Empty(t, actual.Credentials)
-					assert.Empty(t, actual.InternalCredentials)
 				})
 			})
 
@@ -142,7 +141,6 @@ func TestPool(ctx context.Context, conf *config.Config, p persistence.Persister,
 			t.Run("expand=recovery address", func(t *testing.T) {
 				runner(t, sqlxx.Expandables{identity.ExpandFieldRecoveryAddresses}, func(t *testing.T, actual *identity.Identity) {
 					assert.Empty(t, actual.Credentials)
-					assert.Empty(t, actual.InternalCredentials)
 					assert.Empty(t, actual.VerifiableAddresses)
 
 					require.Len(t, actual.RecoveryAddresses, 1)
@@ -153,7 +151,6 @@ func TestPool(ctx context.Context, conf *config.Config, p persistence.Persister,
 			t.Run("expand=verification address", func(t *testing.T) {
 				runner(t, sqlxx.Expandables{identity.ExpandFieldVerifiableAddresses}, func(t *testing.T, actual *identity.Identity) {
 					assert.Empty(t, actual.Credentials)
-					assert.Empty(t, actual.InternalCredentials)
 					assert.Empty(t, actual.RecoveryAddresses)
 
 					require.Len(t, actual.VerifiableAddresses, 1)
@@ -165,7 +162,6 @@ func TestPool(ctx context.Context, conf *config.Config, p persistence.Persister,
 				runner(t, identity.ExpandDefault, func(t *testing.T, actual *identity.Identity) {
 
 					assert.Empty(t, actual.Credentials)
-					assert.Empty(t, actual.InternalCredentials)
 
 					require.Len(t, actual.RecoveryAddresses, 1)
 					assertx.EqualAsJSONExcept(t, expected.RecoveryAddresses, actual.RecoveryAddresses, []string{"0.updated_at", "0.created_at"})

--- a/persistence/sql/identity/persister_identity.go
+++ b/persistence/sql/identity/persister_identity.go
@@ -660,6 +660,14 @@ func (p *IdentityPersister) ListIdentities(ctx context.Context, params identity.
 			schemaCache[i.SchemaID] = i.SchemaURL
 		}
 
+		if err := i.Validate(); err != nil {
+			return nil, err
+		}
+
+		if err := identity.UpgradeCredentials(i); err != nil {
+			return nil, err
+		}
+
 		is[k] = *i
 	}
 

--- a/persistence/sql/migratest/migration_test.go
+++ b/persistence/sql/migratest/migration_test.go
@@ -66,7 +66,8 @@ func CompareWithFixture(t *testing.T, actual interface{}, prefix string, id stri
 	s := snapshotFor("fixtures", prefix)
 	actualJSON, err := json.MarshalIndent(actual, "", "  ")
 	require.NoError(t, err)
-	assert.NoError(t, s.SnapshotWithName(id, actualJSON))
+	err = s.SnapshotWithName(id, actualJSON)
+	assert.NoErrorf(t, err, "actual = %s", string(actualJSON))
 }
 
 func TestMigrations_SQLite(t *testing.T) {

--- a/persistence/sql/persister_test.go
+++ b/persistence/sql/persister_test.go
@@ -58,12 +58,8 @@ func init() {
 }
 
 func TestMain(m *testing.M) {
-	atexit := dockertest.NewOnExit()
-	atexit.Add(func() {
-		// _ = os.Remove(strings.TrimPrefix(sqlite, "sqlite://"))
-		dockertest.KillAllTestDatabases()
-	})
-	atexit.Exit(m.Run())
+	m.Run()
+	dockertest.KillAllTestDatabases()
 }
 
 func pl(t *testing.T) func(lvl logging.Level, s string, args ...interface{}) {

--- a/selfservice/hook/web_hook_integration_test.go
+++ b/selfservice/hook/web_hook_integration_test.go
@@ -682,9 +682,8 @@ func TestWebHooks(t *testing.T) {
 					Value: "some@example.org",
 					Via:   "email",
 				}},
-				MetadataPublic:      []byte(`{"public":"data"}`),
-				MetadataAdmin:       []byte(`{"admin":"data"}`),
-				InternalCredentials: identity.CredentialsCollection{{Type: "password", Identifiers: []string{"test"}, Config: []byte(`{}`)}},
+				MetadataPublic: []byte(`{"public":"data"}`),
+				MetadataAdmin:  []byte(`{"admin":"data"}`),
 			}
 
 			t.Run("case=body is empty", func(t *testing.T) {

--- a/selfservice/strategy/lookup/strategy_test.go
+++ b/selfservice/strategy/lookup/strategy_test.go
@@ -28,25 +28,25 @@ func TestCountActiveFirstFactorCredentials(t *testing.T) {
 
 	t.Run("multi factor", func(t *testing.T) {
 		for k, tc := range []struct {
-			in       identity.CredentialsCollection
+			in       map[identity.CredentialsType]identity.Credentials
 			expected int
 		}{
 			{
-				in: identity.CredentialsCollection{{
+				in: map[identity.CredentialsType]identity.Credentials{strategy.ID(): {
 					Type:   strategy.ID(),
 					Config: []byte{},
 				}},
 				expected: 0,
 			},
 			{
-				in: identity.CredentialsCollection{{
+				in: map[identity.CredentialsType]identity.Credentials{strategy.ID(): {
 					Type:   strategy.ID(),
 					Config: []byte(`{"recovery_codes": []}`),
 				}},
 				expected: 0,
 			},
 			{
-				in: identity.CredentialsCollection{{
+				in: map[identity.CredentialsType]identity.Credentials{strategy.ID(): {
 					Type:        strategy.ID(),
 					Identifiers: []string{"foo"},
 					Config:      []byte(`{"recovery_codes": [{}]}`),
@@ -54,24 +54,19 @@ func TestCountActiveFirstFactorCredentials(t *testing.T) {
 				expected: 1,
 			},
 			{
-				in: identity.CredentialsCollection{{
+				in: map[identity.CredentialsType]identity.Credentials{strategy.ID(): {
 					Type:   strategy.ID(),
 					Config: []byte(`{}`),
 				}},
 				expected: 0,
 			},
 			{
-				in:       identity.CredentialsCollection{{}, {}},
+				in:       nil,
 				expected: 0,
 			},
 		} {
 			t.Run(fmt.Sprintf("case=%d", k), func(t *testing.T) {
-				cc := map[identity.CredentialsType]identity.Credentials{}
-				for _, c := range tc.in {
-					cc[c.Type] = c
-				}
-
-				actual, err := strategy.CountActiveMultiFactorCredentials(cc)
+				actual, err := strategy.CountActiveMultiFactorCredentials(tc.in)
 				require.NoError(t, err)
 				assert.Equal(t, tc.expected, actual)
 			})

--- a/selfservice/strategy/oidc/strategy_test.go
+++ b/selfservice/strategy/oidc/strategy_test.go
@@ -32,8 +32,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 
-	"github.com/ory/x/sqlxx"
-
 	"github.com/ory/x/urlx"
 
 	"github.com/ory/kratos/driver/config"
@@ -671,17 +669,17 @@ func TestCountActiveFirstFactorCredentials(t *testing.T) {
 	}
 
 	for k, tc := range []struct {
-		in       identity.CredentialsCollection
+		in       map[identity.CredentialsType]identity.Credentials
 		expected int
 	}{
 		{
-			in: identity.CredentialsCollection{{
+			in: map[identity.CredentialsType]identity.Credentials{strategy.ID(): {
 				Type:   strategy.ID(),
-				Config: sqlxx.JSONRawMessage{},
+				Config: []byte{},
 			}},
 		},
 		{
-			in: identity.CredentialsCollection{{
+			in: map[identity.CredentialsType]identity.Credentials{strategy.ID(): {
 				Type: strategy.ID(),
 				Config: toJson(identity.CredentialsOIDC{Providers: []identity.CredentialsOIDCProvider{
 					{Subject: "foo", Provider: "bar"},
@@ -689,7 +687,7 @@ func TestCountActiveFirstFactorCredentials(t *testing.T) {
 			}},
 		},
 		{
-			in: identity.CredentialsCollection{{
+			in: map[identity.CredentialsType]identity.Credentials{strategy.ID(): {
 				Type:        strategy.ID(),
 				Identifiers: []string{""},
 				Config: toJson(identity.CredentialsOIDC{Providers: []identity.CredentialsOIDCProvider{
@@ -698,7 +696,7 @@ func TestCountActiveFirstFactorCredentials(t *testing.T) {
 			}},
 		},
 		{
-			in: identity.CredentialsCollection{{
+			in: map[identity.CredentialsType]identity.Credentials{strategy.ID(): {
 				Type:        strategy.ID(),
 				Identifiers: []string{"bar:"},
 				Config: toJson(identity.CredentialsOIDC{Providers: []identity.CredentialsOIDCProvider{
@@ -707,7 +705,7 @@ func TestCountActiveFirstFactorCredentials(t *testing.T) {
 			}},
 		},
 		{
-			in: identity.CredentialsCollection{{
+			in: map[identity.CredentialsType]identity.Credentials{strategy.ID(): {
 				Type:        strategy.ID(),
 				Identifiers: []string{":foo"},
 				Config: toJson(identity.CredentialsOIDC{Providers: []identity.CredentialsOIDCProvider{
@@ -716,7 +714,7 @@ func TestCountActiveFirstFactorCredentials(t *testing.T) {
 			}},
 		},
 		{
-			in: identity.CredentialsCollection{{
+			in: map[identity.CredentialsType]identity.Credentials{strategy.ID(): {
 				Type:        strategy.ID(),
 				Identifiers: []string{"not-bar:foo"},
 				Config: toJson(identity.CredentialsOIDC{Providers: []identity.CredentialsOIDCProvider{
@@ -725,7 +723,7 @@ func TestCountActiveFirstFactorCredentials(t *testing.T) {
 			}},
 		},
 		{
-			in: identity.CredentialsCollection{{
+			in: map[identity.CredentialsType]identity.Credentials{strategy.ID(): {
 				Type:        strategy.ID(),
 				Identifiers: []string{"bar:not-foo"},
 				Config: toJson(identity.CredentialsOIDC{Providers: []identity.CredentialsOIDCProvider{
@@ -734,7 +732,7 @@ func TestCountActiveFirstFactorCredentials(t *testing.T) {
 			}},
 		},
 		{
-			in: identity.CredentialsCollection{{
+			in: map[identity.CredentialsType]identity.Credentials{strategy.ID(): {
 				Type:        strategy.ID(),
 				Identifiers: []string{"bar:foo"},
 				Config: toJson(identity.CredentialsOIDC{Providers: []identity.CredentialsOIDCProvider{

--- a/selfservice/strategy/password/strategy_test.go
+++ b/selfservice/strategy/password/strategy_test.go
@@ -29,25 +29,25 @@ func TestCountActiveFirstFactorCredentials(t *testing.T) {
 	require.NoError(t, err)
 
 	for k, tc := range []struct {
-		in       identity.CredentialsCollection
+		in       map[identity.CredentialsType]identity.Credentials
 		expected int
 	}{
 		{
-			in: identity.CredentialsCollection{{
+			in: map[identity.CredentialsType]identity.Credentials{strategy.ID(): {
 				Type:   strategy.ID(),
 				Config: []byte{},
 			}},
 			expected: 0,
 		},
 		{
-			in: identity.CredentialsCollection{{
+			in: map[identity.CredentialsType]identity.Credentials{strategy.ID(): {
 				Type:   strategy.ID(),
 				Config: []byte(`{"hashed_password": "` + string(h1) + `"}`),
 			}},
 			expected: 0,
 		},
 		{
-			in: identity.CredentialsCollection{{
+			in: map[identity.CredentialsType]identity.Credentials{strategy.ID(): {
 				Type:        strategy.ID(),
 				Identifiers: []string{""},
 				Config:      []byte(`{"hashed_password": "` + string(h1) + `"}`),
@@ -55,7 +55,7 @@ func TestCountActiveFirstFactorCredentials(t *testing.T) {
 			expected: 0,
 		},
 		{
-			in: identity.CredentialsCollection{{
+			in: map[identity.CredentialsType]identity.Credentials{strategy.ID(): {
 				Type:        strategy.ID(),
 				Identifiers: []string{"foo"},
 				Config:      []byte(`{"hashed_password": "` + string(h1) + `"}`),
@@ -63,7 +63,7 @@ func TestCountActiveFirstFactorCredentials(t *testing.T) {
 			expected: 1,
 		},
 		{
-			in: identity.CredentialsCollection{{
+			in: map[identity.CredentialsType]identity.Credentials{strategy.ID(): {
 				Type:        strategy.ID(),
 				Identifiers: []string{"foo"},
 				Config:      []byte(`{"hashed_password": "` + string(h2) + `"}`),
@@ -71,36 +71,31 @@ func TestCountActiveFirstFactorCredentials(t *testing.T) {
 			expected: 1,
 		},
 		{
-			in: identity.CredentialsCollection{{
+			in: map[identity.CredentialsType]identity.Credentials{strategy.ID(): {
 				Type:   strategy.ID(),
 				Config: []byte(`{"hashed_password": "asdf"}`),
 			}},
 			expected: 0,
 		},
 		{
-			in: identity.CredentialsCollection{{
+			in: map[identity.CredentialsType]identity.Credentials{strategy.ID(): {
 				Type:   strategy.ID(),
 				Config: []byte(`{}`),
 			}},
 			expected: 0,
 		},
 		{
-			in:       identity.CredentialsCollection{{}, {}},
+			in:       nil,
 			expected: 0,
 		},
 	} {
 		t.Run(fmt.Sprintf("case=%d", k), func(t *testing.T) {
-			cc := map[identity.CredentialsType]identity.Credentials{}
-			for _, c := range tc.in {
-				cc[c.Type] = c
-			}
-
-			actual, err := strategy.CountActiveFirstFactorCredentials(cc)
-			require.NoError(t, err)
+			actual, err := strategy.CountActiveFirstFactorCredentials(tc.in)
+			assert.NoError(t, err)
 			assert.Equal(t, tc.expected, actual)
 
-			actual, err = strategy.CountActiveMultiFactorCredentials(cc)
-			require.NoError(t, err)
+			actual, err = strategy.CountActiveMultiFactorCredentials(tc.in)
+			assert.NoError(t, err)
 			assert.Equal(t, 0, actual)
 		})
 	}

--- a/selfservice/strategy/totp/strategy_test.go
+++ b/selfservice/strategy/totp/strategy_test.go
@@ -32,25 +32,25 @@ func TestCountActiveCredentials(t *testing.T) {
 
 	t.Run("multi factor", func(t *testing.T) {
 		for k, tc := range []struct {
-			in       identity.CredentialsCollection
+			in       map[identity.CredentialsType]identity.Credentials
 			expected int
 		}{
 			{
-				in: identity.CredentialsCollection{{
+				in: map[identity.CredentialsType]identity.Credentials{strategy.ID(): {
 					Type:   strategy.ID(),
 					Config: []byte{},
 				}},
 				expected: 0,
 			},
 			{
-				in: identity.CredentialsCollection{{
+				in: map[identity.CredentialsType]identity.Credentials{strategy.ID(): {
 					Type:   strategy.ID(),
 					Config: []byte(`{"totp_url": ""}`),
 				}},
 				expected: 0,
 			},
 			{
-				in: identity.CredentialsCollection{{
+				in: map[identity.CredentialsType]identity.Credentials{strategy.ID(): {
 					Type:        strategy.ID(),
 					Identifiers: []string{"foo"},
 					Config:      []byte(`{"totp_url": "` + key.URL() + `"}`),
@@ -58,14 +58,14 @@ func TestCountActiveCredentials(t *testing.T) {
 				expected: 1,
 			},
 			{
-				in: identity.CredentialsCollection{{
+				in: map[identity.CredentialsType]identity.Credentials{strategy.ID(): {
 					Type:   strategy.ID(),
 					Config: []byte(`{}`),
 				}},
 				expected: 0,
 			},
 			{
-				in:       identity.CredentialsCollection{{}, {}},
+				in:       nil,
 				expected: 0,
 			},
 		} {

--- a/selfservice/strategy/webauthn/strategy_test.go
+++ b/selfservice/strategy/webauthn/strategy_test.go
@@ -40,24 +40,24 @@ func TestCountActiveFirstFactorCredentials(t *testing.T) {
 	strategy := webauthn.NewStrategy(reg)
 
 	for k, tc := range []struct {
-		in            identity.CredentialsCollection
+		in            map[identity.CredentialsType]identity.Credentials
 		expectedFirst int
 		expectedMulti int
 	}{
 		{
-			in: identity.CredentialsCollection{{
+			in: map[identity.CredentialsType]identity.Credentials{strategy.ID(): {
 				Type:   strategy.ID(),
 				Config: []byte{},
 			}},
 		},
 		{
-			in: identity.CredentialsCollection{{
+			in: map[identity.CredentialsType]identity.Credentials{strategy.ID(): {
 				Type:   strategy.ID(),
 				Config: []byte(`{"credentials": []}`),
 			}},
 		},
 		{
-			in: identity.CredentialsCollection{{
+			in: map[identity.CredentialsType]identity.Credentials{strategy.ID(): {
 				Type:        strategy.ID(),
 				Identifiers: []string{"foo"},
 				Config:      []byte(`{"credentials": [{}]}`),
@@ -65,7 +65,7 @@ func TestCountActiveFirstFactorCredentials(t *testing.T) {
 			expectedMulti: 1,
 		},
 		{
-			in: identity.CredentialsCollection{{
+			in: map[identity.CredentialsType]identity.Credentials{strategy.ID(): {
 				Type:        strategy.ID(),
 				Identifiers: []string{"foo"},
 				Config:      []byte(`{"credentials": [{"is_passwordless": true}]}`),
@@ -73,7 +73,7 @@ func TestCountActiveFirstFactorCredentials(t *testing.T) {
 			expectedFirst: 1,
 		},
 		{
-			in: identity.CredentialsCollection{{
+			in: map[identity.CredentialsType]identity.Credentials{strategy.ID(): {
 				Type:        strategy.ID(),
 				Identifiers: []string{"foo"},
 				Config:      []byte(`{"credentials": [{"is_passwordless": true}, {"is_passwordless": true}]}`),
@@ -81,7 +81,7 @@ func TestCountActiveFirstFactorCredentials(t *testing.T) {
 			expectedFirst: 2,
 		},
 		{
-			in: identity.CredentialsCollection{{
+			in: map[identity.CredentialsType]identity.Credentials{strategy.ID(): {
 				Type:        strategy.ID(),
 				Identifiers: []string{"foo"},
 				Config:      []byte(`{"credentials": [{"is_passwordless": true}, {"is_passwordless": false}]}`),
@@ -90,13 +90,13 @@ func TestCountActiveFirstFactorCredentials(t *testing.T) {
 			expectedMulti: 1,
 		},
 		{
-			in: identity.CredentialsCollection{{
+			in: map[identity.CredentialsType]identity.Credentials{strategy.ID(): {
 				Type:   strategy.ID(),
 				Config: []byte(`{}`),
 			}},
 		},
 		{
-			in: identity.CredentialsCollection{{}, {}},
+			in: nil,
 		},
 	} {
 		t.Run(fmt.Sprintf("case=%d", k), func(t *testing.T) {

--- a/x/xsql/sql.go
+++ b/x/xsql/sql.go
@@ -48,8 +48,8 @@ func CleanSQL(t *testing.T, c *pop.Connection) {
 
 		new(errorx.ErrorContainer).TableName(ctx),
 
-		new(identity.CredentialIdentifierCollection).TableName(ctx),
-		new(identity.CredentialsCollection).TableName(ctx),
+		new(identity.CredentialIdentifier).TableName(ctx),
+		new(identity.Credentials).TableName(ctx),
 		new(identity.VerifiableAddress).TableName(ctx),
 		new(identity.RecoveryAddress).TableName(ctx),
 		new(identity.Identity).TableName(ctx),


### PR DESCRIPTION
This change revamps the way we fetch identity credentials. We no longer need most of the helper fields for gobuffalo/pop inside the `Identity` and `Credentials` structures, and we collect all the credentials in one joined query rather than using pop's `EagerPreload` functionality.