### PR TITLE
fix: don't return 500 on conflict for POST /admin/identities

### DIFF
--- a/identity/error_test.go
+++ b/identity/error_test.go
@@ -1,0 +1,17 @@
+// Copyright © 2023 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package identity
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrDuplicateCredentials(t *testing.T) {
+	inner := errors.New("inner error")
+	err := &ErrDuplicateCredentials{inner, nil, nil, ""}
+	assert.ErrorIs(t, err, inner)
+}

--- a/identity/handler.go
+++ b/identity/handler.go
@@ -421,7 +421,7 @@ func (h *Handler) create(w http.ResponseWriter, r *http.Request, _ httprouter.Pa
 
 	if err := h.r.IdentityManager().Create(r.Context(), i); err != nil {
 		if errors.Is(err, sqlcon.ErrUniqueViolation) {
-			h.r.Writer().WriteError(w, r, herodot.ErrConflict)
+			h.r.Writer().WriteError(w, r, errors.WithStack(herodot.ErrConflict.WithReason("This identity conflicts with another identity that already exists.")))
 		} else {
 			h.r.Writer().WriteError(w, r, err)
 		}

--- a/identity/handler.go
+++ b/identity/handler.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/ory/x/pagination/migrationpagination"
+	"github.com/ory/x/sqlcon"
 
 	"github.com/ory/kratos/hash"
 	"github.com/ory/kratos/x"
@@ -419,7 +420,11 @@ func (h *Handler) create(w http.ResponseWriter, r *http.Request, _ httprouter.Pa
 	}
 
 	if err := h.r.IdentityManager().Create(r.Context(), i); err != nil {
-		h.r.Writer().WriteError(w, r, err)
+		if errors.Is(err, sqlcon.ErrUniqueViolation) {
+			h.r.Writer().WriteError(w, r, herodot.ErrConflict)
+		} else {
+			h.r.Writer().WriteError(w, r, err)
+		}
 		return
 	}
 

--- a/identity/manager.go
+++ b/identity/manager.go
@@ -254,7 +254,11 @@ type ErrDuplicateCredentials struct {
 
 var _ schema.DuplicateCredentialsHinter = (*ErrDuplicateCredentials)(nil)
 
-func (e ErrDuplicateCredentials) AvailableCredentials() []string {
+func (e *ErrDuplicateCredentials) Unwrap() error {
+	return e.error
+}
+
+func (e *ErrDuplicateCredentials) AvailableCredentials() []string {
 	res := make([]string, len(e.availableCredentials))
 	for k, v := range e.availableCredentials {
 		res[k] = string(v)
@@ -262,14 +266,14 @@ func (e ErrDuplicateCredentials) AvailableCredentials() []string {
 	return res
 }
 
-func (e ErrDuplicateCredentials) AvailableOIDCProviders() []string {
+func (e *ErrDuplicateCredentials) AvailableOIDCProviders() []string {
 	return e.availableOIDCProviders
 }
 
-func (e ErrDuplicateCredentials) IdentifierHint() string {
+func (e *ErrDuplicateCredentials) IdentifierHint() string {
 	return e.identifierHint
 }
-func (e ErrDuplicateCredentials) HasHints() bool {
+func (e *ErrDuplicateCredentials) HasHints() bool {
 	return len(e.availableCredentials) > 0 || len(e.availableOIDCProviders) > 0 || len(e.identifierHint) > 0
 }
 


### PR DESCRIPTION
This is a quick fix to avoid returning status code 500 when attempting to create a new identity which conflicts with an existing one.

As a follow-up, we should improve the diagnostics in the response.