### PR TITLE
fix: invalid SQL syntax in ListIdentities

### DIFF
--- a/identity/test/pool.go
+++ b/identity/test/pool.go
@@ -677,6 +677,7 @@ func TestPool(ctx context.Context, conf *config.Config, p persistence.Persister,
 			t.Run("only webauthn and password", func(t *testing.T) {
 				actual, err := p.ListIdentities(ctx, identity.ListIdentityParameters{
 					CredentialsIdentifier: "find-identity-by-identifier-oidc@ory.sh",
+					Expand:                identity.ExpandEverything,
 				})
 				require.NoError(t, err)
 				assert.Len(t, actual, 0)
@@ -685,6 +686,7 @@ func TestPool(ctx context.Context, conf *config.Config, p persistence.Persister,
 			t.Run("one result set even if multiple matches", func(t *testing.T) {
 				actual, err := p.ListIdentities(ctx, identity.ListIdentityParameters{
 					CredentialsIdentifier: "find-identity-by-identifier-common@ory.sh",
+					Expand:                identity.ExpandEverything,
 				})
 				require.NoError(t, err)
 				assert.Len(t, actual, 1)
@@ -693,6 +695,7 @@ func TestPool(ctx context.Context, conf *config.Config, p persistence.Persister,
 			t.Run("non existing identifier", func(t *testing.T) {
 				actual, err := p.ListIdentities(ctx, identity.ListIdentityParameters{
 					CredentialsIdentifier: "find-identity-by-identifier-non-existing@ory.sh",
+					Expand:                identity.ExpandEverything,
 				})
 				require.NoError(t, err)
 				assert.Len(t, actual, 0)
@@ -702,6 +705,7 @@ func TestPool(ctx context.Context, conf *config.Config, p persistence.Persister,
 				_, on := testhelpers.NewNetwork(t, ctx, p)
 				actual, err := on.ListIdentities(ctx, identity.ListIdentityParameters{
 					CredentialsIdentifier: expectedIdentifiers[0],
+					Expand:                identity.ExpandEverything,
 				})
 				require.NoError(t, err)
 				assert.Len(t, actual, 0)

--- a/persistence/sql/identity/persister_identity.go
+++ b/persistence/sql/identity/persister_identity.go
@@ -697,6 +697,10 @@ func (p *IdentityPersister) ListIdentities(ctx context.Context, params identity.
 		return nil, err
 	}
 
+	if len(is) == 0 {
+		return is, nil
+	}
+
 	if params.Expand.Has(identity.ExpandFieldCredentials) {
 		var ids []interface{}
 		for k := range is {


### PR DESCRIPTION
PostgresQL does not support `... WHERE x IN ( )` with an empty argument list. Works in CRDB, though. Our tests didn't catch this because they didn't expand credentials.

Closes https://github.com/ory/kratos/issues/3194