### PR TITLE
fix: return HTTP 400 instead of 500 for bad query parameters

### DIFF
--- a/x/http_secure_redirect.go
+++ b/x/http_secure_redirect.go
@@ -125,7 +125,7 @@ func SecureRedirectTo(r *http.Request, defaultReturnTo *url.URL, opts ...SecureR
 
 	returnTo, err = url.Parse(rawReturnTo)
 	if err != nil {
-		return nil, errors.WithStack(herodot.ErrInternalServerError.WithWrap(err).WithReasonf("Unable to parse the return_to query parameter as an URL: %s", err))
+		return nil, errors.WithStack(herodot.ErrBadRequest.WithWrap(err).WithReasonf("Unable to parse the return_to query parameter as an URL: %s", err))
 	}
 
 	returnTo.Host = stringsx.Coalesce(returnTo.Host, o.defaultReturnTo.Host)


### PR DESCRIPTION
Fixes [this alert](https://grafana-europe-cmc.production.oryapis.com/explore?orgId=1&left=%7B%22datasource%22:%22ory_datasource_loki%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bapp%3D%5C%22kratos%5C%22,source_cluster%3D%5C%22OWC%5C%22,source_location%3D%5C%22europe-west1%5C%22%7D%20%7C%20json%20%7C%20__error__%21%3D%5C%22JSONParserErr%5C%22,%20level%3D%60error%60,%20http_response_status_code%3D~%605..%60%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22ory_datasource_loki%22%7D,%22editorMode%22:%22code%22,%22maxLines%22:200%7D%5D,%22range%22:%7B%22from%22:%221687343471791%22,%22to%22:%221687347071791%22%7D%7D).