### PR TITLE
feat: implement `crypt(3)` hashers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/duo-labs/webauthn v0.0.0-20220330035159-03696f3d4499
 	github.com/fatih/color v1.13.0
 	github.com/ghodss/yaml v1.0.0
+	github.com/go-crypt/crypt v0.2.9
 	github.com/go-errors/errors v1.0.1
 	github.com/go-openapi/strfmt v0.21.3
 	github.com/go-playground/validator/v10 v10.4.1
@@ -153,6 +154,7 @@ require (
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/fullstorydev/grpcurl v1.8.1 // indirect
 	github.com/fxamacker/cbor/v2 v2.4.0 // indirect
+	github.com/go-crypt/x v0.2.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/analysis v0.21.4 // indirect
@@ -332,7 +334,7 @@ require (
 	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 // indirect
 	golang.org/x/mod v0.10.0 // indirect
-	golang.org/x/sys v0.7.0 // indirect
+	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/term v0.6.0 // indirect
 	golang.org/x/text v0.8.0 // indirect
 	golang.org/x/time v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -377,6 +377,10 @@ github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49P
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
+github.com/go-crypt/crypt v0.2.9 h1:5gWWTId2Qyqs9ROIsegt5pnqo9wUSRLbhpkR6JSftjg=
+github.com/go-crypt/crypt v0.2.9/go.mod h1:JjzdTYE2mArb6nBoIvvpF7o46/rK/1pfmlArCRMTFUk=
+github.com/go-crypt/x v0.2.1 h1:OGw78Bswme9lffCOX6tyuC280ouU5391glsvThMtM5U=
+github.com/go-crypt/x v0.2.1/go.mod h1:Q/y9rms7yw4/1CavBlNGn0Itg4HqwNpe1N9FX0TxXrc=
 github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -1858,8 +1862,8 @@ golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20221010170243-090e33056c14/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
-golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
+golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20191110171634-ad39bd3f0407/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/hash/hash_comparator.go
+++ b/hash/hash_comparator.go
@@ -66,7 +66,7 @@ func Compare(ctx context.Context, password []byte, hash []byte) error {
 func CompareMD5Crypt(_ context.Context, password []byte, hash []byte) error {
 	decoder := crypt.NewDecoder()
 
-	if err := md5crypt.RegisterDecoder(decoder); err != nil {
+	if err := md5crypt.RegisterDecoderCommon(decoder); err != nil {
 		return err
 	}
 

--- a/hash/hasher_test.go
+++ b/hash/hasher_test.go
@@ -365,4 +365,52 @@ func TestCompare(t *testing.T) {
 		assert.Nil(t, hash.CompareMD5(context.Background(), []byte("ory"), []byte("$md5$pf=e1BBU1NXT1JEfXtTQUxUfSQ/$MTIzNDU2Nzg5$8PhwWanVRnpJAFK4NUjR0w=="))) // pf={PASSWORD}{SALT}$? salt=123456789
 		assert.Error(t, hash.CompareMD5(context.Background(), []byte("ory1"), []byte("$md5$pf=e1BBU1NXT1JEfXtTQUxUfSQ/$MTIzNDU2Nzg5$8PhwWanVRnpJAFK4NUjR0w==")))
 	})
+
+	t.Run("md5crypt", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$1$TVEiiKNb$SN6/pUaRQS/E8Jh46As2C/")))
+		assert.Nil(t, hash.CompareMD5Crypt(context.Background(), []byte("test"), []byte("$1$TVEiiKNb$SN6/pUaRQS/E8Jh46As2C/")))
+		assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$1$$whuMjZj.HMFoaTaZRRtkO0")))
+		assert.Error(t, hash.Compare(context.Background(), []byte("test"), []byte("$1$xWMlm2eL$GGTOpgZu4p2k6ORprAu3b.")))
+
+		assert.Nil(t, hash.Compare(context.Background(), []byte("ory"), []byte("$1$xWMlm2eL$GGTOpgZu4p2k6ORprAu3b.")))
+		assert.Nil(t, hash.CompareMD5Crypt(context.Background(), []byte("ory"), []byte("$1$xWMlm2eL$GGTOpgZu4p2k6ORprAu3b.")))
+		assert.Error(t, hash.Compare(context.Background(), []byte("ory"), []byte("$1$E7zjruqF$RTglYR1CzBHwwiTk9nVzx1")))
+
+		assert.ErrorIs(t, hash.Compare(context.Background(), []byte("ory"), []byte("$1$$")), hash.ErrMismatchedHashAndPassword)
+		assert.Error(t, hash.Compare(context.Background(), []byte("ory"), []byte("$1$$$")))
+		// per crypt(5), `md5crypt` can be run without a salt, but the salt section must still be present
+		assert.Error(t, hash.Compare(context.Background(), []byte("test"), []byte("$1$whuMjZj.HMFoaTaZRRtkO0")), "md5crypt decode error: provided encoded hash has an invalid format")
+	})
+
+	t.Run("sha256crypt", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$5$rounds=535000$05R.9KB6UC2kLI3w$Q/zslzx./JjkAVPTwp6th7nW5l7JU91Gte/UmIh.U78")))
+		assert.Nil(t, hash.CompareSHA256Crypt(context.Background(), []byte("test"), []byte("$5$rounds=535000$05R.9KB6UC2kLI3w$Q/zslzx./JjkAVPTwp6th7nW5l7JU91Gte/UmIh.U78")))
+		assert.Error(t, hash.Compare(context.Background(), []byte("test"), []byte("$5$rounds=535000$awpcR7lDlnK/S7WE$vHU7KkQwyjfGz6u4MUi7.lH9htK/l63HloTsX1ZMz.3")))
+
+		assert.Nil(t, hash.Compare(context.Background(), []byte("ory"), []byte("$5$rounds=535000$awpcR7lDlnK/S7WE$vHU7KkQwyjfGz6u4MUi7.lH9htK/l63HloTsX1ZMz.3")))
+		assert.Nil(t, hash.CompareSHA256Crypt(context.Background(), []byte("ory"), []byte("$5$rounds=535000$awpcR7lDlnK/S7WE$vHU7KkQwyjfGz6u4MUi7.lH9htK/l63HloTsX1ZMz.3")))
+		assert.Error(t, hash.Compare(context.Background(), []byte("ory"), []byte("$5$rounds=535000$T95kH8e37IGVdxzJ$gLeaNa6qRog.bx4Bzqp63ceWItH6nSAal6c3WmT5GHB")))
+
+		assert.Error(t, hash.Compare(context.Background(), []byte("ory"), []byte("$5$$")), "shacrypt decode error: provided encoded hash has an invalid format")
+		assert.Error(t, hash.Compare(context.Background(), []byte("ory"), []byte("$5$$$")))
+	})
+
+	t.Run("sha512crypt", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Nil(t, hash.Compare(context.Background(), []byte("test"), []byte("$6$rounds=656000$3LVbIAVxR//cRajw$uuNasMW.RYxlGzIRFU1Was70BPSa933AjxhZIGJdJBOlqJAHlgqa0yuiuq5JHF/ryNGryJkj87G9i3G2HPSXg1")))
+		assert.Nil(t, hash.CompareSHA512Crypt(context.Background(), []byte("test"), []byte("$6$rounds=656000$3LVbIAVxR//cRajw$uuNasMW.RYxlGzIRFU1Was70BPSa933AjxhZIGJdJBOlqJAHlgqa0yuiuq5JHF/ryNGryJkj87G9i3G2HPSXg1")))
+		assert.Error(t, hash.Compare(context.Background(), []byte("test"), []byte("$5$rounds=535000$awpcR7lDlnK/S7WE$vHU7KkQwyjfGz6u4MUi7.lH9htK/l63HloTsX1ZMz.3")))
+
+		assert.Nil(t, hash.Compare(context.Background(), []byte("ory"), []byte("$6$rounds=656000$0baQbxBrfpKqvizk$Q9cYk1MeNAlECPgpG3jjfNI2DumLqd0yHbxzLdxiX6nsSD5i9n0awcbiCf8R5DzpIYxeBPznPcb1wtzlgUKtH0")))
+		assert.Nil(t, hash.CompareSHA512Crypt(context.Background(), []byte("ory"), []byte("$6$rounds=656000$0baQbxBrfpKqvizk$Q9cYk1MeNAlECPgpG3jjfNI2DumLqd0yHbxzLdxiX6nsSD5i9n0awcbiCf8R5DzpIYxeBPznPcb1wtzlgUKtH0")))
+		assert.Error(t, hash.Compare(context.Background(), []byte("ory"), []byte("$6$rounds=656000$hNcDLFO63bkYVDZf$Mt9dhH0xqfxWZ6Pu8zXw.Ku5f15IRTweuaDcUc.ObXWGn7B1h8YIWLmArZd8psd2mrUVswCXLAVptmISr.8iI/")))
+
+		assert.Error(t, hash.Compare(context.Background(), []byte("ory"), []byte("$6$$")), "shacrypt decode error: provided encoded hash has an invalid format")
+		assert.Error(t, hash.Compare(context.Background(), []byte("ory"), []byte("$6$$$")))
+	})
 }


### PR DESCRIPTION
Implement `crypt(3)` based hashers.

This PR implements `md5crypt`, `sha256crypt`, `sha512crypt`, which are considered legacy (like `md5`), but are used in legacy systems looking to convert to ory. They use the existing format of `crypt(5)` (which is compliant to PHC).

## Related issue(s)

* #3291

## Checklist


- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
