### PR TITLE
docs: flip order of pagination args in example

### DIFF
--- a/cmd/identities/list.go
+++ b/cmd/identities/list.go
@@ -27,7 +27,7 @@ func NewListIdentitiesCmd() *cobra.Command {
 		Use:     "identities [<page> <per-page>]",
 		Short:   "List identities",
 		Long:    "List identities (paginated)",
-		Example: "{{ .CommandPath }} 100 1",
+		Example: "{{ .CommandPath }} 1 100",
 		Args:    cmdx.ZeroOrTwoArgs,
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
The cli command to list identities takes two pagination arguments: page and page-limit.

In the sub command description they are list as:

https://github.com/mblarsen/kratos/blob/085d5002df27d455057d33bd2d93dfbca0de4872/cmd/identities/list.go#L27-L30

Looking at code parsing they are indeed parsed in the page, page-limit order.

https://github.com/mblarsen/kratos/blob/085d5002df27d455057d33bd2d93dfbca0de4872/cmd/identities/list.go#L41

The example, however, as you can see from the above code snippet shows 100 1. This would mean page 100 with 1 identity per page. This is probably not untended.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

The changes affects only the cli tools documentation
