### PR TITLE
feat: link oidc credentials when login

### DIFF
--- a/cmd/clidoc/main.go
+++ b/cmd/clidoc/main.go
@@ -132,6 +132,7 @@ func init() {
 		"NewInfoSelfServiceLoginContinue":                         text.NewInfoSelfServiceLoginContinue(),
 		"NewErrorValidationSuchNoWebAuthnUser":                    text.NewErrorValidationSuchNoWebAuthnUser(),
 		"NewInfoSelfServiceLoginLinkCredentials":                  text.NewInfoSelfServiceLoginLinkCredentials(),
+		"NewErrorValidationLoginLinkedCredentialsDoNotMatch":      text.NewErrorValidationLoginLinkedCredentialsDoNotMatch(),
 	}
 }
 

--- a/cmd/clidoc/main.go
+++ b/cmd/clidoc/main.go
@@ -131,6 +131,7 @@ func init() {
 		"NewInfoSelfServiceContinueLoginWebAuthn":                 text.NewInfoSelfServiceContinueLoginWebAuthn(),
 		"NewInfoSelfServiceLoginContinue":                         text.NewInfoSelfServiceLoginContinue(),
 		"NewErrorValidationSuchNoWebAuthnUser":                    text.NewErrorValidationSuchNoWebAuthnUser(),
+		"NewInfoSelfServiceLoginLinkCredentials":                  text.NewInfoSelfServiceLoginLinkCredentials(),
 	}
 }
 

--- a/schema/errors.go
+++ b/schema/errors.go
@@ -303,3 +303,13 @@ func NewNoWebAuthnCredentials() error {
 		Messages: new(text.Messages).Add(text.NewErrorValidationSuchNoWebAuthnUser()),
 	})
 }
+
+func NewLinkedCredentialsDoNotMatch() error {
+	return errors.WithStack(&ValidationError{
+		ValidationError: &jsonschema.ValidationError{
+			Message:     `linked credentials do not match`,
+			InstancePtr: "#/",
+		},
+		Messages: new(text.Messages).Add(text.NewErrorValidationLoginLinkedCredentialsDoNotMatch()),
+	})
+}

