### PR TITLE
fix: mark identity as optional in session struct

### DIFF
--- a/internal/client-go/model_session.go
+++ b/internal/client-go/model_session.go
@@ -30,8 +30,8 @@ type Session struct {
 	// The Session Expiry  When this session expires at.
 	ExpiresAt *time.Time `json:"expires_at,omitempty"`
 	// Session ID
-	Id       string   `json:"id"`
-	Identity Identity `json:"identity"`
+	Id       string    `json:"id"`
+	Identity *Identity `json:"identity,omitempty"`
 	// The Session Issuance Timestamp  When this session was issued at. Usually equal or close to `authenticated_at`.
 	IssuedAt *time.Time `json:"issued_at,omitempty"`
 }
@@ -40,10 +40,9 @@ type Session struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewSession(id string, identity Identity) *Session {
+func NewSession(id string) *Session {
 	this := Session{}
 	this.Id = id
-	this.Identity = identity
 	return &this
 }
 
@@ -271,28 +270,36 @@ func (o *Session) SetId(v string) {
 	o.Id = v
 }
 
-// GetIdentity returns the Identity field value
+// GetIdentity returns the Identity field value if set, zero value otherwise.
 func (o *Session) GetIdentity() Identity {
-	if o == nil {
+	if o == nil || o.Identity == nil {
 		var ret Identity
 		return ret
 	}
-
-	return o.Identity
+	return *o.Identity
 }
 
-// GetIdentityOk returns a tuple with the Identity field value
+// GetIdentityOk returns a tuple with the Identity field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Session) GetIdentityOk() (*Identity, bool) {
-	if o == nil {
+	if o == nil || o.Identity == nil {
 		return nil, false
 	}
-	return &o.Identity, true
+	return o.Identity, true
 }
 
-// SetIdentity sets field value
+// HasIdentity returns a boolean if a field has been set.
+func (o *Session) HasIdentity() bool {
+	if o != nil && o.Identity != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetIdentity gets a reference to the given Identity and assigns it to the Identity field.
 func (o *Session) SetIdentity(v Identity) {
-	o.Identity = v
+	o.Identity = &v
 }
 
 // GetIssuedAt returns the IssuedAt field value if set, zero value otherwise.
@@ -350,7 +357,7 @@ func (o Session) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["id"] = o.Id
 	}
-	if true {
+	if o.Identity != nil {
 		toSerialize["identity"] = o.Identity
 	}
 	if o.IssuedAt != nil {

--- a/internal/httpclient/model_session.go
+++ b/internal/httpclient/model_session.go
@@ -30,8 +30,8 @@ type Session struct {
 	// The Session Expiry  When this session expires at.
 	ExpiresAt *time.Time `json:"expires_at,omitempty"`
 	// Session ID
-	Id       string   `json:"id"`
-	Identity Identity `json:"identity"`
+	Id       string    `json:"id"`
+	Identity *Identity `json:"identity,omitempty"`
 	// The Session Issuance Timestamp  When this session was issued at. Usually equal or close to `authenticated_at`.
 	IssuedAt *time.Time `json:"issued_at,omitempty"`
 }
@@ -40,10 +40,9 @@ type Session struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewSession(id string, identity Identity) *Session {
+func NewSession(id string) *Session {
 	this := Session{}
 	this.Id = id
-	this.Identity = identity
 	return &this
 }
 
@@ -271,28 +270,36 @@ func (o *Session) SetId(v string) {
 	o.Id = v
 }
 
-// GetIdentity returns the Identity field value
+// GetIdentity returns the Identity field value if set, zero value otherwise.
 func (o *Session) GetIdentity() Identity {
-	if o == nil {
+	if o == nil || o.Identity == nil {
 		var ret Identity
 		return ret
 	}
-
-	return o.Identity
+	return *o.Identity
 }
 
-// GetIdentityOk returns a tuple with the Identity field value
+// GetIdentityOk returns a tuple with the Identity field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Session) GetIdentityOk() (*Identity, bool) {
-	if o == nil {
+	if o == nil || o.Identity == nil {
 		return nil, false
 	}
-	return &o.Identity, true
+	return o.Identity, true
 }
 
-// SetIdentity sets field value
+// HasIdentity returns a boolean if a field has been set.
+func (o *Session) HasIdentity() bool {
+	if o != nil && o.Identity != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetIdentity gets a reference to the given Identity and assigns it to the Identity field.
 func (o *Session) SetIdentity(v Identity) {
-	o.Identity = v
+	o.Identity = &v
 }
 
 // GetIssuedAt returns the IssuedAt field value if set, zero value otherwise.
@@ -350,7 +357,7 @@ func (o Session) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["id"] = o.Id
 	}
-	if true {
+	if o.Identity != nil {
 		toSerialize["identity"] = o.Identity
 	}
 	if o.IssuedAt != nil {

--- a/session/session.go
+++ b/session/session.go
@@ -120,7 +120,12 @@ type Session struct {
 	// Use this token to log out a user.
 	LogoutToken string `json:"-" db:"logout_token"`
 
-	// required: true
+	// The Session Identity
+	//
+	// The identity that authenticated this session.
+	//
+	// If 2FA is required for the user, and the authentication process only solved the first factor, this field will be
+	// null until the session has been fully authenticated with the second factor.
 	Identity *identity.Identity `json:"identity" faker:"identity" db:"-" belongs_to:"identities" fk_id:"IdentityID"`
 
 	// Devices has history of all endpoints where the session was used

--- a/spec/api.json
+++ b/spec/api.json
@@ -1759,8 +1759,7 @@
           }
         },
         "required": [
-          "id",
-          "identity"
+          "id"
         ],
         "type": "object"
       },

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -4638,8 +4638,7 @@
       "description": "A Session",
       "type": "object",
       "required": [
-        "id",
-        "identity"
+        "id"
       ],
       "properties": {
         "active": {


### PR DESCRIPTION
The identity is not always available in the session struct, for example when AAL2 is required.

Closes #3461

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [ ] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
