### PR TITLE
feat: make session object available in web_hook context

### DIFF
--- a/selfservice/hook/stub/test_body.jsonnet
+++ b/selfservice/hook/stub/test_body.jsonnet
@@ -1,6 +1,7 @@
 function(ctx) std.prune({
   flow_id: ctx.flow.id,
   identity_id: if std.objectHas(ctx, "identity") then ctx.identity.id,
+  session_id: if std.objectHas(ctx, "session") then ctx.session.id,
   headers: ctx.request_headers,
   url: ctx.request_url,
   method: ctx.request_method,

--- a/selfservice/hook/web_hook.go
+++ b/selfservice/hook/web_hook.go
@@ -64,6 +64,7 @@ type (
 		RequestURL     string             `json:"request_url"`
 		RequestCookies map[string]string  `json:"request_cookies"`
 		Identity       *identity.Identity `json:"identity,omitempty"`
+		Session        *session.Session   `json:"session,omitempty"`
 	}
 
 	WebHook struct {
@@ -123,6 +124,7 @@ func (e *WebHook) ExecuteLoginPostHook(_ http.ResponseWriter, req *http.Request,
 			RequestURL:     x.RequestURL(req).String(),
 			RequestCookies: cookies(req),
 			Identity:       session.Identity,
+			Session:        session,
 		})
 	})
 }
@@ -173,6 +175,7 @@ func (e *WebHook) ExecutePostRecoveryHook(_ http.ResponseWriter, req *http.Reque
 			RequestURL:     x.RequestURL(req).String(),
 			RequestCookies: cookies(req),
 			Identity:       session.Identity,
+			Session:        session,
 		})
 	})
 }
@@ -217,6 +220,7 @@ func (e *WebHook) ExecutePostRegistrationPostPersistHook(_ http.ResponseWriter, 
 			RequestURL:     x.RequestURL(req).String(),
 			RequestCookies: cookies(req),
 			Identity:       session.Identity,
+			Session:        session,
 		})
 	})
 }

--- a/selfservice/hook/web_hook_integration_test.go
+++ b/selfservice/hook/web_hook_integration_test.go
@@ -167,17 +167,17 @@ func TestWebHooks(t *testing.T) {
 		h, _ := json.Marshal(req.Header)
 		return fmt.Sprintf(`{
    					"flow_id": "%s",
-					"identity_id": "%s",
-					"session_id": "%s",
+						"identity_id": "%s",
+						"session_id": "%s",
    					"headers": %s,
-					"method": "%s",
-					"url": "%s",
-					"cookies": {
-						"Some-Cookie-1": "Some-Cookie-Value",
-						"Some-Cookie-2": "Some-other-Cookie-Value",
-						"Some-Cookie-3": "Third-Cookie-Value"
-					},
-					"transient_payload": %s
+						"method": "%s",
+						"url": "%s",
+						"cookies": {
+							"Some-Cookie-1": "Some-Cookie-Value",
+							"Some-Cookie-2": "Some-other-Cookie-Value",
+							"Some-Cookie-3": "Third-Cookie-Value"
+						},
+						"transient_payload": %s
 				}`, f.GetID(), s.Identity.ID, s.ID, string(h), req.Method, "http://www.ory.sh/some_end_point", string(tp))
 	}
 


### PR DESCRIPTION
Right now it's not possible to link `web_hook` actions with the corresponding user session. This allows more possibilities in `web_hook` actions when a user logins or a session is started for the first time after user registration.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

#3203 

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
