### PR TITLE
feat: add RecoveryURL to recovery code email template data

### DIFF
--- a/courier/email_templates_test.go
+++ b/courier/email_templates_test.go
@@ -43,7 +43,7 @@ func TestNewEmailTemplateFromMessage(t *testing.T) {
 	for tmplType, expectedTmpl := range map[courier.TemplateType]courier.EmailTemplate{
 		courier.TypeRecoveryInvalid:         email.NewRecoveryInvalid(reg, &email.RecoveryInvalidModel{To: "foo"}),
 		courier.TypeRecoveryValid:           email.NewRecoveryValid(reg, &email.RecoveryValidModel{To: "bar", RecoveryURL: "http://foo.bar"}),
-		courier.TypeRecoveryCodeValid:       email.NewRecoveryCodeValid(reg, &email.RecoveryCodeValidModel{To: "bar", RecoveryCode: "12345678"}),
+		courier.TypeRecoveryCodeValid:       email.NewRecoveryCodeValid(reg, &email.RecoveryCodeValidModel{To: "bar", RecoveryURL: "http://foo.bar", RecoveryCode: "12345678"}),
 		courier.TypeRecoveryCodeInvalid:     email.NewRecoveryCodeInvalid(reg, &email.RecoveryCodeInvalidModel{To: "bar"}),
 		courier.TypeVerificationInvalid:     email.NewVerificationInvalid(reg, &email.VerificationInvalidModel{To: "baz"}),
 		courier.TypeVerificationValid:       email.NewVerificationValid(reg, &email.VerificationValidModel{To: "faz", VerificationURL: "http://bar.foo"}),

--- a/courier/template/courier/builtin/templates/recovery_code/valid/email.body.gotmpl
+++ b/courier/template/courier/builtin/templates/recovery_code/valid/email.body.gotmpl
@@ -3,3 +3,7 @@ Hi,
 please recover access to your account by entering the following code:
 
 {{ .RecoveryCode }}
+
+You can reopen the recovery page by following the link:
+
+{{ .RecoveryURL }}

--- a/courier/template/courier/builtin/templates/recovery_code/valid/email.body.plaintext.gotmpl
+++ b/courier/template/courier/builtin/templates/recovery_code/valid/email.body.plaintext.gotmpl
@@ -3,3 +3,7 @@ Hi,
 please recover access to your account by entering the following code:
 
 {{ .RecoveryCode }}
+
+You can reopen the recovery page by following the link:
+
+{{ .RecoveryURL }}

--- a/courier/template/email/recovery_code_valid.go
+++ b/courier/template/email/recovery_code_valid.go
@@ -19,6 +19,7 @@ type (
 	}
 	RecoveryCodeValidModel struct {
 		To           string
+		RecoveryURL  string
 		RecoveryCode string
 		Identity     map[string]interface{}
 	}


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

In some cases we may want to include a link to the recovery UI page (including the flow ID) in the recovery email. That may be useful if the user has closed the page, for example. (In my particular case recovery is triggered by a backend process, so when the user receives the email, they are not on the recovery page and there is no way to pass on the flow ID to them.)

The link added to the template data as `.RecoveryURL` is the exact same link as the one generated by `POST /admin/recovery/code`.

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
