### PR TITLE
fix: Run post recovery hook before storing the session and issuing a cookie

### DIFF
--- a/selfservice/strategy/code/strategy_recovery.go
+++ b/selfservice/strategy/code/strategy_recovery.go
@@ -373,6 +373,10 @@ func (s *Strategy) recoveryIssueSession(w http.ResponseWriter, r *http.Request, 
 		return s.retryRecoveryFlowWithError(w, r, f.Type, err)
 	}
 
+	if err := s.deps.RecoveryExecutor().PostRecoveryHook(w, r, f, sess); err != nil {
+		return s.retryRecoveryFlowWithError(w, r, f.Type, err)
+	}
+
 	// TODO: How does this work with Mobile?
 	if err := s.deps.SessionManager().UpsertAndIssueCookie(ctx, w, r, sess); err != nil {
 		return s.retryRecoveryFlowWithError(w, r, f.Type, err)
@@ -391,10 +395,6 @@ func (s *Strategy) recoveryIssueSession(w http.ResponseWriter, r *http.Request, 
 	sf.RequestURL, err = x.TakeOverReturnToParameter(f.RequestURL, sf.RequestURL, returnTo)
 	if err != nil {
 		return s.retryRecoveryFlowWithError(w, r, flow.TypeBrowser, err)
-	}
-
-	if err := s.deps.RecoveryExecutor().PostRecoveryHook(w, r, f, sess); err != nil {
-		return s.retryRecoveryFlowWithError(w, r, f.Type, err)
 	}
 
 	config := s.deps.Config()

--- a/selfservice/strategy/code/strategy_recovery_test.go
+++ b/selfservice/strategy/code/strategy_recovery_test.go
@@ -1055,6 +1055,72 @@ func TestRecovery(t *testing.T) {
 		assert.Empty(t, gjson.Get(body, "ui.nodes.#(attributes.name==code).messages").Array())
 		testhelpers.AssertMessage(t, []byte(body), "The recovery code is invalid or has already been used. Please try again.")
 	})
+
+	t.Run("description=should recover if post recovery hook is successful", func(t *testing.T) {
+		conf.MustSet(ctx, config.HookStrategyKey(config.ViperKeySelfServiceRecoveryAfter, config.HookGlobal), []config.SelfServiceHook{{Name: "err", Config: []byte(`{}`)}})
+		t.Cleanup(func() {
+			conf.MustSet(ctx, config.HookStrategyKey(config.ViperKeySelfServiceRecoveryAfter, config.HookGlobal), nil)
+		})
+
+		recoveryEmail := testhelpers.RandomEmail()
+		createIdentityToRecover(t, reg, recoveryEmail)
+
+		cl := testhelpers.NewClientWithCookies(t)
+		body := expectSuccessfulRecovery(t, cl, RecoveryFlowTypeBrowser, func(v url.Values) {
+			v.Set("email", recoveryEmail)
+		})
+
+		message := testhelpers.CourierExpectMessage(t, reg, recoveryEmail, "Recover access to your account")
+		recoveryCode := testhelpers.CourierExpectCodeInMessage(t, message, 1)
+
+		action := gjson.Get(body, "ui.action").String()
+		require.NotEmpty(t, action)
+		assert.Equal(t, recoveryEmail, gjson.Get(body, "ui.nodes.#(attributes.name==email).attributes.value").String())
+
+		cl.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+
+		body = submitRecoveryCode(t, cl, body, RecoveryFlowTypeBrowser, recoveryCode, http.StatusSeeOther)
+
+		require.Len(t, cl.Jar.Cookies(urlx.ParseOrPanic(public.URL)), 2)
+		cookies := spew.Sdump(cl.Jar.Cookies(urlx.ParseOrPanic(public.URL)))
+		assert.Contains(t, cookies, "ory_kratos_session")
+	})
+
+	t.Run("description=should not be able to recover if post recovery hook fails", func(t *testing.T) {
+		conf.MustSet(ctx, config.HookStrategyKey(config.ViperKeySelfServiceRecoveryAfter, config.HookGlobal), []config.SelfServiceHook{{Name: "err", Config: []byte(`{"ExecutePostRecoveryHook": "err"}`)}})
+		t.Cleanup(func() {
+			conf.MustSet(ctx, config.HookStrategyKey(config.ViperKeySelfServiceRecoveryAfter, config.HookGlobal), nil)
+		})
+
+		recoveryEmail := testhelpers.RandomEmail()
+		createIdentityToRecover(t, reg, recoveryEmail)
+
+		cl := testhelpers.NewClientWithCookies(t)
+		body := expectSuccessfulRecovery(t, cl, RecoveryFlowTypeBrowser, func(v url.Values) {
+			v.Set("email", recoveryEmail)
+		})
+
+		message := testhelpers.CourierExpectMessage(t, reg, recoveryEmail, "Recover access to your account")
+		recoveryCode := testhelpers.CourierExpectCodeInMessage(t, message, 1)
+
+		action := gjson.Get(body, "ui.action").String()
+		require.NotEmpty(t, action)
+		assert.Equal(t, recoveryEmail, gjson.Get(body, "ui.nodes.#(attributes.name==email).attributes.value").String())
+
+		cl.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+
+		initialFlowId := gjson.Get(body, "id")
+		body = submitRecoveryCode(t, cl, body, RecoveryFlowTypeBrowser, recoveryCode, http.StatusSeeOther)
+		assert.NotEqual(t, gjson.Get(body, "id"), initialFlowId)
+
+		require.Len(t, cl.Jar.Cookies(urlx.ParseOrPanic(public.URL)), 1)
+		cookies := spew.Sdump(cl.Jar.Cookies(urlx.ParseOrPanic(public.URL)))
+		assert.NotContains(t, cookies, "ory_kratos_session")
+	})
 }
 
 func TestDisabledStrategy(t *testing.T) {

--- a/selfservice/strategy/link/strategy_recovery.go
+++ b/selfservice/strategy/link/strategy_recovery.go
@@ -296,6 +296,10 @@ func (s *Strategy) recoveryIssueSession(w http.ResponseWriter, r *http.Request, 
 		return s.retryRecoveryFlowWithError(w, r, flow.TypeBrowser, err)
 	}
 
+	if err := s.d.RecoveryExecutor().PostRecoveryHook(w, r, f, sess); err != nil {
+		return s.retryRecoveryFlowWithError(w, r, flow.TypeBrowser, err)
+	}
+
 	if err := s.d.SessionManager().UpsertAndIssueCookie(r.Context(), w, r, sess); err != nil {
 		return s.retryRecoveryFlowWithError(w, r, flow.TypeBrowser, err)
 	}
@@ -313,10 +317,6 @@ func (s *Strategy) recoveryIssueSession(w http.ResponseWriter, r *http.Request, 
 
 	sf.RequestURL, err = x.TakeOverReturnToParameter(f.RequestURL, sf.RequestURL, returnTo)
 	if err != nil {
-		return s.retryRecoveryFlowWithError(w, r, flow.TypeBrowser, err)
-	}
-
-	if err := s.d.RecoveryExecutor().PostRecoveryHook(w, r, f, sess); err != nil {
 		return s.retryRecoveryFlowWithError(w, r, flow.TypeBrowser, err)
 	}
 


### PR DESCRIPTION
If the response to a flow-interrupting, after recovery webhook is `4xx` or `5xx`, the recovery flow should fail and no session should be issued.

## Related issue(s)

Fixes #3193

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).