### PR TITLE
chore: add index to improve DB cleanup job performance

### DIFF
--- a/persistence/sql/migrations/sql/20230815171813000000_add_cleanup_index.down.sql
+++ b/persistence/sql/migrations/sql/20230815171813000000_add_cleanup_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX selfservice_login_flows_expires_at_idx;

--- a/persistence/sql/migrations/sql/20230815171813000000_add_cleanup_index.mysql.down.sql
+++ b/persistence/sql/migrations/sql/20230815171813000000_add_cleanup_index.mysql.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX selfservice_login_flows_expires_at_idx ON selfservice_login_flows;

--- a/persistence/sql/migrations/sql/20230815171813000000_add_cleanup_index.up.sql
+++ b/persistence/sql/migrations/sql/20230815171813000000_add_cleanup_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX selfservice_login_flows_expires_at_idx ON selfservice_login_flows (expires_at);


### PR DESCRIPTION
The Kratos cleanup job does a query looking like
```
DELETE FROM selfservice_login_flows
WHERE id in (
  SELECT id FROM (
    SELECT id
    FROM selfservice_login_flows c
    WHERE expires_at <= $1
     AND nid = $2
    ORDER BY expires_at ASC
    LIMIT 200000 )
  AS s )
```

The query plan of the SELECT-subquery looks like this (on PostgreSQL):
```
$ EXPLAIN SELECT id FROM (SELECT id FROM selfservice_login_flows c WHERE expires_at <= '2023-08-01' and nid = '750e49c8-a7ce-495e-8f79-ff8848d9e78e' ORDER BY expires_at ASC LIMIT 200000 ) as s;
                                                                        QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------------------------------
 Subquery Scan on s  (cost=1059.36..1059.38 rows=1 width=16)
   ->  Limit  (cost=1059.36..1059.37 rows=1 width=24)
         ->  Sort  (cost=1059.36..1059.37 rows=1 width=24)
               Sort Key: c.expires_at
               ->  Seq Scan on selfservice_login_flows c  (cost=0.00..1059.35 rows=1 width=24)
                     Filter: ((expires_at <= '2023-08-01 00:00:00'::timestamp without time zone) AND (nid = '750e49c8-a7ce-495e-8f79-ff8848d9e78e'::uuid))
(6 rows)
```
which does a **sequential scan on the table**.

This PR adds the index
```
CREATE INDEX david_test ON selfservice_login_flows (expires_at);
```
which results in this query plan:
```
$ EXPLAIN SELECT id FROM (SELECT id FROM selfservice_login_flows c WHERE expires_at <= '2023-08-01' and nid = '750e49c8-a7ce-495e-8f79-ff8848d9e78e' ORDER BY expires_at ASC LIMIT 200000 ) as s;
                                               QUERY PLAN
---------------------------------------------------------------------------------------------------------
 Subquery Scan on s  (cost=0.28..7.87 rows=1 width=16)
   ->  Limit  (cost=0.28..7.86 rows=1 width=24)
         ->  Index Scan using david_test on selfservice_login_flows c  (cost=0.28..7.86 rows=1 width=24)
               Index Cond: (expires_at <= '2023-08-01 00:00:00'::timestamp without time zone)
               Filter: (nid = '750e49c8-a7ce-495e-8f79-ff8848d9e78e'::uuid)
(5 rows)
```

Doing an **Index Scan** instead of the sequential one.

➡️ We created this index manually on our Kratos DB in order to optimize the Kratos cleanup process, which works very well for us.

💡  An alternative can be to create this index containing **all columns**:
```
CREATE INDEX david_test_all_cols ON selfservice_login_flows (expires_at, nid, id);
```
then the query plan looks like:
```
$ EXPLAIN SELECT id FROM (SELECT id FROM selfservice_login_flows c WHERE expires_at <= '2023-08-01' and nid = '750e49c8-a7ce-495e-8f79-ff8848d9e78e' ORDER BY expires_at ASC LIMIT 200000 ) as s;
                                                                       QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------------------
 Subquery Scan on s  (cost=0.28..8.06 rows=1 width=16)
   ->  Limit  (cost=0.28..8.05 rows=1 width=24)
         ->  Index Only Scan using david_test_all_cols on selfservice_login_flows c  (cost=0.28..8.05 rows=1 width=24)
               Index Cond: ((expires_at <= '2023-08-01 00:00:00'::timestamp without time zone) AND (nid = '750e49c8-a7ce-495e-8f79-ff8848d9e78e'::uuid))
(4 rows)
```
Which does an **Index Only Scan**, no data loaded from the table itself.
For us, it was not worth it, but maybe that's more in the vein of something you'd like to skip to all Kratos customers :)

Let me know what you think of this PR!

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
