### PR TITLE
feat: provide login hints when registration fails due to duplicate credentials/addresses

### DIFF
--- a/cmd/clidoc/main.go
+++ b/cmd/clidoc/main.go
@@ -97,6 +97,7 @@ func init() {
 		"NewErrorValidationPasswordPolicyViolation":               text.NewErrorValidationPasswordPolicyViolation("{reason}"),
 		"NewErrorValidationInvalidCredentials":                    text.NewErrorValidationInvalidCredentials(),
 		"NewErrorValidationDuplicateCredentials":                  text.NewErrorValidationDuplicateCredentials(),
+		"NewErrorValidationDuplicateCredentialsCustomMessage":     text.NewErrorValidationDuplicateCredentialsCustomMessage("{reason}"),
 		"NewErrorValidationDuplicateCredentialsOnOIDCLink":        text.NewErrorValidationDuplicateCredentialsOnOIDCLink(),
 		"NewErrorValidationTOTPVerifierWrong":                     text.NewErrorValidationTOTPVerifierWrong(),
 		"NewErrorValidationLookupAlreadyUsed":                     text.NewErrorValidationLookupAlreadyUsed(),

--- a/cmd/clidoc/main.go
+++ b/cmd/clidoc/main.go
@@ -97,7 +97,7 @@ func init() {
 		"NewErrorValidationPasswordPolicyViolation":               text.NewErrorValidationPasswordPolicyViolation("{reason}"),
 		"NewErrorValidationInvalidCredentials":                    text.NewErrorValidationInvalidCredentials(),
 		"NewErrorValidationDuplicateCredentials":                  text.NewErrorValidationDuplicateCredentials(),
-		"NewErrorValidationDuplicateCredentialsCustomMessage":     text.NewErrorValidationDuplicateCredentialsCustomMessage("{reason}"),
+		"NewErrorValidationDuplicateCredentialsWithHints":         text.NewErrorValidationDuplicateCredentialsWithHints("{reason}", nil, nil, ""),
 		"NewErrorValidationDuplicateCredentialsOnOIDCLink":        text.NewErrorValidationDuplicateCredentialsOnOIDCLink(),
 		"NewErrorValidationTOTPVerifierWrong":                     text.NewErrorValidationTOTPVerifierWrong(),
 		"NewErrorValidationLookupAlreadyUsed":                     text.NewErrorValidationLookupAlreadyUsed(),

--- a/driver/config/config.go
+++ b/driver/config/config.go
@@ -117,6 +117,7 @@ const (
 	ViperKeySelfServiceBrowserDefaultReturnTo                = "selfservice." + DefaultBrowserReturnURL
 	ViperKeyURLsAllowedReturnToDomains                       = "selfservice.allowed_return_urls"
 	ViperKeySelfServiceRegistrationEnabled                   = "selfservice.flows.registration.enabled"
+	ViperKeySelfServiceRegistrationLoginHints                = "selfservice.flows.registration.login_hints"
 	ViperKeySelfServiceRegistrationUI                        = "selfservice.flows.registration.ui_url"
 	ViperKeySelfServiceRegistrationRequestLifespan           = "selfservice.flows.registration.lifespan"
 	ViperKeySelfServiceRegistrationAfter                     = "selfservice.flows.registration.after"
@@ -626,6 +627,10 @@ func (p *Config) ClientHTTPPrivateIPExceptionURLs(ctx context.Context) []string 
 
 func (p *Config) SelfServiceFlowRegistrationEnabled(ctx context.Context) bool {
 	return p.GetProvider(ctx).Bool(ViperKeySelfServiceRegistrationEnabled)
+}
+
+func (p *Config) SelfServiceFlowRegistrationLoginHints(ctx context.Context) bool {
+	return p.GetProvider(ctx).Bool(ViperKeySelfServiceRegistrationLoginHints)
 }
 
 func (p *Config) SelfServiceFlowVerificationEnabled(ctx context.Context) bool {

--- a/embedx/config.schema.json
+++ b/embedx/config.schema.json
@@ -1196,7 +1196,7 @@
                 },
                 "login_hints": {
                   "type": "boolean",
-                  "title": "EXPERIMENTAL: Provide Login Hints on Failed Registration",
+                  "title": "Provide Login Hints on Failed Registration",
                   "description": "When registration fails because an account with the given credentials or addresses previously signed up, provide login hints about available methods to sign in to the user.",
                   "default": false
                 },

--- a/embedx/config.schema.json
+++ b/embedx/config.schema.json
@@ -1194,6 +1194,12 @@
                   "description": "If set to true will enable [User Registration](https://www.ory.sh/kratos/docs/self-service/flows/user-registration/).",
                   "default": true
                 },
+                "login_hints": {
+                  "type": "boolean",
+                  "title": "EXPERIMENTAL: Provide Login Hints on Failed Registration",
+                  "description": "When registration fails because an account with the given credentials or addresses previously signed up, provide login hints about available methods to sign in to the user.",
+                  "default": false
+                },
                 "ui_url": {
                   "title": "Registration UI URL",
                   "description": "URL where the Registration UI is hosted. Check the [reference implementation](https://github.com/ory/kratos-selfservice-ui-node).",

--- a/identity/handler_test.go
+++ b/identity/handler_test.go
@@ -1469,6 +1469,7 @@ func TestHandler(t *testing.T) {
 		require.NoError(t, reg.PrivilegedIdentityPool().CreateIdentities(context.Background(), toCreate...))
 
 		for _, perPage := range []int{10, 50, 100, 500} {
+			perPage := perPage
 			t.Run(fmt.Sprintf("perPage=%d", perPage), func(t *testing.T) {
 				t.Parallel()
 				body, res := getFull(t, ts, fmt.Sprintf("/identities?per_page=%d", perPage), http.StatusOK)
@@ -1524,7 +1525,7 @@ func TestHandler(t *testing.T) {
 				assert.Equal(t, count/perPage, pages)
 			})
 
-			t.Run("using üage pagination", func(t *testing.T) {
+			t.Run("using page pagination", func(t *testing.T) {
 				knownIDs := make(map[string]struct{})
 				var isLast bool
 				var pages int

--- a/identity/manager.go
+++ b/identity/manager.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sort"
 
 	"go.opentelemetry.io/otel/trace"
 
@@ -169,7 +170,16 @@ func (m *Manager) findExistingAuthMethod(ctx context.Context, e error, i *Identi
 		return &ErrDuplicateCredentials{error: e}
 	}
 
+	// We need to sort the credentials for the error message to be deterministic.
+	var creds []Credentials
 	for _, cred := range found.Credentials {
+		creds = append(creds, cred)
+	}
+	sort.Slice(creds, func(i, j int) bool {
+		return creds[i].Type < creds[j].Type
+	})
+
+	for _, cred := range creds {
 		if cred.Config == nil {
 			continue
 		}

--- a/identity/manager_test.go
+++ b/identity/manager_test.go
@@ -36,7 +36,7 @@ func TestManager(t *testing.T) {
 
 	t.Run("case=should fail to create because validation fails", func(t *testing.T) {
 		i := identity.NewIdentity(config.DefaultIdentityTraitsSchemaID)
-		i.Traits = identity.Traits("{}")
+		i.Traits = identity.Traits(`{"email":"not an email"}`)
 		require.Error(t, reg.IdentityManager().Create(context.Background(), i))
 	})
 
@@ -162,6 +162,132 @@ func TestManager(t *testing.T) {
 			err := reg.IdentityManager().Create(context.Background(), original)
 			require.Error(t, err)
 			assert.NotContains(t, err.Error(), "\"not an email\" is not valid \"email\"")
+		})
+
+		t.Run("case=should correctly hint at the duplicate credential", func(t *testing.T) {
+			createIdentity := func(email string, field string, creds map[identity.CredentialsType]identity.Credentials) *identity.Identity {
+				i := identity.NewIdentity(config.DefaultIdentityTraitsSchemaID)
+				i.Traits = identity.Traits(fmt.Sprintf(`{"%s":"%s"}`, field, email))
+				i.Credentials = creds
+				return i
+			}
+
+			t.Run("case=credential identifier duplicate", func(t *testing.T) {
+				t.Run("type=password", func(t *testing.T) {
+					email := uuid.Must(uuid.NewV4()).String() + "@ory.sh"
+					creds := map[identity.CredentialsType]identity.Credentials{
+						identity.CredentialsTypePassword: {
+							Type:        identity.CredentialsTypePassword,
+							Identifiers: []string{email},
+							Config:      sqlxx.JSONRawMessage(`{"hashed_password":"$2a$08$.cOYmAd.vCpDOoiVJrO5B.hjTLKQQ6cAK40u8uB.FnZDyPvVvQ9Q."}`),
+						},
+					}
+
+					first := createIdentity(email, "email_creds", creds)
+					require.NoError(t, reg.IdentityManager().Create(context.Background(), first))
+
+					second := createIdentity(email, "email_creds", creds)
+					err := reg.IdentityManager().Create(context.Background(), second)
+					require.Error(t, err)
+
+					var verr = new(identity.ErrDuplicateCredentials)
+					assert.ErrorAs(t, err, &verr)
+					assert.EqualValues(t, []string{identity.CredentialsTypePassword.String()}, verr.AvailableCredentials())
+					assert.Len(t, verr.AvailableOIDCProviders(), 0)
+					assert.Equal(t, verr.IdentifierHint(), email)
+				})
+
+				t.Run("type=webauthn", func(t *testing.T) {
+					email := uuid.Must(uuid.NewV4()).String() + "@ory.sh"
+					creds := map[identity.CredentialsType]identity.Credentials{
+						identity.CredentialsTypeWebAuthn: {
+							Type:        identity.CredentialsTypeWebAuthn,
+							Identifiers: []string{email},
+							Config:      sqlxx.JSONRawMessage(`{"credentials": [{"is_passwordless":true}]}`),
+						},
+					}
+
+					first := createIdentity(email, "email_webauthn", creds)
+					require.NoError(t, reg.IdentityManager().Create(context.Background(), first))
+
+					second := createIdentity(email, "email_webauthn", nil)
+					err := reg.IdentityManager().Create(context.Background(), second)
+					require.Error(t, err)
+
+					var verr = new(identity.ErrDuplicateCredentials)
+					assert.ErrorAs(t, err, &verr)
+					assert.EqualValues(t, []string{identity.CredentialsTypeWebAuthn.String()}, verr.AvailableCredentials())
+					assert.Len(t, verr.AvailableOIDCProviders(), 0)
+					assert.Equal(t, verr.IdentifierHint(), email)
+				})
+			})
+
+			runAddress := func(t *testing.T, field string) {
+				t.Run("case=password duplicate", func(t *testing.T) {
+					// This test mimics a case where an existing user with email + password exists, and the
+					// new user tries to sign up with a verification email (NOT email + password) that matches
+					// this existing record. Here, the end result is that we want to show the
+					// user: "Sign up with email foo@bar.com and your password instead."
+					email := uuid.Must(uuid.NewV4()).String() + "@ory.sh"
+					creds := map[identity.CredentialsType]identity.Credentials{
+						identity.CredentialsTypePassword: {
+							Type:        identity.CredentialsTypePassword,
+							Identifiers: []string{email},
+							Config:      sqlxx.JSONRawMessage(`{"hashed_password":"$2a$08$.cOYmAd.vCpDOoiVJrO5B.hjTLKQQ6cAK40u8uB.FnZDyPvVvQ9Q."}`),
+						},
+					}
+
+					first := createIdentity(email, field, creds)
+					require.NoError(t, reg.IdentityManager().Create(context.Background(), first))
+
+					second := createIdentity(email, field, nil)
+					err := reg.IdentityManager().Create(context.Background(), second)
+					require.Error(t, err)
+
+					var verr = new(identity.ErrDuplicateCredentials)
+					assert.ErrorAs(t, err, &verr)
+					assert.EqualValues(t, []string{identity.CredentialsTypePassword.String()}, verr.AvailableCredentials())
+					assert.Len(t, verr.AvailableOIDCProviders(), 0)
+					assert.Equal(t, verr.IdentifierHint(), email)
+				})
+
+				t.Run("case=OIDC duplicate", func(t *testing.T) {
+					// This test mimics a case where user signed up using Social Sign In exists, and the
+					// new user tries to sign up with a verification email (NOT email + password) that matches
+					// this existing record (for example by using another social sign in provider.
+					// Here, the end result is that we want to show "Sign in using google instead".
+					email := uuid.Must(uuid.NewV4()).String() + "@ory.sh"
+					creds := map[identity.CredentialsType]identity.Credentials{
+						identity.CredentialsTypeOIDC: {
+							Type: identity.CredentialsTypeOIDC,
+							// Identifiers in OIDC are not email addresses, but a unique user ID.
+							Identifiers: []string{"google:" + uuid.Must(uuid.NewV4()).String()},
+							Config:      sqlxx.JSONRawMessage(`{"providers":[{"provider": "google"},{"provider": "github"}]}`),
+						},
+					}
+
+					first := createIdentity(email, field, creds)
+					require.NoError(t, reg.IdentityManager().Create(context.Background(), first))
+
+					second := createIdentity(email, field, nil)
+					err := reg.IdentityManager().Create(context.Background(), second)
+					require.Error(t, err)
+
+					var verr = new(identity.ErrDuplicateCredentials)
+					assert.ErrorAs(t, err, &verr)
+					assert.EqualValues(t, []string{identity.CredentialsTypeOIDC.String()}, verr.AvailableCredentials())
+					assert.EqualValues(t, verr.AvailableOIDCProviders(), []string{"google", "github"})
+					assert.Equal(t, verr.IdentifierHint(), email)
+				})
+			}
+
+			t.Run("case=verifiable address", func(t *testing.T) {
+				runAddress(t, "email_verify")
+			})
+
+			t.Run("case=recovery address", func(t *testing.T) {
+				runAddress(t, "email_recovery")
+			})
 		})
 	})
 

--- a/identity/manager_test.go
+++ b/identity/manager_test.go
@@ -33,6 +33,7 @@ func TestManager(t *testing.T) {
 	extensionSchemaID := testhelpers.UseIdentitySchema(t, conf, "file://./stub/extension.schema.json")
 	conf.MustSet(ctx, config.ViperKeyPublicBaseURL, "https://www.ory.sh/")
 	conf.MustSet(ctx, config.ViperKeyCourierSMTPURL, "smtp://foo@bar@dev.null/")
+	conf.MustSet(ctx, config.ViperKeySelfServiceRegistrationLoginHints, true)
 
 	t.Run("case=should fail to create because validation fails", func(t *testing.T) {
 		i := identity.NewIdentity(config.DefaultIdentityTraitsSchemaID)

--- a/identity/stub/manager.schema.json
+++ b/identity/stub/manager.schema.json
@@ -29,6 +29,17 @@
             }
           }
         },
+        "email_webauthn": {
+          "type": "string",
+          "format": "email",
+          "ory.sh/kratos": {
+            "credentials": {
+              "webauthn": {
+                "identifier": true
+              }
+            }
+          }
+        },
         "email_verify": {
           "type": "string",
           "format": "email",
@@ -52,7 +63,6 @@
         }
       },
       "required": [
-        "email"
       ]
     }
   },

--- a/schema/errors.go
+++ b/schema/errors.go
@@ -5,9 +5,10 @@ package schema
 
 import (
 	"fmt"
+	"strings"
+
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
-	"strings"
 
 	"github.com/pkg/errors"
 

--- a/schema/errors.go
+++ b/schema/errors.go
@@ -173,7 +173,7 @@ func NewDuplicateCredentialsError(err error) error {
 
 			reason = fmt.Sprintf("%s You can sign in using %s.", reason, strings.Join(humanReadable, ", "))
 			if len(hinter.AvailableOIDCProviders()) > 0 {
-				reason = fmt.Sprintf("%s Or using the following social sign in providers: %s", reason, strings.Join(oidcProviders, ", "))
+				reason = fmt.Sprintf("%s Use one of the following social sign in providers: %s", reason, strings.Join(oidcProviders, ", "))
 			}
 		} else if len(hinter.AvailableOIDCProviders()) > 0 {
 			reason = fmt.Sprintf("%s You can sign in using one of the following social sign in providers: %s.", reason, strings.Join(oidcProviders, ", "))

--- a/schema/errors.go
+++ b/schema/errors.go
@@ -5,6 +5,10 @@ package schema
 
 import (
 	"fmt"
+	"strings"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"github.com/pkg/errors"
 
@@ -16,11 +20,6 @@ import (
 type ValidationError struct {
 	*jsonschema.ValidationError
 	Messages text.Messages
-}
-
-type Hinter interface {
-	MessageOverride() string
-	Hints() []string
 }
 
 func NewRequiredError(missingPtr, missingFieldName string) error {
@@ -128,31 +127,80 @@ func NewInvalidCredentialsError() error {
 	})
 }
 
-type ValidationErrorContextDuplicateCredentialsError struct{}
+type ValidationErrorContextDuplicateCredentialsError struct {
+	AvailableCredentials   []string `json:"available_credential_types"`
+	AvailableOIDCProviders []string `json:"available_oidc_providers"`
+	IdentifierHint         string   `json:"credential_identifier_hint"`
+}
 
 func (r *ValidationErrorContextDuplicateCredentialsError) AddContext(_, _ string) {}
 
 func (r *ValidationErrorContextDuplicateCredentialsError) FinishInstanceContext() {}
 
+type DuplicateCredentialsHinter interface {
+	AvailableCredentials() []string
+	AvailableOIDCProviders() []string
+	IdentifierHint() string
+	HasHints() bool
+}
+
 func NewDuplicateCredentialsError(err error) error {
-	e := &ValidationError{
+	if hinter := DuplicateCredentialsHinter(nil); errors.As(err, &hinter) && hinter.HasHints() {
+		reason := ""
+		if hinter.IdentifierHint() != "" {
+			reason = fmt.Sprintf("You tried signing with %s which is already in use by another account.", hinter.IdentifierHint())
+		} else {
+			reason = "You tried to sign up using an email, phone, or username that is already used by another account."
+		}
+
+		oidcProviders := make([]string, 0, len(hinter.AvailableOIDCProviders()))
+		for _, provider := range hinter.AvailableOIDCProviders() {
+			oidcProviders = append(oidcProviders, cases.Title(language.English).String(provider))
+		}
+
+		if len(hinter.AvailableCredentials()) > 0 {
+			humanReadable := make([]string, 0, len(hinter.AvailableCredentials()))
+			for _, cred := range hinter.AvailableCredentials() {
+				switch cred {
+				case "password":
+					humanReadable = append(humanReadable, "your password")
+				case "oidc":
+					humanReadable = append(humanReadable, "social sign in")
+				case "webauthn":
+					humanReadable = append(humanReadable, "your PassKey or a security key")
+				}
+			}
+
+			reason = fmt.Sprintf("%s You can sign in using %s.", reason, strings.Join(humanReadable, ", "))
+			if len(hinter.AvailableOIDCProviders()) > 0 {
+				reason = fmt.Sprintf("%s Or using the following social sign in providers: %s", reason, strings.Join(hinter.AvailableOIDCProviders(), ", "))
+			}
+		} else if len(hinter.AvailableOIDCProviders()) > 0 {
+			reason = fmt.Sprintf("%s You can sign in using one of the following social sign in providers: %s.", reason, strings.Join(hinter.AvailableOIDCProviders(), ", "))
+		}
+
+		return errors.WithStack(&ValidationError{
+			ValidationError: &jsonschema.ValidationError{
+				Message:     `an account with the same identifier (email, phone, username, ...) exists already`,
+				InstancePtr: "#/",
+				Context: &ValidationErrorContextDuplicateCredentialsError{
+					AvailableCredentials:   hinter.AvailableCredentials(),
+					AvailableOIDCProviders: hinter.AvailableOIDCProviders(),
+					IdentifierHint:         hinter.IdentifierHint(),
+				},
+			},
+			Messages: new(text.Messages).Add(text.NewErrorValidationDuplicateCredentialsWithHints(reason, hinter.AvailableCredentials(), hinter.AvailableOIDCProviders(), hinter.IdentifierHint())),
+		})
+	}
+
+	return errors.WithStack(&ValidationError{
 		ValidationError: &jsonschema.ValidationError{
 			Message:     `an account with the same identifier (email, phone, username, ...) exists already`,
 			InstancePtr: "#/",
 			Context:     &ValidationErrorContextDuplicateCredentialsError{},
 		},
 		Messages: new(text.Messages).Add(text.NewErrorValidationDuplicateCredentials()),
-	}
-	if hinter := Hinter(nil); errors.As(err, &hinter) {
-		if msg := hinter.MessageOverride(); msg != "" {
-			e.Messages.Clear()
-			e.Messages.Add(text.NewErrorValidationDuplicateCredentialsCustomMessage(msg))
-		}
-		for _, hint := range hinter.Hints() {
-			e.Messages.Add(&text.Message{Text: hint})
-		}
-	}
-	return errors.WithStack(e)
+	})
 }
 
 func NewNoLoginStrategyResponsible() error {

--- a/selfservice/flow/registration/hook.go
+++ b/selfservice/flow/registration/hook.go
@@ -16,8 +16,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/ory/x/sqlcon"
-
 	"github.com/ory/kratos/driver/config"
 	"github.com/ory/kratos/hydra"
 	"github.com/ory/kratos/identity"
@@ -145,12 +143,6 @@ func (e *HookExecutor) PostRegistrationHook(w http.ResponseWriter, r *http.Reque
 		// We're now creating the identity because any of the hooks could trigger a "redirect" or a "session" which
 		// would imply that the identity has to exist already.
 	} else if err := e.d.IdentityManager().Create(r.Context(), i); err != nil {
-		if errors.Is(err, sqlcon.ErrUniqueViolation) {
-			// In this case the user is already registered through another method.
-			// We handle this case by returning a spcial error that is handled by
-			// the caller.
-			return ErrDuplicateCredentials
-		}
 		return err
 	}
 

--- a/selfservice/flow/settings/hook.go
+++ b/selfservice/flow/settings/hook.go
@@ -221,7 +221,7 @@ func (e *HookExecutor) PostSettingsHook(w http.ResponseWriter, r *http.Request, 
 			return errors.WithStack(NewFlowNeedsReAuth())
 		}
 		if errors.Is(err, sqlcon.ErrUniqueViolation) {
-			return schema.NewDuplicateCredentialsError()
+			return schema.NewDuplicateCredentialsError(err)
 		}
 		return err
 	}

--- a/selfservice/strategy/oidc/strategy.go
+++ b/selfservice/strategy/oidc/strategy.go
@@ -522,7 +522,7 @@ func (s *Strategy) handleError(w http.ResponseWriter, r *http.Request, f flow.Fl
 		// Reset all nodes to not confuse users.
 		// This is kinda hacky and will probably need to be updated at some point.
 
-		if errors.Is(err, registration.ErrDuplicateCredentials) {
+		if dup := new(identity.ErrDuplicateCredentials); errors.As(err, &dup) {
 			rf.UI.Messages.Add(text.NewErrorValidationDuplicateCredentialsOnOIDCLink())
 			lf, err := s.registrationToLogin(w, r, rf, provider)
 			if err != nil {

--- a/selfservice/strategy/password/registration_test.go
+++ b/selfservice/strategy/password/registration_test.go
@@ -300,7 +300,7 @@ func TestRegistration(t *testing.T) {
 					body := testhelpers.SubmitRegistrationForm(t, true, apiClient, publicTS,
 						applyTransform(values, transform), false, http.StatusBadRequest,
 						publicTS.URL+registration.RouteSubmitFlow)
-					assert.Contains(t, gjson.Get(body, "ui.messages.0.text").String(), "An account with the same identifier (email, phone, username, ...) exists already.", "%s", body)
+					assert.Contains(t, gjson.Get(body, "ui.messages.0.text").String(), "You tried signing with registration-identifier-8-api-duplicate-"+suffix+" which is already in use by another account. You can sign in using your password.", "%s", body)
 				})
 
 				t.Run("type=spa", func(t *testing.T) {
@@ -312,7 +312,7 @@ func TestRegistration(t *testing.T) {
 
 					_ = expectSuccessfulLogin(t, false, true, nil, values)
 					body := registrationhelpers.ExpectValidationError(t, publicTS, conf, "spa", applyTransform(values, transform))
-					assert.Contains(t, gjson.Get(body, "ui.messages.0.text").String(), "An account with the same identifier (email, phone, username, ...) exists already.", "%s", body)
+					assert.Contains(t, gjson.Get(body, "ui.messages.0.text").String(), "You tried signing with registration-identifier-8-spa-duplicate-"+suffix+" which is already in use by another account. You can sign in using your password.", "%s", body)
 				})
 
 				t.Run("type=browser", func(t *testing.T) {
@@ -324,7 +324,7 @@ func TestRegistration(t *testing.T) {
 
 					_ = expectSuccessfulLogin(t, false, false, nil, values)
 					body := registrationhelpers.ExpectValidationError(t, publicTS, conf, "browser", applyTransform(values, transform))
-					assert.Contains(t, gjson.Get(body, "ui.messages.0.text").String(), "An account with the same identifier (email, phone, username, ...) exists already.", "%s", body)
+					assert.Contains(t, gjson.Get(body, "ui.messages.0.text").String(), "You tried signing with registration-identifier-8-browser-duplicate-"+suffix+" which is already in use by another account. You can sign in using your password.", "%s", body)
 				})
 			}
 

--- a/selfservice/strategy/password/registration_test.go
+++ b/selfservice/strategy/password/registration_test.go
@@ -45,10 +45,12 @@ func newRegistrationRegistry(t *testing.T) *driver.RegistryDefault {
 	ctx := context.Background()
 	conf, reg := internal.NewFastRegistryWithMocks(t)
 	conf.MustSet(ctx, config.ViperKeySelfServiceStrategyConfig+"."+string(identity.CredentialsTypePassword), map[string]interface{}{"enabled": true})
+	conf.MustSet(ctx, config.ViperKeySelfServiceRegistrationLoginHints, true)
 	return reg
 }
 
 func TestRegistration(t *testing.T) {
+
 	ctx := context.Background()
 	t.Run("case=registration", func(t *testing.T) {
 		reg := newRegistrationRegistry(t)

--- a/selfservice/strategy/webauthn/registration_test.go
+++ b/selfservice/strategy/webauthn/registration_test.go
@@ -392,7 +392,7 @@ func TestRegistration(t *testing.T) {
 					actual, _, _ = makeRegistration(t, f, values(email))
 					assert.Contains(t, gjson.Get(actual, "ui.action").String(), publicTS.URL+registration.RouteSubmitFlow, "%s", actual)
 					registrationhelpers.CheckFormContent(t, []byte(actual), node.WebAuthnRegisterTrigger, "csrf_token", "traits.username")
-					assert.Equal(t, "You tried signing with "+email+" which is already in use by another account. You can sign in using your PassKey or a security key.", gjson.Get(actual, "ui.messages.0.text").String(), "%s", actual)
+					assert.Equal(t, "You tried signing with "+email+" which is already in use by another account. You can sign in using your password.", gjson.Get(actual, "ui.messages.0.text").String(), "%s", actual)
 				})
 			}
 		})

--- a/selfservice/strategy/webauthn/registration_test.go
+++ b/selfservice/strategy/webauthn/registration_test.go
@@ -392,7 +392,7 @@ func TestRegistration(t *testing.T) {
 					actual, _, _ = makeRegistration(t, f, values(email))
 					assert.Contains(t, gjson.Get(actual, "ui.action").String(), publicTS.URL+registration.RouteSubmitFlow, "%s", actual)
 					registrationhelpers.CheckFormContent(t, []byte(actual), node.WebAuthnRegisterTrigger, "csrf_token", "traits.username")
-					assert.Equal(t, text.NewErrorValidationDuplicateCredentials().Text, gjson.Get(actual, "ui.messages.0.text").String(), "%s", actual)
+					assert.Equal(t, "You tried signing with "+email+" which is already in use by another account. You can sign in using your PassKey or a security key.", gjson.Get(actual, "ui.messages.0.text").String(), "%s", actual)
 				})
 			}
 		})

--- a/selfservice/strategy/webauthn/registration_test.go
+++ b/selfservice/strategy/webauthn/registration_test.go
@@ -51,6 +51,7 @@ func newRegistrationRegistry(t *testing.T) *driver.RegistryDefault {
 	conf.MustSet(ctx, config.ViperKeySelfServiceStrategyConfig+"."+string(identity.CredentialsTypePassword)+".enabled", true)
 	enableWebAuthn(conf)
 	conf.MustSet(ctx, config.ViperKeyWebAuthnPasswordless, true)
+	conf.MustSet(ctx, config.ViperKeySelfServiceRegistrationLoginHints, true)
 	return reg
 }
 

--- a/spec/api.json
+++ b/spec/api.json
@@ -337,7 +337,7 @@
             "description": "IDTokenHintClaims are the claims of the ID Token previously issued by the Authorization Server being passed as a hint about the End-User's current or past authenticated session with the Client.",
             "type": "object"
           },
-          "login_hint": {
+          "login_hints": {
             "description": "LoginHint hints about the login identifier the End-User might use to log in (if necessary). This hint can be used by an RP if it first asks the End-User for their e-mail address (or other identifier) and then wants to pass that value as a hint to the discovered authorization service. This value MAY also be a phone number in the format specified for the phone_number Claim. The use of this parameter is optional.",
             "type": "string"
           },

--- a/test/e2e/cypress/integration/profiles/email/registration/errors.spec.ts
+++ b/test/e2e/cypress/integration/profiles/email/registration/errors.spec.ts
@@ -22,6 +22,10 @@ describe("Registration failures with email profile", () => {
       before(() => {
         cy.useConfigProfile(profile)
         cy.proxy(app)
+        cy.updateConfigFile((config) => {
+          config.selfservice.flows.registration.login_hints = true
+          return config
+        })
       })
 
       beforeEach(() => {

--- a/test/e2e/cypress/integration/profiles/email/registration/errors.spec.ts
+++ b/test/e2e/cypress/integration/profiles/email/registration/errors.spec.ts
@@ -1,7 +1,7 @@
 // Copyright © 2023 Ory Corp
 // SPDX-License-Identifier: Apache-2.0
 
-import { appPrefix, gen } from "../../../../helpers"
+import { appPrefix, gen, website } from "../../../../helpers"
 import { routes as express } from "../../../../helpers/express"
 import { routes as react } from "../../../../helpers/react"
 
@@ -223,6 +223,29 @@ describe("Registration failures with email profile", () => {
           cy.get('[data-testid="ui/message/4000020"]').should(
             "contain.text",
             "must be <= 300 but found 600",
+          )
+        })
+
+        it("should show a hint for existing account", () => {
+          const email = gen.email()
+          const password = gen.password()
+
+          cy.registerApi({
+            email,
+            password,
+            fields: { "traits.website": website },
+          })
+
+          cy.get('input[name="traits.email"]').type(email)
+          cy.get('input[name="password"]').type(password)
+          cy.get('input[name="traits.website').type(website)
+          cy.get('input[name="traits.age"]').type(`30`)
+          cy.submitPasswordForm()
+          cy.get('[data-testid="ui/message/4000028"]').should(
+            "contain.text",
+            "You tried signing with " +
+              email +
+              " which is already in use by another account. You can sign in using your password.",
           )
         })
       })

--- a/test/e2e/cypress/support/config.d.ts
+++ b/test/e2e/cypress/support/config.d.ts
@@ -483,6 +483,7 @@ export interface OryKratosConfiguration2 {
         lifespan?: string
         before?: SelfServiceBeforeRegistration
         after?: SelfServiceAfterRegistration
+        login_hints?: boolean
       }
       login?: {
         ui_url?: LoginUIURL

--- a/test/e2e/profiles/email/.kratos.yml
+++ b/test/e2e/profiles/email/.kratos.yml
@@ -10,7 +10,6 @@ selfservice:
 
     registration:
       ui_url: http://localhost:4455/registration
-      login_hints: true
       after:
         password:
           hooks:

--- a/test/e2e/profiles/email/.kratos.yml
+++ b/test/e2e/profiles/email/.kratos.yml
@@ -10,6 +10,7 @@ selfservice:
 
     registration:
       ui_url: http://localhost:4455/registration
+      login_hints: true
       after:
         password:
           hooks:

--- a/text/id.go
+++ b/text/id.go
@@ -121,6 +121,7 @@ const (
 	ErrorValidationUniqueItems
 	ErrorValidationWrongType
 	ErrorValidationDuplicateCredentialsOnOIDCLink
+	ErrorValidationDuplicateCredentialsWithHints
 )
 
 const (

--- a/text/message_validation.go
+++ b/text/message_validation.go
@@ -164,6 +164,15 @@ func NewErrorValidationDuplicateCredentials() *Message {
 	}
 }
 
+func NewErrorValidationDuplicateCredentialsCustomMessage(reason string) *Message {
+	return &Message{
+		ID:      ErrorValidationDuplicateCredentials,
+		Text:    reason,
+		Type:    Error,
+		Context: context(nil),
+	}
+}
+
 func NewErrorValidationDuplicateCredentialsOnOIDCLink() *Message {
 	return &Message{
 		ID:      ErrorValidationDuplicateCredentialsOnOIDCLink,

--- a/text/message_validation.go
+++ b/text/message_validation.go
@@ -164,12 +164,16 @@ func NewErrorValidationDuplicateCredentials() *Message {
 	}
 }
 
-func NewErrorValidationDuplicateCredentialsCustomMessage(reason string) *Message {
+func NewErrorValidationDuplicateCredentialsWithHints(reason string, availableCredentialTypes []string, availableOIDCProviders []string, credentialIdentifierHint string) *Message {
 	return &Message{
-		ID:      ErrorValidationDuplicateCredentials,
-		Text:    reason,
-		Type:    Error,
-		Context: context(nil),
+		ID:   ErrorValidationDuplicateCredentialsWithHints,
+		Text: reason,
+		Type: Error,
+		Context: context(map[string]interface{}{
+			"available_credential_types": availableCredentialTypes,
+			"available_oidc_providers":   availableOIDCProviders,
+			"credential_identifier_hint": credentialIdentifierHint,
+		}),
 	}
 }
 


### PR DESCRIPTION
When trying to sign up with email+password when that email has previously been used with GitHub SSO:
![image](https://github.com/ory/kratos/assets/3969502/3017e012-01a2-4d0d-ae7e-5048257c8cbf)

When trying to sign up with the same email+password twice:
![image](https://github.com/ory/kratos/assets/3969502/d10c3f8d-0ffe-447d-ab99-4120bcbdb153)
