### PR TITLE
fix: remove duplicate message ID usage

### DIFF
--- a/cmd/clidoc/main.go
+++ b/cmd/clidoc/main.go
@@ -70,7 +70,6 @@ func init() {
 		"NewInfoSelfServiceSettingsLookupSecretsLabel":            text.NewInfoSelfServiceSettingsLookupSecretsLabel(),
 		"NewInfoSelfServiceSettingsUpdateLinkOIDC":                text.NewInfoSelfServiceSettingsUpdateLinkOIDC("{provider}"),
 		"NewInfoSelfServiceSettingsUpdateUnlinkOIDC":              text.NewInfoSelfServiceSettingsUpdateUnlinkOIDC("{provider}"),
-		"NewInfoSelfServiceRegisterWebAuthn":                      text.NewInfoSelfServiceSettingsRegisterWebAuthn(),
 		"NewInfoSelfServiceRegisterWebAuthnDisplayName":           text.NewInfoSelfServiceRegisterWebAuthnDisplayName(),
 		"NewInfoSelfServiceRemoveWebAuthn":                        text.NewInfoSelfServiceRemoveWebAuthn("{display_name}", aSecondAgo),
 		"NewErrorValidationVerificationFlowExpired":               text.NewErrorValidationVerificationFlowExpired(aSecondAgo),
@@ -149,7 +148,6 @@ func init() {
 		"NewInfoSelfServiceSettingsRegisterWebAuthn":              text.NewInfoSelfServiceSettingsRegisterWebAuthn(),
 		"NewInfoLoginWebAuthnPasswordless":                        text.NewInfoLoginWebAuthnPasswordless(),
 		"NewInfoSelfServiceRegistrationRegisterWebAuthn":          text.NewInfoSelfServiceRegistrationRegisterWebAuthn(),
-		"NewInfoLoginPasswordlessWebAuthn":                        text.NewInfoLoginPasswordlessWebAuthn(),
 		"NewInfoSelfServiceContinueLoginWebAuthn":                 text.NewInfoSelfServiceContinueLoginWebAuthn(),
 		"NewInfoSelfServiceLoginContinue":                         text.NewInfoSelfServiceLoginContinue(),
 		"NewErrorValidationSuchNoWebAuthnUser":                    text.NewErrorValidationSuchNoWebAuthnUser(),
@@ -180,6 +178,12 @@ func main() {
 	}
 
 	sortedMessages := sortMessages()
+	for i := 1; i < len(sortedMessages); i++ {
+		if sortedMessages[i].ID == sortedMessages[i-1].ID {
+			_, _ = fmt.Fprintf(os.Stderr, "Message ID %d is used more than once: %q %q\n", sortedMessages[i].ID, sortedMessages[i].Text, sortedMessages[i-1].Text)
+			os.Exit(1)
+		}
+	}
 
 	if err := writeMessages(filepath.Join(os.Args[2], "concepts/ui-user-interface.mdx"), sortedMessages); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Unable to generate message table: %+v\n", err)

--- a/selfservice/strategy/webauthn/.snapshots/TestCompleteLogin-flow=passwordless-case=webauthn_button_exists.json
+++ b/selfservice/strategy/webauthn/.snapshots/TestCompleteLogin-flow=passwordless-case=webauthn_button_exists.json
@@ -44,8 +44,8 @@
     "messages": [],
     "meta": {
       "label": {
-        "id": 1010001,
-        "text": "Sign in with security key",
+        "id": 1010008,
+        "text": "Use security key",
         "type": "info"
       }
     },

--- a/selfservice/strategy/webauthn/login.go
+++ b/selfservice/strategy/webauthn/login.go
@@ -92,7 +92,7 @@ func (s *Strategy) populateLoginMethodForPasswordless(r *http.Request, sr *login
 
 	sr.UI.SetCSRF(s.d.GenerateCSRFToken(r))
 	sr.UI.SetNode(node.NewInputField("identifier", "", node.DefaultGroup, node.InputAttributeTypeText, node.WithRequiredInputAttribute).WithMetaLabel(text.NewInfoNodeLabelID()))
-	sr.UI.GetNodes().Append(node.NewInputField("method", "webauthn", node.WebAuthnGroup, node.InputAttributeTypeSubmit).WithMetaLabel(text.NewInfoLoginPasswordlessWebAuthn()))
+	sr.UI.GetNodes().Append(node.NewInputField("method", "webauthn", node.WebAuthnGroup, node.InputAttributeTypeSubmit).WithMetaLabel(text.NewInfoSelfServiceLoginWebAuthn()))
 	return nil
 }
 

--- a/text/message_login.go
+++ b/text/message_login.go
@@ -56,14 +56,6 @@ func NewInfoLogin() *Message {
 	}
 }
 
-func NewInfoLoginPasswordlessWebAuthn() *Message {
-	return &Message{
-		ID:   InfoSelfServiceLogin,
-		Text: "Sign in with security key",
-		Type: Info,
-	}
-}
-
 func NewInfoLoginTOTP() *Message {
 	return &Message{
 		ID:   InfoLoginTOTP,


### PR DESCRIPTION
Instead of `Sign in with security key` the button now is labeled `Use security key`

![image](https://github.com/ory/kratos/assets/5354445/54b2af7f-c1d0-4a33-a1d4-7e3a5d0d237d)
