### PR TITLE
fix: false-positives for requiring re-authentication on update

### DIFF
--- a/identity/credentials.go
+++ b/identity/credentials.go
@@ -237,7 +237,14 @@ func CredentialsEqual(a, b map[CredentialsType]Credentials) bool {
 			return false
 		}
 
-		if !reflect.DeepEqual(expect.Identifiers, actual.Identifiers) {
+		expectIdentifiers, actualIdentifiers := make(map[string]struct{}, len(expect.Identifiers)), make(map[string]struct{}, len(actual.Identifiers))
+		for _, i := range expect.Identifiers {
+			expectIdentifiers[i] = struct{}{}
+		}
+		for _, i := range actual.Identifiers {
+			actualIdentifiers[i] = struct{}{}
+		}
+		if !reflect.DeepEqual(expectIdentifiers, actualIdentifiers) {
 			return false
 		}
 	}

--- a/identity/manager_test.go
+++ b/identity/manager_test.go
@@ -6,9 +6,10 @@ package identity_test
 import (
 	"context"
 	"fmt"
-	"github.com/ory/x/pointerx"
 	"testing"
 	"time"
+
+	"github.com/ory/x/pointerx"
 
 	"github.com/gofrs/uuid"
 


### PR DESCRIPTION
closes #1889 

Somehow I could not reproduce the second case with the verified address, probably it is fixed already by accident. Added a test though.