### PR TITLE
fix: properly normalize OIDC verified emails

### DIFF
--- a/selfservice/strategy/oidc/strategy_registration.go
+++ b/selfservice/strategy/oidc/strategy_registration.go
@@ -409,7 +409,8 @@ func (s *Strategy) extractVerifiedAddresses(evaluated string) ([]VerifiedAddress
 			return nil, errors.WithStack(herodot.ErrBadRequest.WithReasonf("Failed to unmarshal value for key %s. Please check your Jsonnet code!", VerifiedAddressesKey).WithDebugf("%s", err))
 		}
 
-		for _, va := range va {
+		for i := range va {
+			va := &va[i]
 			if va.Via == identity.VerifiableAddressTypeEmail {
 				va.Value = strings.ToLower(strings.TrimSpace(va.Value))
 			}

--- a/selfservice/strategy/oidc/strategy_test.go
+++ b/selfservice/strategy/oidc/strategy_test.go
@@ -825,6 +825,17 @@ func TestStrategy(t *testing.T) {
 			assertVerifiedEmail(t, body, true)
 		})
 
+		t.Run("case=should have verified address when subject matches after normalization", func(t *testing.T) {
+			subject = " Denormalized-Verified-Email@ory.sh "
+			r := newBrowserRegistrationFlow(t, returnTS.URL, time.Minute)
+			action := assertFormValues(t, r.ID, "valid")
+			res, body := makeRequest(t, "valid", action, url.Values{"traits.subject": {"denormalized-verified-EMAIL@ory.sh"}})
+			subject = "denormalized-verified-EMAIL@ory.sh"
+			assertIdentity(t, res, body)
+			subject = "denormalized-verified-email@ory.sh"
+			assertVerifiedEmail(t, body, true)
+		})
+
 		t.Run("case=should have unverified address when subject does not match", func(t *testing.T) {
 			subject = "changed-verified-email@ory.sh"
 			r := newBrowserRegistrationFlow(t, returnTS.URL, time.Minute)


### PR DESCRIPTION
This addresses an oversight where emails returned from Jsonnet mappers weren't properly normalized. In case one contained any uppercase letters, resulting verifiable address wouldn't be marked as verified.

## Related issue(s)

Followup to #3445 / #3448. Can be reproduced by registering with a provider that returns denormalized emails (see the new test case).

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

My bad :sweat_smile: