### PR TITLE
fix: verificaton after registration

### DIFF
--- a/persistence/sql/migrations/sql/20230823000000000001_verification_add_oauth2_login_challenge_params.down.sql
+++ b/persistence/sql/migrations/sql/20230823000000000001_verification_add_oauth2_login_challenge_params.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE selfservice_verification_flows DROP COLUMN identity_id;
+ALTER TABLE selfservice_verification_flows DROP COLUMN authentication_methods;

--- a/persistence/sql/migrations/sql/20230823000000000001_verification_add_oauth2_login_challenge_params.mysql.up.sql
+++ b/persistence/sql/migrations/sql/20230823000000000001_verification_add_oauth2_login_challenge_params.mysql.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE selfservice_verification_flows ADD COLUMN identity_id VARCHAR(36);
+ALTER TABLE selfservice_verification_flows ADD COLUMN authentication_methods JSON;

--- a/persistence/sql/migrations/sql/20230823000000000001_verification_add_oauth2_login_challenge_params.sqlite.up.sql
+++ b/persistence/sql/migrations/sql/20230823000000000001_verification_add_oauth2_login_challenge_params.sqlite.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE selfservice_verification_flows ADD COLUMN identity_id VARCHAR(36);
+ALTER TABLE selfservice_verification_flows ADD COLUMN authentication_methods TEXT;

--- a/persistence/sql/migrations/sql/20230823000000000001_verification_add_oauth2_login_challenge_params.up.sql
+++ b/persistence/sql/migrations/sql/20230823000000000001_verification_add_oauth2_login_challenge_params.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE selfservice_verification_flows ADD COLUMN identity_id UUID;
+ALTER TABLE selfservice_verification_flows ADD COLUMN authentication_methods JSON;

--- a/selfservice/flow/verification/flow.go
+++ b/selfservice/flow/verification/flow.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/ory/kratos/driver/config"
 	"github.com/ory/kratos/selfservice/flow"
+	"github.com/ory/kratos/session"
 	"github.com/ory/kratos/ui/container"
 	"github.com/ory/kratos/x"
 	"github.com/ory/x/sqlxx"
@@ -81,9 +82,7 @@ type Flow struct {
 
 	// OAuth2LoginChallenge holds the login challenge originally set during the registration flow.
 	OAuth2LoginChallenge sqlxx.NullString `json:"-" db:"oauth2_login_challenge"`
-
-	// SessionID holds the session id if set from a registraton hook.
-	SessionID uuid.NullUUID `json:"-" faker:"-" db:"session_id"`
+	OAuth2LoginChallengeParams
 
 	// CSRFToken contains the anti-csrf token associated with this request.
 	CSRFToken string `json:"-" db:"csrf_token"`
@@ -93,6 +92,18 @@ type Flow struct {
 	// UpdatedAt is a helper struct field for gobuffalo.pop.
 	UpdatedAt time.Time `json:"-" faker:"-" db:"updated_at"`
 	NID       uuid.UUID `json:"-"  faker:"-" db:"nid"`
+}
+
+type OAuth2LoginChallengeParams struct {
+	// SessionID holds the session id if set from a registraton hook.
+	SessionID uuid.NullUUID `json:"-" faker:"-" db:"session_id"`
+
+	// IdentityID holds the identity id if set from a registraton hook.
+	IdentityID uuid.NullUUID `json:"-" faker:"-" db:"identity_id"`
+
+	// AMR contains a list of authentication methods that were used to verify the
+	// session if set from a registration hook.
+	AMR session.AuthenticationMethods `db:"authentication_methods" json:"-"`
 }
 
 func (f *Flow) GetType() flow.Type {

--- a/selfservice/flow/verification/handler_test.go
+++ b/selfservice/flow/verification/handler_test.go
@@ -20,9 +20,11 @@ import (
 
 	"github.com/ory/kratos/driver/config"
 	"github.com/ory/kratos/hydra"
+	"github.com/ory/kratos/identity"
 	"github.com/ory/kratos/internal"
 	"github.com/ory/kratos/internal/testhelpers"
 	"github.com/ory/kratos/selfservice/flow/verification"
+	"github.com/ory/kratos/session"
 	"github.com/ory/kratos/x"
 )
 
@@ -214,15 +216,17 @@ func TestPostFlow(t *testing.T) {
 
 	t.Run("suite=with OIDC login challenge", func(t *testing.T) {
 		t.Run("case=succeeds with a session", func(t *testing.T) {
-			s := testhelpers.CreateSession(t, reg)
-
 			f := &verification.Flow{
 				ID:                   uuid.Must(uuid.NewV4()),
 				Type:                 "browser",
 				ExpiresAt:            time.Now().Add(1 * time.Hour),
 				IssuedAt:             time.Now(),
 				OAuth2LoginChallenge: hydra.FakeValidLoginChallenge,
-				SessionID:            uuid.NullUUID{UUID: s.ID, Valid: true},
+				OAuth2LoginChallengeParams: verification.OAuth2LoginChallengeParams{
+					SessionID:  uuid.NullUUID{UUID: uuid.Must(uuid.NewV4()), Valid: true},
+					IdentityID: uuid.NullUUID{UUID: uuid.Must(uuid.NewV4()), Valid: true},
+					AMR:        session.AuthenticationMethods{{Method: identity.CredentialsTypePassword}},
+				},
 			}
 			require.NoError(t, reg.VerificationFlowPersister().CreateVerificationFlow(ctx, f))
 

--- a/selfservice/hook/verification.go
+++ b/selfservice/hook/verification.go
@@ -47,6 +47,8 @@ func (e *Verifier) ExecutePostRegistrationPostPersistHook(w http.ResponseWriter,
 		return e.do(w, r.WithContext(ctx), s.Identity, f, func(v *verification.Flow) {
 			v.OAuth2LoginChallenge = f.OAuth2LoginChallenge
 			v.SessionID = uuid.NullUUID{UUID: s.ID, Valid: true}
+			v.IdentityID = uuid.NullUUID{UUID: s.Identity.ID, Valid: true}
+			v.AMR = s.AMR
 		})
 	})
 }

--- a/session/session.go
+++ b/session/session.go
@@ -329,6 +329,9 @@ type AuthenticationMethod struct {
 
 // Scan implements the Scanner interface.
 func (n *AuthenticationMethod) Scan(value interface{}) error {
+	if value == nil {
+		return nil
+	}
 	v := fmt.Sprintf("%s", value)
 	if len(v) == 0 {
 		return nil
@@ -347,6 +350,9 @@ func (n AuthenticationMethod) Value() (driver.Value, error) {
 
 // Scan implements the Scanner interface.
 func (n *AuthenticationMethods) Scan(value interface{}) error {
+	if value == nil {
+		return nil
+	}
 	v := fmt.Sprintf("%s", value)
 	if len(v) == 0 {
 		return nil


### PR DESCRIPTION
This fixes a bug in the session lookup after the verification hook ran and the OIDC challenge needs to be accepted.

Rather than looking up the session in the DB, we now pass along all information (session ID, identity ID, and AMR) to the verification hook so that the hook has all information to accept the login challenge on its own terms.

I verified that the E2E tests on Cloud pass with this change.


<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [ ] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
