### PR TITLE
feat: support auth_type param

### DIFF
--- a/selfservice/strategy/oidc/.schema/link.schema.json
+++ b/selfservice/strategy/oidc/.schema/link.schema.json
@@ -33,6 +33,10 @@
           "description": "The prompt specifies whether the Authorization Server prompts the End-User for reauthentication and consent (for example, select_account).",
           "type": "string"
         },
+        "auth_type": {
+          "description": "The `auth_type` parameter specifies the requested authentication features (as a comma-separated list).",
+          "type": "string"
+        },
         "additionalProperties": false
       }
     }

--- a/selfservice/strategy/oidc/provider.go
+++ b/selfservice/strategy/oidc/provider.go
@@ -76,6 +76,7 @@ func (c *Claims) Validate() error {
 // - `login_hint` (string): The `login_hint` parameter suppresses the account chooser and either pre-fills the email box on the sign-in form, or selects the proper session.
 // - `hd` (string): The `hd` parameter limits the login/registration process to a Google Organization, e.g. `mycollege.edu`.
 // - `prompt` (string): The `prompt` specifies whether the Authorization Server prompts the End-User for reauthentication and consent, e.g. `select_account`.
+// - `auth_type` (string): The `auth_type` parameter specifies the requested authentication features (as a comma-separated list), e.g. `reauthenticate`.
 func UpstreamParameters(provider Provider, upstreamParameters map[string]string) []oauth2.AuthCodeOption {
 	// validation of upstream parameters are already handled in the `oidc/.schema/link.schema.json` and `oidc/.schema/settings.schema.json` file.
 	// `upstreamParameters` will always only contain allowed parameters based on the configuration.
@@ -85,6 +86,7 @@ func UpstreamParameters(provider Provider, upstreamParameters map[string]string)
 		"login_hint": {},
 		"hd":         {},
 		"prompt":     {},
+		"auth_type":  {},
 	}
 
 	var params []oauth2.AuthCodeOption

--- a/selfservice/strategy/oidc/strategy_test.go
+++ b/selfservice/strategy/oidc/strategy_test.go
@@ -730,6 +730,7 @@ func TestStrategy(t *testing.T) {
 			fv.Set("upstream_parameters.login_hint", "oidc-upstream-parameters@ory.sh")
 			fv.Set("upstream_parameters.hd", "ory.sh")
 			fv.Set("upstream_parameters.prompt", "select_account")
+			fv.Set("upstream_parameters.auth_type", "reauthenticate")
 
 			res, err := c.PostForm(action, fv)
 			require.NoError(t, err)
@@ -741,6 +742,7 @@ func TestStrategy(t *testing.T) {
 			require.Equal(t, "oidc-upstream-parameters@ory.sh", loc.Query().Get("login_hint"))
 			require.Equal(t, "ory.sh", loc.Query().Get("hd"))
 			require.Equal(t, "select_account", loc.Query().Get("prompt"))
+			require.Equal(t, "reauthenticate", loc.Query().Get("auth_type"))
 		})
 
 		t.Run("case=should pass when logging in", func(t *testing.T) {


### PR DESCRIPTION
    The Facebook OIDC provider supports an auth_type parameter that
    when set to "reauthenticate" will force the user to
    reauthenticate (similar to `prompt=login` for other Providers).


<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [ ] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