--- a/selfservice/flow/flow.go
+++ b/selfservice/flow/flow.go
@@ -25,8 +25,9 @@ const InternalContextDuplicateCredentialsPath = "registration_duplicate_credenti
 const InternalContextLinkCredentialsPath = "link_credentials"
 
 type RegistrationDuplicateCredentials struct {
-	CredentialsType   identity.CredentialsType
-	CredentialsConfig sqlxx.JSONRawMessage
+	CredentialsType     identity.CredentialsType
+	CredentialsConfig   sqlxx.JSONRawMessage
+	DuplicateIdentifier string
 }
 
 func AppendFlowTo(src *url.URL, id uuid.UUID) *url.URL {

--- a/selfservice/flow/flow.go
+++ b/selfservice/flow/flow.go
@@ -4,6 +4,8 @@
 package flow
 
 import (
+	"github.com/ory/kratos/identity"
+	"github.com/ory/x/sqlxx"
 	"net/http"
 	"net/url"
 
@@ -18,6 +20,14 @@ import (
 
 	"github.com/ory/x/urlx"
 )
+
+const InternalContextDuplicateCredentialsPath = "registration_duplicate_credentials"
+const InternalContextLinkCredentialsPath = "link_credentials"
+
+type RegistrationDuplicateCredentials struct {
+	CredentialsType   identity.CredentialsType
+	CredentialsConfig sqlxx.JSONRawMessage
+}
 
 func AppendFlowTo(src *url.URL, id uuid.UUID) *url.URL {
 	return urlx.CopyWithQuery(src, url.Values{"flow": {id.String()}})

--- a/selfservice/flow/login/.schema/link_credentials.schema.json
+++ b/selfservice/flow/login/.schema/link_credentials.schema.json
@@ -1,0 +1,10 @@
+{
+  "$id": "https://schemas.ory.sh/kratos/selfservice/flow/link_credentials.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "linkCredentialsFlow": {
+      "type": "string"
+    }
+  }
+}

--- a/selfservice/flow/login/handler.go
+++ b/selfservice/flow/login/handler.go
@@ -800,6 +800,9 @@ func (h *Handler) linkCredentials(r *http.Request, s *session.Session, i *identi
 			return innerErr
 		}
 		linkCredentialsFlow, innerErr := h.d.LoginFlowPersister().GetLoginFlow(r.Context(), linkCredentialsFlowID)
+		if innerErr != nil {
+			return innerErr
+		}
 		innerErr = h.getInternalContextLinkCredentials(linkCredentialsFlow, flow.InternalContextDuplicateCredentialsPath, &lc)
 		if innerErr != nil {
 			return innerErr

--- a/selfservice/flow/login/handler.go
+++ b/selfservice/flow/login/handler.go
@@ -4,10 +4,8 @@
 package login
 
 import (
-	"context"
 	_ "embed"
 	"encoding/json"
-	"fmt"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 	"net/http"
@@ -68,7 +66,6 @@ type (
 		x.CSRFProvider
 		config.Provider
 		ErrorHandlerProvider
-		identity.PrivilegedPoolProvider
 	}
 	HandlerProvider interface {
 		LoginHandler() *Handler
@@ -755,11 +752,6 @@ continueLogin:
 			sess = session.NewInactiveSession()
 		}
 
-		if err := h.linkCredentials(r, sess, interim, f); err != nil {
-			h.d.LoginFlowErrorHandler().WriteFlowError(w, r, f, group, err)
-			return
-		}
-
 		method := ss.CompletedAuthenticationMethod(r.Context())
 		sess.CompletedLoginFor(method.Method, method.AAL)
 		i = interim
@@ -780,90 +772,4 @@ continueLogin:
 		h.d.LoginFlowErrorHandler().WriteFlowError(w, r, f, node.DefaultGroup, err)
 		return
 	}
-}
-
-func (h *Handler) linkCredentials(r *http.Request, s *session.Session, i *identity.Identity, f *Flow) error {
-	var lc flow.RegistrationDuplicateCredentials
-
-	var p struct {
-		FlowID string `json:"linkCredentialsFlow" form:"linkCredentialsFlow"`
-	}
-
-	if err := h.hd.Decode(r, &p,
-		decoderx.HTTPDecoderSetValidatePayloads(true),
-		decoderx.MustHTTPRawJSONSchemaCompiler(linkCredentialsSchema),
-		decoderx.HTTPDecoderJSONFollowsFormFormat()); err != nil {
-		return err
-	}
-
-	if p.FlowID != "" {
-		linkCredentialsFlowID, innerErr := uuid.FromString(p.FlowID)
-		if innerErr != nil {
-			return innerErr
-		}
-		linkCredentialsFlow, innerErr := h.d.LoginFlowPersister().GetLoginFlow(r.Context(), linkCredentialsFlowID)
-		if innerErr != nil {
-			return innerErr
-		}
-		innerErr = h.getInternalContextLinkCredentials(linkCredentialsFlow, flow.InternalContextDuplicateCredentialsPath, &lc)
-		if innerErr != nil {
-			return innerErr
-		}
-	}
-
-	if lc.CredentialsType == "" {
-		err := h.getInternalContextLinkCredentials(f, flow.InternalContextLinkCredentialsPath, &lc)
-		if err != nil {
-			return err
-		}
-	}
-
-	if lc.CredentialsType != "" {
-		if err := h.checkDuplecateCredentialsIdentifierMatch(r.Context(), i.ID, lc.DuplicateIdentifier); err != nil {
-			return err
-		}
-		strategy, err := h.d.AllLoginStrategies().Strategy(lc.CredentialsType)
-		if err != nil {
-			return err
-		}
-
-		linkableStrategy, ok := strategy.(LinkableStrategy)
-		if !ok {
-			return errors.New(fmt.Sprintf("Strategy is not linkable: %T", linkableStrategy))
-		}
-
-		if err := linkableStrategy.Link(r.Context(), i, lc.CredentialsConfig); err != nil {
-			return err
-		}
-
-		method := strategy.CompletedAuthenticationMethod(r.Context())
-		s.CompletedLoginFor(method.Method, method.AAL)
-	}
-
-	return nil
-}
-
-func (h *Handler) getInternalContextLinkCredentials(f *Flow, internalContextPath string, lc *flow.RegistrationDuplicateCredentials) error {
-	internalContextLinkCredentials := gjson.GetBytes(f.InternalContext, internalContextPath)
-	if internalContextLinkCredentials.IsObject() {
-		if err := json.Unmarshal([]byte(internalContextLinkCredentials.Raw), lc); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (h *Handler) checkDuplecateCredentialsIdentifierMatch(ctx context.Context, identityID uuid.UUID, match string) error {
-	i, err := h.d.PrivilegedIdentityPool().GetIdentityConfidential(ctx, identityID)
-	if err != nil {
-		return err
-	}
-	for _, credentials := range i.Credentials {
-		for _, identifier := range credentials.Identifiers {
-			if identifier == match {
-				return nil
-			}
-		}
-	}
-	return schema.NewLinkedCredentialsDoNotMatch()
 }

--- a/selfservice/flow/login/strategy.go
+++ b/selfservice/flow/login/strategy.go
@@ -5,6 +5,7 @@ package login
 
 import (
 	"context"
+	"github.com/ory/x/sqlxx"
 	"net/http"
 
 	"github.com/ory/kratos/session"
@@ -26,6 +27,10 @@ type Strategy interface {
 }
 
 type Strategies []Strategy
+
+type LinkableStrategy interface {
+	Link(ctx context.Context, i *identity.Identity, credentials sqlxx.JSONRawMessage) error
+}
 
 func (s Strategies) Strategy(id identity.CredentialsType) (Strategy, error) {
 	ids := make([]identity.CredentialsType, len(s))

--- a/selfservice/flow/registration/hook.go
+++ b/selfservice/flow/registration/hook.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/ory/kratos/selfservice/flow/login"
+	"github.com/ory/kratos/ui/node"
 	"github.com/tidwall/sjson"
 	"net/http"
 	"time"
@@ -76,6 +77,7 @@ type (
 		identity.ManagementProvider
 		identity.ValidationProvider
 		login.FlowPersistenceProvider
+		login.StrategyProvider
 		session.PersistenceProvider
 		session.ManagementProvider
 		HooksProvider
@@ -141,36 +143,56 @@ func (e *HookExecutor) PostRegistrationHook(w http.ResponseWriter, r *http.Reque
 		// would imply that the identity has to exist already.
 	} else if err := e.d.IdentityManager().Create(r.Context(), i); err != nil {
 		if errors.Is(err, sqlcon.ErrUniqueViolation) {
-			registrationDuplicateCredentials := flow.RegistrationDuplicateCredentials{
-				CredentialsType:   ct,
-				CredentialsConfig: i.Credentials[ct].Config,
-			}
-			loginFlowID, err := a.GetOuterLoginFlowID()
+			strategy, err := e.d.AllLoginStrategies().Strategy(ct)
 			if err != nil {
 				return err
 			}
-			if loginFlowID != nil {
-				loginFlow, err := e.d.LoginFlowPersister().GetLoginFlow(r.Context(), *loginFlowID)
+
+			_, ok := strategy.(login.LinkableStrategy)
+
+			if ok {
+				registrationDuplicateCredentials := flow.RegistrationDuplicateCredentials{
+					CredentialsType:   ct,
+					CredentialsConfig: i.Credentials[ct].Config,
+				}
+				loginFlowID, err := a.GetOuterLoginFlowID()
 				if err != nil {
 					return err
 				}
-				loginFlow.InternalContext, err = sjson.SetBytes(loginFlow.InternalContext, flow.InternalContextDuplicateCredentialsPath,
+				if loginFlowID != nil {
+					loginFlow, err := e.d.LoginFlowPersister().GetLoginFlow(r.Context(), *loginFlowID)
+					if err != nil {
+						return err
+					}
+					loginFlow.InternalContext, err = sjson.SetBytes(loginFlow.InternalContext, flow.InternalContextDuplicateCredentialsPath,
+						registrationDuplicateCredentials)
+					if err != nil {
+						return err
+					}
+					loginFlow.UI.SetNode(node.NewInputField(
+						"method",
+						node.LoginAndLinkCredentials,
+						node.DefaultGroup,
+						node.InputAttributeTypeSubmit))
+					if err := e.d.LoginFlowPersister().UpdateLoginFlow(r.Context(), loginFlow); err != nil {
+						return err
+					}
+
+				}
+
+				a.InternalContext, err = sjson.SetBytes(a.InternalContext, flow.InternalContextDuplicateCredentialsPath,
 					registrationDuplicateCredentials)
 				if err != nil {
 					return err
 				}
-				if err := e.d.LoginFlowPersister().UpdateLoginFlow(r.Context(), loginFlow); err != nil {
+				a.UI.SetNode(node.NewInputField(
+					"method",
+					node.LoginAndLinkCredentials,
+					node.DefaultGroup,
+					node.InputAttributeTypeSubmit))
+				if err := e.d.RegistrationFlowPersister().UpdateRegistrationFlow(r.Context(), a); err != nil {
 					return err
 				}
-			}
-
-			a.InternalContext, err = sjson.SetBytes(a.InternalContext, flow.InternalContextDuplicateCredentialsPath,
-				registrationDuplicateCredentials)
-			if err != nil {
-				return err
-			}
-			if err := e.d.RegistrationFlowPersister().UpdateRegistrationFlow(r.Context(), a); err != nil {
-				return err
 			}
 
 			return schema.NewDuplicateCredentialsError()

--- a/selfservice/strategy/oidc/.snapshots/TestStrategy-method=TestPopulateLoginMethod.json
+++ b/selfservice/strategy/oidc/.snapshots/TestStrategy-method=TestPopulateLoginMethod.json
@@ -42,6 +42,28 @@
       "attributes": {
         "name": "provider",
         "type": "submit",
+        "value": "secondProvider",
+        "disabled": false,
+        "node_type": "input"
+      },
+      "messages": [],
+      "meta": {
+        "label": {
+          "id": 1010002,
+          "text": "Sign in with secondProvider",
+          "type": "info",
+          "context": {
+            "provider": "secondProvider"
+          }
+        }
+      }
+    },
+    {
+      "type": "input",
+      "group": "oidc",
+      "attributes": {
+        "name": "provider",
+        "type": "submit",
         "value": "invalid-issuer",
         "disabled": false,
         "node_type": "input"

--- a/selfservice/strategy/oidc/.snapshots/TestStrategy-method=TestPopulateSignUpMethod.json
+++ b/selfservice/strategy/oidc/.snapshots/TestStrategy-method=TestPopulateSignUpMethod.json
@@ -42,6 +42,28 @@
       "attributes": {
         "name": "provider",
         "type": "submit",
+        "value": "secondProvider",
+        "disabled": false,
+        "node_type": "input"
+      },
+      "messages": [],
+      "meta": {
+        "label": {
+          "id": 1040002,
+          "text": "Sign up with secondProvider",
+          "type": "info",
+          "context": {
+            "provider": "secondProvider"
+          }
+        }
+      }
+    },
+    {
+      "type": "input",
+      "group": "oidc",
+      "attributes": {
+        "name": "provider",
+        "type": "submit",
         "value": "invalid-issuer",
         "disabled": false,
         "node_type": "input"

--- a/selfservice/strategy/oidc/strategy.go
+++ b/selfservice/strategy/oidc/strategy.go
@@ -449,7 +449,17 @@ func (s *Strategy) handleError(w http.ResponseWriter, r *http.Request, f flow.Fl
 		// Reset all nodes to not confuse users.
 		// This is kinda hacky and will probably need to be updated at some point.
 
+		var loginAndLinkCredentialsNode *node.Node
+		for _, n := range rf.UI.Nodes {
+			if n.ID() == "method" && n.GetValue() == node.LoginAndLinkCredentials {
+				loginAndLinkCredentialsNode = n
+				break
+			}
+		}
 		rf.UI.Nodes = node.Nodes{}
+		if loginAndLinkCredentialsNode != nil {
+			rf.UI.Nodes.Upsert(loginAndLinkCredentialsNode)
+		}
 
 		// Adds the "Continue" button
 		rf.UI.SetCSRF(s.d.GenerateCSRFToken(r))

--- a/selfservice/strategy/oidc/strategy_login.go
+++ b/selfservice/strategy/oidc/strategy_login.go
@@ -96,6 +96,8 @@ func (s *Strategy) processLogin(w http.ResponseWriter, r *http.Request, a *login
 				opts = append(opts, registration.WithFlowReturnTo(a.ReturnTo))
 			}
 
+			opts = append(opts, registration.WithOuterFlow(a.ID))
+
 			// This flow only works for browsers anyways.
 			aa, err := s.d.RegistrationHandler().NewRegistrationFlow(w, r, flow.TypeBrowser, opts...)
 			if err != nil {

--- a/selfservice/strategy/oidc/strategy_settings.go
+++ b/selfservice/strategy/oidc/strategy_settings.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"github.com/ory/x/sqlxx"
 	"net/http"
 	"time"
 
@@ -391,31 +392,10 @@ func (s *Strategy) linkProvider(w http.ResponseWriter, r *http.Request, ctxUpdat
 		return s.handleSettingsError(w, r, ctxUpdate, p, err)
 	}
 
-	var conf identity.CredentialsOIDC
-	creds, err := i.ParseCredentials(s.ID(), &conf)
-	if errors.Is(err, herodot.ErrNotFound) {
-		var err error
-		if creds, err = identity.NewCredentialsOIDC(it, cat, crt, provider.Config().ID, claims.Subject); err != nil {
-			return s.handleSettingsError(w, r, ctxUpdate, p, err)
-		}
-	} else if err != nil {
+	if err := s.linkCredentials(r.Context(), i, it, cat, crt, provider.Config().ID, claims.Subject); err != nil {
 		return s.handleSettingsError(w, r, ctxUpdate, p, err)
-	} else {
-		creds.Identifiers = append(creds.Identifiers, identity.OIDCUniqueID(provider.Config().ID, claims.Subject))
-		conf.Providers = append(conf.Providers, identity.CredentialsOIDCProvider{
-			Subject: claims.Subject, Provider: provider.Config().ID,
-			InitialAccessToken:  cat,
-			InitialRefreshToken: crt,
-			InitialIDToken:      it,
-		})
-
-		creds.Config, err = json.Marshal(conf)
-		if err != nil {
-			return s.handleSettingsError(w, r, ctxUpdate, p, err)
-		}
 	}
 
-	i.Credentials[s.ID()] = *creds
 	if err := s.d.SettingsHookExecutor().PostSettingsHook(w, r, s.SettingsStrategyID(), ctxUpdate, i, settings.WithCallback(func(ctxUpdate *settings.UpdateContext) error {
 		return s.PopulateSettingsMethod(r, ctxUpdate.Session.Identity, ctxUpdate.Flow)
 	})); err != nil {
@@ -502,4 +482,34 @@ func (s *Strategy) handleSettingsError(w http.ResponseWriter, r *http.Request, c
 	}
 
 	return err
+}
+
+func (s *Strategy) Link(ctx context.Context, i *identity.Identity, credentialsConfig sqlxx.JSONRawMessage) error {
+	var credentialsOIDCConfig identity.CredentialsOIDC
+	if err := json.Unmarshal(credentialsConfig, &credentialsOIDCConfig); err != nil {
+		return err
+	}
+	if len(credentialsOIDCConfig.Providers) != 1 {
+		return errors.New("No oidc provider was set")
+	}
+	var credentialsOIDCProvider = credentialsOIDCConfig.Providers[0]
+
+	if err := s.linkCredentials(
+		ctx,
+		i,
+		credentialsOIDCProvider.InitialIDToken,
+		credentialsOIDCProvider.InitialAccessToken,
+		credentialsOIDCProvider.InitialRefreshToken,
+		credentialsOIDCProvider.Provider,
+		credentialsOIDCProvider.Subject,
+	); err != nil {
+		return err
+	}
+
+	options := []identity.ManagerOption{identity.ManagerAllowWriteProtectedTraits}
+	if err := s.d.IdentityManager().Update(ctx, i, options...); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/selfservice/strategy/oidc/strategy_test.go
+++ b/selfservice/strategy/oidc/strategy_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/ory/kratos/ui/node"
 	"io"
 	"net/http"
 	"net/http/cookiejar"
@@ -576,13 +577,14 @@ func TestStrategy(t *testing.T) {
 			require.NoError(t, res.Body.Close())
 			require.NoError(t, err)
 			aue(t, res, body, "An account with the same identifier (email, phone, username, ...) exists already.")
+			assert.Equal(t, node.LoginAndLinkCredentials, gjson.GetBytes(body, "ui.nodes.#(attributes.name==\"method\").attributes.value").String(), "%s", body)
 		})
 
 		var loginFlow *login.Flow
 
 		t.Run("case=should start new login flow", func(t *testing.T) {
 			action := afv(t, r.ID, "valid")
-			res, err := c.PostForm(action, url.Values{"provider": {"valid"}})
+			res, err := c.PostForm(action, url.Values{"method": {node.LoginAndLinkCredentials}})
 			require.NoError(t, err, action)
 			body, err := io.ReadAll(res.Body)
 			require.NoError(t, res.Body.Close())

--- a/selfservice/strategy/oidc/strategy_test.go
+++ b/selfservice/strategy/oidc/strategy_test.go
@@ -75,6 +75,7 @@ func TestStrategy(t *testing.T) {
 		t,
 		conf,
 		newOIDCProvider(t, ts, remotePublic, remoteAdmin, "valid"),
+		newOIDCProvider(t, ts, remotePublic, remoteAdmin, "secondProvider"),
 		oidc.Configuration{
 			Provider:     "generic",
 			ID:           "invalid-issuer",
@@ -363,22 +364,24 @@ func TestStrategy(t *testing.T) {
 		})
 	})
 
+	expectTokens := func(t *testing.T, provider string, body []byte) uuid.UUID {
+		id := uuid.FromStringOrNil(gjson.GetBytes(body, "identity.id").String())
+		i, err := reg.PrivilegedIdentityPool().GetIdentityConfidential(context.Background(), id)
+		require.NoError(t, err)
+		c := i.Credentials[identity.CredentialsTypeOIDC].Config
+		assert.NotEmpty(t, gjson.GetBytes(c, "providers.0.initial_access_token").String())
+		assertx.EqualAsJSONExcept(
+			t,
+			json.RawMessage(fmt.Sprintf(`{"providers": [{"subject":"%s","provider":"%s"}]}`, subject, provider)),
+			json.RawMessage(c),
+			[]string{"providers.0.initial_id_token", "providers.0.initial_access_token", "providers.0.initial_refresh_token"},
+		)
+		return id
+	}
+
 	t.Run("case=register and then login", func(t *testing.T) {
 		subject = "register-then-login@ory.sh"
 		scope = []string{"openid", "offline"}
-
-		expectTokens := func(t *testing.T, provider string, body []byte) {
-			i, err := reg.PrivilegedIdentityPool().GetIdentityConfidential(context.Background(), uuid.FromStringOrNil(gjson.GetBytes(body, "identity.id").String()))
-			require.NoError(t, err)
-			c := i.Credentials[identity.CredentialsTypeOIDC].Config
-			assert.NotEmpty(t, gjson.GetBytes(c, "providers.0.initial_access_token").String())
-			assertx.EqualAsJSONExcept(
-				t,
-				json.RawMessage(fmt.Sprintf(`{"providers": [{"subject":"%s","provider":"%s"}]}`, subject, provider)),
-				json.RawMessage(c),
-				[]string{"providers.0.initial_id_token", "providers.0.initial_access_token", "providers.0.initial_refresh_token"},
-			)
-		}
 
 		t.Run("case=should pass registration", func(t *testing.T) {
 			r := newRegistrationFlow(t, returnTS.URL, time.Minute)
@@ -550,90 +553,155 @@ func TestStrategy(t *testing.T) {
 	})
 
 	t.Run("case=registration should start new login flow if duplicate credentials detected", func(t *testing.T) {
-		subject = "new-login-if-email-exist-with-password-strategy@ory.sh"
-		subject2 := "new-login-subject2@ory.sh"
-		scope = []string{"openid"}
-		password := "lwkj52sdkjf"
 
-		var i *identity.Identity
-		t.Run("case=create password identity", func(t *testing.T) {
-			i = identity.NewIdentity(config.DefaultIdentityTraitsSchemaID)
-			p, err := reg.Hasher(ctx).Generate(ctx, []byte(password))
-			require.NoError(t, err)
-			i.SetCredentials(identity.CredentialsTypePassword, identity.Credentials{
-				Identifiers: []string{subject},
-				Config:      sqlxx.JSONRawMessage(`{"hashed_password":"` + string(p) + `"}`),
-			})
-			i.Traits = identity.Traits(`{"subject":"` + subject + `"}`)
-			require.NoError(t, reg.PrivilegedIdentityPool().CreateIdentity(context.Background(), i))
-
-			i2 := identity.NewIdentity(config.DefaultIdentityTraitsSchemaID)
-			i2.SetCredentials(identity.CredentialsTypePassword, identity.Credentials{
-				Identifiers: []string{subject2},
-				Config:      sqlxx.JSONRawMessage(`{"hashed_password":"` + string(p) + `"}`),
-			})
-			i2.Traits = identity.Traits(`{"subject":"` + subject2 + `"}`)
-			require.NoError(t, reg.PrivilegedIdentityPool().CreateIdentity(context.Background(), i2))
-		})
-
-		c := testhelpers.NewClientWithCookieJar(t, nil, false)
-		r := newLoginFlow(t, returnTS.URL, time.Minute)
-		t.Run("case=should fail login", func(t *testing.T) {
-			action := afv(t, r.ID, "valid")
-			res, err := c.PostForm(action, url.Values{"provider": {"valid"}})
+		loginWithOIDC := func(t *testing.T, c *http.Client, flowID uuid.UUID, provider string) (*http.Response, []byte) {
+			action := afv(t, flowID, provider)
+			res, err := c.PostForm(action, url.Values{"provider": {provider}})
 			require.NoError(t, err, action)
 			body, err := io.ReadAll(res.Body)
 			require.NoError(t, res.Body.Close())
 			require.NoError(t, err)
-			aue(t, res, body, "An account with the same identifier (email, phone, username, ...) exists already.")
-			assert.Equal(t, node.LoginAndLinkCredentials, gjson.GetBytes(body, "ui.nodes.#(attributes.name==\"method\").attributes.value").String(), "%s", body)
-		})
+			return res, body
+		}
 
-		var loginFlow *login.Flow
-
-		t.Run("case=should start new login flow", func(t *testing.T) {
-			action := afv(t, r.ID, "valid")
+		stratNewLoginFlowForLinking := func(t *testing.T, c *http.Client, flowID uuid.UUID) *login.Flow {
+			action := afv(t, flowID, "valid")
 			res, err := c.PostForm(action, url.Values{"method": {node.LoginAndLinkCredentials}})
 			require.NoError(t, err, action)
 			body, err := io.ReadAll(res.Body)
 			require.NoError(t, res.Body.Close())
 			require.NoError(t, err)
 			aue(t, res, body, "New credentials will be linked to existing account after login.")
-			loginFlow, err = reg.LoginFlowPersister().GetLoginFlow(context.Background(), uuid.FromStringOrNil(gjson.GetBytes(body, "id").String()))
+			loginFlow, err := reg.LoginFlowPersister().GetLoginFlow(context.Background(), uuid.FromStringOrNil(gjson.GetBytes(body, "id").String()))
 			assert.NotNil(t, loginFlow, "%s", body)
-		})
+			return loginFlow
+		}
 
-		t.Run("case=should fail login if existing identity identifier doesn't match", func(t *testing.T) {
-			res, err := c.PostForm(loginFlow.UI.Action, url.Values{
-				"csrf_token": {loginFlow.CSRFToken},
-				"method":     {"password"},
-				"identifier": {subject2},
-				"password":   {password}})
-			require.NoError(t, err, loginFlow.UI.Action)
-			body, err := io.ReadAll(res.Body)
-			require.NoError(t, res.Body.Close())
-			require.NoError(t, err)
-			assert.Equal(t, strconv.Itoa(int(text.ErrorValidationLoginLinkedCredentialsDoNotMatch)), gjson.GetBytes(body, "ui.messages.0.id").String(), "%s", body)
-		})
-
-		t.Run("case=should link oidc credentials to existing identity", func(t *testing.T) {
-			res, err := c.PostForm(loginFlow.UI.Action, url.Values{
-				"csrf_token": {loginFlow.CSRFToken},
-				"method":     {"password"},
-				"identifier": {subject},
-				"password":   {password}})
-			require.NoError(t, err, loginFlow.UI.Action)
-			body, err := io.ReadAll(res.Body)
-			require.NoError(t, res.Body.Close())
-			require.NoError(t, err)
+		checkCredentialsLinked := func(res *http.Response, body []byte, identityID uuid.UUID, provider string) {
 			assert.Contains(t, res.Request.URL.String(), returnTS.URL, "%s", body)
 			assert.Equal(t, subject, gjson.GetBytes(body, "identity.traits.subject").String(), "%s", body)
-			i, err = reg.PrivilegedIdentityPool().GetIdentityConfidential(ctx, i.ID)
+			i, err := reg.PrivilegedIdentityPool().GetIdentityConfidential(ctx, identityID)
 			require.NoError(t, err)
 			assert.NotEmpty(t, i.Credentials["oidc"], "%+v", i.Credentials)
-			assert.Equal(t, "valid", gjson.GetBytes(i.Credentials["oidc"].Config, "providers.0.provider").String(),
+			assert.Equal(t, provider, gjson.GetBytes(i.Credentials["oidc"].Config, "providers.0.provider").String(),
 				"%s", string(i.Credentials["oidc"].Config[:]))
-			assert.Equal(t, "oidc", gjson.GetBytes(body, "authentication_methods.0.method").String(), "%s", body)
+			assert.Contains(t, gjson.GetBytes(body, "authentication_methods").String(), "oidc", "%s", body)
+		}
+
+		t.Run("case=second login is password", func(t *testing.T) {
+			subject = "new-login-if-email-exist-with-password-strategy@ory.sh"
+			subject2 := "new-login-subject2@ory.sh"
+			scope = []string{"openid"}
+			password := "lwkj52sdkjf"
+
+			var i *identity.Identity
+			t.Run("case=create password identity", func(t *testing.T) {
+				i = identity.NewIdentity(config.DefaultIdentityTraitsSchemaID)
+				p, err := reg.Hasher(ctx).Generate(ctx, []byte(password))
+				require.NoError(t, err)
+				i.SetCredentials(identity.CredentialsTypePassword, identity.Credentials{
+					Identifiers: []string{subject},
+					Config:      sqlxx.JSONRawMessage(`{"hashed_password":"` + string(p) + `"}`),
+				})
+				i.Traits = identity.Traits(`{"subject":"` + subject + `"}`)
+				require.NoError(t, reg.PrivilegedIdentityPool().CreateIdentity(context.Background(), i))
+
+				i2 := identity.NewIdentity(config.DefaultIdentityTraitsSchemaID)
+				i2.SetCredentials(identity.CredentialsTypePassword, identity.Credentials{
+					Identifiers: []string{subject2},
+					Config:      sqlxx.JSONRawMessage(`{"hashed_password":"` + string(p) + `"}`),
+				})
+				i2.Traits = identity.Traits(`{"subject":"` + subject2 + `"}`)
+				require.NoError(t, reg.PrivilegedIdentityPool().CreateIdentity(context.Background(), i2))
+			})
+
+			c := testhelpers.NewClientWithCookieJar(t, nil, false)
+			r := newLoginFlow(t, returnTS.URL, time.Minute)
+			t.Run("case=should fail login", func(t *testing.T) {
+				res, body := loginWithOIDC(t, c, r.ID, "valid")
+				aue(t, res, body, "An account with the same identifier (email, phone, username, ...) exists already.")
+				assert.Equal(t, node.LoginAndLinkCredentials, gjson.GetBytes(body, "ui.nodes.#(attributes.name==\"method\").attributes.value").String(), "%s", body)
+			})
+
+			var loginFlow *login.Flow
+			t.Run("case=should start new login flow", func(t *testing.T) {
+				loginFlow = stratNewLoginFlowForLinking(t, c, r.ID)
+			})
+
+			t.Run("case=should fail login if existing identity identifier doesn't match", func(t *testing.T) {
+				res, err := c.PostForm(loginFlow.UI.Action, url.Values{
+					"csrf_token": {loginFlow.CSRFToken},
+					"method":     {"password"},
+					"identifier": {subject2},
+					"password":   {password}})
+				require.NoError(t, err, loginFlow.UI.Action)
+				body, err := io.ReadAll(res.Body)
+				require.NoError(t, res.Body.Close())
+				require.NoError(t, err)
+				assert.Equal(t, strconv.Itoa(int(text.ErrorValidationLoginLinkedCredentialsDoNotMatch)), gjson.GetBytes(body, "ui.messages.0.id").String(), "%s", body)
+			})
+
+			t.Run("case=should link oidc credentials to existing identity", func(t *testing.T) {
+				res, err := c.PostForm(loginFlow.UI.Action, url.Values{
+					"csrf_token": {loginFlow.CSRFToken},
+					"method":     {"password"},
+					"identifier": {subject},
+					"password":   {password}})
+				require.NoError(t, err, loginFlow.UI.Action)
+				body, err := io.ReadAll(res.Body)
+				require.NoError(t, res.Body.Close())
+				require.NoError(t, err)
+				checkCredentialsLinked(res, body, i.ID, "valid")
+			})
+		})
+
+		t.Run("case=second login is OIDC", func(t *testing.T) {
+			email1 := "existing-oidc-identity-1@ory.sh"
+			email2 := "existing-oidc-identity-2@ory.sh"
+			scope = []string{"openid", "offline"}
+
+			var identityID uuid.UUID
+			t.Run("case=create OIDC identity", func(t *testing.T) {
+				subject = email1
+				r := newRegistrationFlow(t, returnTS.URL, time.Minute)
+				action := afv(t, r.ID, "secondProvider")
+				res, body := makeRequest(t, "secondProvider", action, url.Values{})
+				ai(t, res, body)
+				identityID = expectTokens(t, "secondProvider", body)
+
+				subject = email2
+				r = newRegistrationFlow(t, returnTS.URL, time.Minute)
+				action = afv(t, r.ID, "valid")
+				res, body = makeRequest(t, "valid", action, url.Values{})
+				ai(t, res, body)
+				expectTokens(t, "valid", body)
+			})
+
+			subject = email1
+			c := testhelpers.NewClientWithCookieJar(t, nil, false)
+			r := newLoginFlow(t, returnTS.URL, time.Minute)
+			t.Run("case=should fail login", func(t *testing.T) {
+				res, body := loginWithOIDC(t, c, r.ID, "valid")
+				aue(t, res, body, "An account with the same identifier (email, phone, username, ...) exists already.")
+				assert.Equal(t, node.LoginAndLinkCredentials, gjson.GetBytes(body, "ui.nodes.#(attributes.name==\"method\").attributes.value").String(), "%s", body)
+			})
+
+			var loginFlow *login.Flow
+			t.Run("case=should start new login flow", func(t *testing.T) {
+				loginFlow = stratNewLoginFlowForLinking(t, c, r.ID)
+			})
+
+			subject = email2
+			t.Run("case=should fail login if existing identity identifier doesn't match", func(t *testing.T) {
+				res, body := loginWithOIDC(t, c, loginFlow.ID, "valid")
+				aue(t, res, body, "Linked credentials do not match.")
+			})
+
+			subject = email1
+			t.Run("case=should link oidc credentials to existing identity", func(t *testing.T) {
+				res, body := loginWithOIDC(t, c, loginFlow.ID, "secondProvider")
+				checkCredentialsLinked(res, body, identityID, "secondProvider")
+			})
 		})
 	})
 

--- a/selfservice/strategy/password/login_test.go
+++ b/selfservice/strategy/password/login_test.go
@@ -466,6 +466,29 @@ func TestCompleteLogin(t *testing.T) {
 		})
 	})
 
+	t.Run("case=should return an error because the linkCredentialsFlow does not exist", func(t *testing.T) {
+		identifier, pwd := x.NewUUID().String(), "password"
+		createIdentity(ctx, reg, t, identifier, pwd)
+
+		var check = func(t *testing.T, actual string) {
+			assert.Equal(t, int64(http.StatusNotFound), gjson.Get(actual, "code").Int(), "%s", actual)
+			assert.Equal(t, "Not Found", gjson.Get(actual, "status").String(), "%s", actual)
+			assert.Contains(t, gjson.Get(actual, "message").String(), "Unable to locate the resource", "%s", actual)
+		}
+
+		var values = func(v url.Values) {
+			v.Set("identifier", identifier)
+			v.Set("password", pwd)
+			v.Set("linkCredentialsFlow", "00000000-0000-0000-0000-000000000000")
+		}
+
+		t.Run("type=api", func(t *testing.T) {
+			actual := testhelpers.SubmitLoginForm(t, true, nil, publicTS, values,
+				false, false, http.StatusNotFound, publicTS.URL+login.RouteSubmitFlow)
+			check(t, gjson.Get(actual, "error").Raw)
+		})
+	})
+
 	t.Run("should pass with real request", func(t *testing.T) {
 		identifier, pwd := x.NewUUID().String(), "password"
 		createIdentity(ctx, reg, t, identifier, pwd)

--- a/text/id.go
+++ b/text/id.go
@@ -23,6 +23,7 @@ const (
 	InfoSelfServiceLoginContinueWebAuthn                         // 1010011
 	InfoSelfServiceLoginWebAuthnPasswordless                     // 1010012
 	InfoSelfServiceLoginContinue                                 // 1010013
+	InfoSelfServiceLoginLinkCredentials                          // 1010014
 )
 
 const (

--- a/text/id.go
+++ b/text/id.go
@@ -112,13 +112,14 @@ const (
 )
 
 const (
-	ErrorValidationLogin                       ID = 4010000 + iota // 4010000
-	ErrorValidationLoginFlowExpired                                // 4010001
-	ErrorValidationLoginNoStrategyFound                            // 4010002
-	ErrorValidationRegistrationNoStrategyFound                     // 4010003
-	ErrorValidationSettingsNoStrategyFound                         // 4010004
-	ErrorValidationRecoveryNoStrategyFound                         // 4010005
-	ErrorValidationVerificationNoStrategyFound                     // 4010006
+	ErrorValidationLogin                            ID = 4010000 + iota // 4010000
+	ErrorValidationLoginFlowExpired                                     // 4010001
+	ErrorValidationLoginNoStrategyFound                                 // 4010002
+	ErrorValidationRegistrationNoStrategyFound                          // 4010003
+	ErrorValidationSettingsNoStrategyFound                              // 4010004
+	ErrorValidationRecoveryNoStrategyFound                              // 4010005
+	ErrorValidationVerificationNoStrategyFound                          // 4010006
+	ErrorValidationLoginLinkedCredentialsDoNotMatch                     // 4010007
 )
 
 const (

--- a/text/message_login.go
+++ b/text/message_login.go
@@ -192,3 +192,11 @@ func NewInfoSelfServiceLoginLinkCredentials() *Message {
 		Context: context(nil),
 	}
 }
+
+func NewErrorValidationLoginLinkedCredentialsDoNotMatch() *Message {
+	return &Message{
+		ID:   ErrorValidationLoginLinkedCredentialsDoNotMatch,
+		Text: "Linked credentials do not match.",
+		Type: Error,
+	}
+}

--- a/text/message_login.go
+++ b/text/message_login.go
@@ -183,3 +183,12 @@ func NewInfoSelfServiceLoginContinue() *Message {
 		Type: Info,
 	}
 }
+
+func NewInfoSelfServiceLoginLinkCredentials() *Message {
+	return &Message{
+		ID:      InfoSelfServiceLoginLinkCredentials,
+		Text:    "New credentials will be linked to existing account after login.",
+		Type:    Info,
+		Context: context(nil),
+	}
+}

--- a/ui/node/identifiers.go
+++ b/ui/node/identifiers.go
@@ -28,3 +28,7 @@ const (
 	WebAuthnRemove              = "webauthn_remove"
 	WebAuthnScript              = "webauthn_script"
 )
+
+const (
+	LoginAndLinkCredentials = "login_and_link_credentials"
+)


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

When user tries to login with OIDC for the first time but has already registered before with email/password a credentials identifier conflict may be detected by Kratos. In this case user needs to login with email/password first and then link OIDC credentials on a settings screen.
This PR simplifies UX and allows user to link OIDC credentials to existing account right in the login flow, without
switching to settings flow.

## Related issue(s)
#2727 

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [ x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [ x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [ x] I have read the [security policy](../security/policy).
- [ x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

