### PR TITLE
feat: hook to revoke sessions after password changed

### DIFF
--- a/embedx/config.schema.json
+++ b/embedx/config.schema.json
@@ -733,6 +733,9 @@
             "anyOf": [
               {
                 "$ref": "#/definitions/selfServiceWebHook"
+              },
+              {
+                "$ref": "#/definitions/selfServiceSessionRevokerHook"
               }
             ]
           },

--- a/selfservice/flow/settings/hook.go
+++ b/selfservice/flow/settings/hook.go
@@ -44,9 +44,9 @@ type (
 	PostHookPrePersistExecutorFunc func(w http.ResponseWriter, r *http.Request, a *Flow, s *identity.Identity) error
 
 	PostHookPostPersistExecutor interface {
-		ExecuteSettingsPostPersistHook(w http.ResponseWriter, r *http.Request, a *Flow, s *identity.Identity) error
+		ExecuteSettingsPostPersistHook(w http.ResponseWriter, r *http.Request, a *Flow, id *identity.Identity, s *session.Session) error
 	}
-	PostHookPostPersistExecutorFunc func(w http.ResponseWriter, r *http.Request, a *Flow, s *identity.Identity) error
+	PostHookPostPersistExecutorFunc func(w http.ResponseWriter, r *http.Request, a *Flow, id *identity.Identity, s *session.Session) error
 
 	HooksProvider interface {
 		PreSettingsHooks(ctx context.Context) []PreHookExecutor
@@ -84,8 +84,8 @@ func (f PostHookPrePersistExecutorFunc) ExecuteSettingsPrePersistHook(w http.Res
 	return f(w, r, a, s)
 }
 
-func (f PostHookPostPersistExecutorFunc) ExecuteSettingsPostPersistHook(w http.ResponseWriter, r *http.Request, a *Flow, s *identity.Identity) error {
-	return f(w, r, a, s)
+func (f PostHookPostPersistExecutorFunc) ExecuteSettingsPostPersistHook(w http.ResponseWriter, r *http.Request, a *Flow, id *identity.Identity, s *session.Session) error {
+	return f(w, r, a, id, s)
 }
 
 func PostHookPostPersistExecutorNames(e []PostHookPostPersistExecutor) []string {
@@ -252,7 +252,7 @@ func (e *HookExecutor) PostSettingsHook(w http.ResponseWriter, r *http.Request, 
 	}
 
 	for k, executor := range e.d.PostSettingsPostPersistHooks(r.Context(), settingsType) {
-		if err := executor.ExecuteSettingsPostPersistHook(w, r, ctxUpdate.Flow, i); err != nil {
+		if err := executor.ExecuteSettingsPostPersistHook(w, r, ctxUpdate.Flow, i, ctxUpdate.Session); err != nil {
 			if errors.Is(err, ErrHookAbortFlow) {
 				e.d.Logger().
 					WithRequest(r).

--- a/selfservice/hook/error.go
+++ b/selfservice/hook/error.go
@@ -60,7 +60,7 @@ func (e Error) ExecuteSettingsPrePersistHook(w http.ResponseWriter, r *http.Requ
 	return e.err("ExecuteSettingsPrePersistHook", settings.ErrHookAbortFlow)
 }
 
-func (e Error) ExecuteSettingsPostPersistHook(w http.ResponseWriter, r *http.Request, a *settings.Flow, s *identity.Identity) error {
+func (e Error) ExecuteSettingsPostPersistHook(w http.ResponseWriter, r *http.Request, a *settings.Flow, id *identity.Identity, s *session.Session) error {
 	return e.err("ExecuteSettingsPostPersistHook", settings.ErrHookAbortFlow)
 }
 

--- a/selfservice/hook/session_destroyer.go
+++ b/selfservice/hook/session_destroyer.go
@@ -7,8 +7,10 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/ory/kratos/identity"
 	"github.com/ory/kratos/selfservice/flow/login"
 	"github.com/ory/kratos/selfservice/flow/recovery"
+	"github.com/ory/kratos/selfservice/flow/settings"
 	"github.com/ory/kratos/session"
 	"github.com/ory/kratos/ui/node"
 	"github.com/ory/x/otelx"
@@ -16,6 +18,7 @@ import (
 
 var _ login.PostHookExecutor = new(SessionDestroyer)
 var _ recovery.PostHookExecutor = new(SessionDestroyer)
+var _ settings.PostHookPostPersistExecutor = new(SessionDestroyer)
 
 type (
 	sessionDestroyerDependencies interface {
@@ -43,6 +46,15 @@ func (e *SessionDestroyer) ExecuteLoginPostHook(_ http.ResponseWriter, r *http.R
 func (e *SessionDestroyer) ExecutePostRecoveryHook(_ http.ResponseWriter, r *http.Request, _ *recovery.Flow, s *session.Session) error {
 	return otelx.WithSpan(r.Context(), "selfservice.hook.SessionDestroyer.ExecutePostRecoveryHook", func(ctx context.Context) error {
 		if _, err := e.r.SessionPersister().RevokeSessionsIdentityExcept(ctx, s.Identity.ID, s.ID); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func (e *SessionDestroyer) ExecuteSettingsPostPersistHook(_ http.ResponseWriter, r *http.Request, _ *settings.Flow, i *identity.Identity, s *session.Session) error {
+	return otelx.WithSpan(r.Context(), "selfservice.hook.SessionDestroyer.ExecuteSettingsPostPersistHook", func(ctx context.Context) error {
+		if _, err := e.r.SessionPersister().RevokeSessionsIdentityExcept(ctx, i.ID, s.ID); err != nil {
 			return err
 		}
 		return nil

--- a/selfservice/hook/session_destroyer_test.go
+++ b/selfservice/hook/session_destroyer_test.go
@@ -66,6 +66,18 @@ func TestSessionDestroyer(t *testing.T) {
 				)
 			},
 		},
+		{
+			name: "ExecuteSettingsPostPersistHook",
+			hook: func(i *identity.Identity) error {
+				return h.ExecuteSettingsPostPersistHook(
+					httptest.NewRecorder(),
+					new(http.Request),
+					nil,
+					i,
+					&session.Session{Identity: i},
+				)
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var i identity.Identity

--- a/selfservice/hook/verification.go
+++ b/selfservice/hook/verification.go
@@ -55,7 +55,7 @@ func (e *Verifier) ExecutePostRegistrationPostPersistHook(w http.ResponseWriter,
 	})
 }
 
-func (e *Verifier) ExecuteSettingsPostPersistHook(w http.ResponseWriter, r *http.Request, f *settings.Flow, i *identity.Identity) error {
+func (e *Verifier) ExecuteSettingsPostPersistHook(w http.ResponseWriter, r *http.Request, f *settings.Flow, i *identity.Identity, _ *session.Session) error {
 	return otelx.WithSpan(r.Context(), "selfservice.hook.Verifier.ExecuteSettingsPostPersistHook", func(ctx context.Context) error {
 		return e.do(w, r.WithContext(ctx), i, f, nil)
 	})

--- a/selfservice/hook/verification_test.go
+++ b/selfservice/hook/verification_test.go
@@ -35,7 +35,7 @@ func TestVerifier(t *testing.T) {
 	for k, hf := range map[string]func(*hook.Verifier, *identity.Identity, flow.Flow) error{
 		"settings": func(h *hook.Verifier, i *identity.Identity, f flow.Flow) error {
 			return h.ExecuteSettingsPostPersistHook(
-				httptest.NewRecorder(), u, f.(*settings.Flow), i)
+				httptest.NewRecorder(), u, f.(*settings.Flow), i, &session.Session{ID: x.NewUUID(), Identity: i})
 		},
 		"register": func(h *hook.Verifier, i *identity.Identity, f flow.Flow) error {
 			return h.ExecutePostRegistrationPostPersistHook(

--- a/selfservice/hook/web_hook.go
+++ b/selfservice/hook/web_hook.go
@@ -250,7 +250,7 @@ func (e *WebHook) ExecuteSettingsPreHook(_ http.ResponseWriter, req *http.Reques
 	})
 }
 
-func (e *WebHook) ExecuteSettingsPostPersistHook(_ http.ResponseWriter, req *http.Request, flow *settings.Flow, id *identity.Identity) error {
+func (e *WebHook) ExecuteSettingsPostPersistHook(_ http.ResponseWriter, req *http.Request, flow *settings.Flow, id *identity.Identity, _ *session.Session) error {
 	if gjson.GetBytes(e.conf, "can_interrupt").Bool() || gjson.GetBytes(e.conf, "response.parse").Bool() {
 		return nil
 	}

--- a/selfservice/hook/web_hook_integration_test.go
+++ b/selfservice/hook/web_hook_integration_test.go
@@ -248,7 +248,7 @@ func TestWebHooks(t *testing.T) {
 			uc:         "Post Settings Hook",
 			createFlow: func() flow.Flow { return &settings.Flow{ID: x.NewUUID()} },
 			callWebHook: func(wh *hook.WebHook, req *http.Request, f flow.Flow, s *session.Session) error {
-				return wh.ExecuteSettingsPostPersistHook(nil, req, f.(*settings.Flow), s.Identity)
+				return wh.ExecuteSettingsPostPersistHook(nil, req, f.(*settings.Flow), s.Identity, s)
 			},
 			expectedBody: func(req *http.Request, f flow.Flow, s *session.Session) string {
 				return bodyWithFlowAndIdentity(req, f, s)
@@ -568,7 +568,7 @@ func TestWebHooks(t *testing.T) {
 			uc:         "Post Settings Hook - no block",
 			createFlow: func() flow.Flow { return &settings.Flow{ID: x.NewUUID()} },
 			callWebHook: func(wh *hook.WebHook, req *http.Request, f flow.Flow, s *session.Session) error {
-				return wh.ExecuteSettingsPostPersistHook(nil, req, f.(*settings.Flow), s.Identity)
+				return wh.ExecuteSettingsPostPersistHook(nil, req, f.(*settings.Flow), s.Identity, s)
 			},
 			webHookResponse: func() (int, []byte) {
 				return http.StatusOK, []byte{}
@@ -590,7 +590,7 @@ func TestWebHooks(t *testing.T) {
 			uc:         "Post Settings Hook Post Persist - block has no effect",
 			createFlow: func() flow.Flow { return &settings.Flow{ID: x.NewUUID()} },
 			callWebHook: func(wh *hook.WebHook, req *http.Request, f flow.Flow, s *session.Session) error {
-				return wh.ExecuteSettingsPostPersistHook(nil, req, f.(*settings.Flow), s.Identity)
+				return wh.ExecuteSettingsPostPersistHook(nil, req, f.(*settings.Flow), s.Identity, s)
 			},
 			webHookResponse: func() (int, []byte) {
 				return http.StatusBadRequest, webHookResponse
@@ -789,8 +789,9 @@ func TestWebHooks(t *testing.T) {
 			wh := hook.NewWebHook(&whDeps, conf)
 			uuid := x.NewUUID()
 			in := &identity.Identity{ID: uuid}
+			s := &session.Session{ID: x.NewUUID(), Identity: in}
 
-			postPersistErr := wh.ExecuteSettingsPostPersistHook(nil, req, f, in)
+			postPersistErr := wh.ExecuteSettingsPostPersistHook(nil, req, f, in, s)
 			assert.NoError(t, postPersistErr)
 			assert.Equal(t, in, &identity.Identity{ID: uuid})
 

--- a/test/e2e/cypress/support/config.d.ts
+++ b/test/e2e/cypress/support/config.d.ts
@@ -679,7 +679,7 @@ export interface SelfServiceAfterSettings {
 }
 export interface SelfServiceAfterSettingsMethod {
   default_browser_return_url?: RedirectBrowsersToSetURLPerDefault
-  hooks?: SelfServiceWebHook[]
+  hooks?: (SelfServiceWebHook | SelfServiceSessionRevokerHook)[]
 }
 export interface SelfServiceWebHook {
   hook: "web_hook"

--- a/test/schema/fixtures/config.schema.test.success/selfServiceAfterSettingsMethod.full.yaml
+++ b/test/schema/fixtures/config.schema.test.success/selfServiceAfterSettingsMethod.full.yaml
@@ -1,3 +1,4 @@
 default_browser_return_url: "#/definitions/defaultReturnTo"
 hooks:
   - "#/definitions/selfServiceWebHook"
+  - "#/definitions/selfServiceSessionRevokerHook"


### PR DESCRIPTION
Currently, the Kratos system does not automatically log out or invalidate other active sessions when a user changes their password. This poses a significant security risk as it allows potentially unauthorized individuals to maintain access to the account even after the password has been updated.
This PR provides the option to add the revoke_active_sessions hook to the settings after actions.

## Related issue(s)
https://github.com/ory/kratos/issues/3503

## Checklist

- [x]  I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).