### PR TITLE
feat: allow marking OIDC provider-verified addresses as verified during registration

### DIFF
--- a/selfservice/strategy/oidc/stub/oidc.hydra.jsonnet
+++ b/selfservice/strategy/oidc/stub/oidc.hydra.jsonnet
@@ -17,4 +17,7 @@ else
         [if "phone_number" in claims then "phone_number" else null]: claims.phone_number,
       }
     },
+    verified_addresses: [
+      { via: "email", value: claims.sub },
+    ],
   }

--- a/selfservice/strategy/oidc/stub/registration-verifiable-email.schema.json
+++ b/selfservice/strategy/oidc/stub/registration-verifiable-email.schema.json
@@ -1,0 +1,61 @@
+{
+  "$id": "https://example.com/person.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Person",
+  "type": "object",
+  "properties": {
+    "traits": {
+      "type": "object",
+      "properties": {
+        "subject": {
+          "format": "email",
+          "type": "string",
+          "ory.sh/kratos": {
+            "credentials": {
+              "password": {
+                "identifier": true
+              }
+            },
+            "verification": {
+              "via": "email"
+            }
+          }
+        },
+        "name": {
+          "type": "string",
+          "minLength": 2
+        },
+        "website": {
+          "type": "string",
+          "format": "uri"
+        },
+        "groups": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "subject"
+      ]
+    },
+    "metadata_public": {
+      "type": "object",
+      "properties": {
+        "picture": {
+          "type": "string"
+        }
+      }
+    },
+    "metadata_admin": {
+      "type": "object",
+      "properties": {
+        "phone_number": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
Allows identities to skip address verification if Kratos is configured to trust OIDC providers to verify them ahead of time.

## Related issue(s)

#3424

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

I chose to extend existing default OIDC provider configuration in tests instead of adding a new provider because the result is ignored if the schema doesn't have any verifiable addresses anyway and it was easier to do it this way (or so I believe). If you'd prefer to move the key under which `verified_addresses` are returned into `identity` object, like mentioned in linked issue, let me know and I'll change it.