### PR TITLE
fix: use the correct redirect_uri for linkedin social login

### DIFF
--- a/selfservice/strategy/oidc/provider_linkedin.go
+++ b/selfservice/strategy/oidc/provider_linkedin.go
@@ -88,7 +88,7 @@ func (l *ProviderLinkedIn) oauth2(ctx context.Context) *oauth2.Config {
 		ClientSecret: l.config.ClientSecret,
 		Endpoint:     linkedin.Endpoint,
 		Scopes:       l.config.Scope,
-		RedirectURL:  l.config.Redir(l.reg.Config().SelfPublicURL(ctx)),
+		RedirectURL:  l.config.Redir(l.reg.Config().OIDCRedirectURIBase(ctx)),
 	}
 }
 


### PR DESCRIPTION
LinkedIn Social Login shows the oryapis.com URL as the redirect target in the UI to the user, even when a custom domain is configured. 
This works correctly on other social login providers. This PR points the flow to the right domain.

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

Reported in Community Slack