### PR TITLE
ci: update tags in quickstart before release

### DIFF
--- a/.orycli.yml
+++ b/.orycli.yml
@@ -5,3 +5,4 @@ pre_release_hooks:
   - ./script/render-schemas.sh
   - git config --unset user.email
   - git config --unset user.name
+  - make update-quickstart

--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,11 @@ test-update-snapshots:
 	UPDATE_SNAPSHOTS=true go test -p 4 -tags sqlite -short ./...
 
 .PHONY: post-release
-post-release: .bin/yq
+post-release:
+	echo "nothing to do here"
+
+.PHONY: update-quickstart
+update-quickstart: .bin/yq
 	cat quickstart.yml | yq '.services.kratos.image = "oryd/kratos:'$$DOCKER_TAG'"' | sponge quickstart.yml
 	cat quickstart.yml | yq '.services.kratos-migrate.image = "oryd/kratos:'$$DOCKER_TAG'"' | sponge quickstart.yml
 	cat quickstart.yml | yq '.services.kratos-selfservice-ui-node.image = "oryd/kratos-selfservice-ui-node:'$$DOCKER_TAG'"' | sponge quickstart.yml


### PR DESCRIPTION
Currently we update them after release, which means that the quickstart as described in the docs does not work:

```
git checkout v0.13.0
grep "oryd/kratos" quickstart.yml 
    image: oryd/kratos:v0.11.1
    image: oryd/kratos-selfservice-ui-node:v0.11.1
    image: oryd/kratos:v0.11.1
```

which in turn leads to issues like #3267 