### PR TITLE
fix: wrong continue_with enum declaration

### DIFF
--- a/internal/client-go/model_continue_with_set_ory_session_token.go
+++ b/internal/client-go/model_continue_with_set_ory_session_token.go
@@ -17,7 +17,7 @@ import (
 
 // ContinueWithSetOrySessionToken Indicates that a session was issued, and the application should use this token for authenticated requests
 type ContinueWithSetOrySessionToken struct {
-	// Action will always be `set_ory_session_token` set_ory_session_token ContinueWithActionSetOrySessionToken show_verification_ui ContinueWithActionShowVerificationUI
+	// Action will always be `set_ory_session_token` set_ory_session_token ContinueWithActionSetOrySessionTokenString
 	Action string `json:"action"`
 	// Token is the token of the session
 	OrySessionToken string `json:"ory_session_token"`

--- a/internal/client-go/model_continue_with_verification_ui.go
+++ b/internal/client-go/model_continue_with_verification_ui.go
@@ -17,7 +17,7 @@ import (
 
 // ContinueWithVerificationUi Indicates, that the UI flow could be continued by showing a verification ui
 type ContinueWithVerificationUi struct {
-	// Action will always be `show_verification_ui` set_ory_session_token ContinueWithActionSetOrySessionToken show_verification_ui ContinueWithActionShowVerificationUI
+	// Action will always be `show_verification_ui` show_verification_ui ContinueWithActionShowVerificationUIString
 	Action string                         `json:"action"`
 	Flow   ContinueWithVerificationUiFlow `json:"flow"`
 }

--- a/internal/httpclient/model_continue_with_set_ory_session_token.go
+++ b/internal/httpclient/model_continue_with_set_ory_session_token.go
@@ -17,7 +17,7 @@ import (
 
 // ContinueWithSetOrySessionToken Indicates that a session was issued, and the application should use this token for authenticated requests
 type ContinueWithSetOrySessionToken struct {
-	// Action will always be `set_ory_session_token` set_ory_session_token ContinueWithActionSetOrySessionToken show_verification_ui ContinueWithActionShowVerificationUI
+	// Action will always be `set_ory_session_token` set_ory_session_token ContinueWithActionSetOrySessionTokenString
 	Action string `json:"action"`
 	// Token is the token of the session
 	OrySessionToken string `json:"ory_session_token"`

--- a/internal/httpclient/model_continue_with_verification_ui.go
+++ b/internal/httpclient/model_continue_with_verification_ui.go
@@ -17,7 +17,7 @@ import (
 
 // ContinueWithVerificationUi Indicates, that the UI flow could be continued by showing a verification ui
 type ContinueWithVerificationUi struct {
-	// Action will always be `show_verification_ui` set_ory_session_token ContinueWithActionSetOrySessionToken show_verification_ui ContinueWithActionShowVerificationUI
+	// Action will always be `show_verification_ui` show_verification_ui ContinueWithActionShowVerificationUIString
 	Action string                         `json:"action"`
 	Flow   ContinueWithVerificationUiFlow `json:"flow"`
 }

--- a/selfservice/flow/continue_with.go
+++ b/selfservice/flow/continue_with.go
@@ -14,24 +14,23 @@ import (
 // swagger:model continueWith
 type ContinueWith any
 
-// swagger:enum ContinueWithAction
-type ContinueWithAction string
+// swagger:enum ContinueWithActionSetOrySessionToken
+type ContinueWithActionSetOrySessionToken string
 
 // #nosec G101 -- only a key constant
 const (
-	ContinueWithActionSetOrySessionToken ContinueWithAction = "set_ory_session_token"
-	ContinueWithActionShowVerificationUI ContinueWithAction = "show_verification_ui"
+	ContinueWithActionSetOrySessionTokenString ContinueWithActionSetOrySessionToken = "set_ory_session_token"
 )
 
-var _ ContinueWith = new(ContinueWithSetToken)
+var _ ContinueWith = new(ContinueWithSetOrySessionToken)
 
 // Indicates that a session was issued, and the application should use this token for authenticated requests
 // swagger:model continueWithSetOrySessionToken
-type ContinueWithSetToken struct {
+type ContinueWithSetOrySessionToken struct {
 	// Action will always be `set_ory_session_token`
 	//
 	// required: true
-	Action ContinueWithAction `json:"action"`
+	Action ContinueWithActionSetOrySessionToken `json:"action"`
 
 	// Token is the token of the session
 	//
@@ -39,16 +38,24 @@ type ContinueWithSetToken struct {
 	OrySessionToken string `json:"ory_session_token"`
 }
 
-func (ContinueWithSetToken) AppendTo(url.Values) url.Values {
+func (ContinueWithSetOrySessionToken) AppendTo(url.Values) url.Values {
 	return nil
 }
 
-func NewContinueWithSetToken(t string) *ContinueWithSetToken {
-	return &ContinueWithSetToken{
-		Action:          ContinueWithActionSetOrySessionToken,
+func NewContinueWithSetToken(t string) *ContinueWithSetOrySessionToken {
+	return &ContinueWithSetOrySessionToken{
+		Action:          ContinueWithActionSetOrySessionTokenString,
 		OrySessionToken: t,
 	}
 }
+
+// swagger:enum ContinueWithActionShowVerificationUI
+type ContinueWithActionShowVerificationUI string
+
+// #nosec G101 -- only a key constant
+const (
+	ContinueWithActionShowVerificationUIString ContinueWithActionShowVerificationUI = "show_verification_ui"
+)
 
 var _ ContinueWith = new(ContinueWithVerificationUI)
 
@@ -59,7 +66,7 @@ type ContinueWithVerificationUI struct {
 	// Action will always be `show_verification_ui`
 	//
 	// required: true
-	Action ContinueWithAction `json:"action"`
+	Action ContinueWithActionShowVerificationUI `json:"action"`
 	// Flow contains the ID of the verification flow
 	//
 	// required: true
@@ -86,7 +93,7 @@ type ContinueWithVerificationUIFlow struct {
 
 func NewContinueWithVerificationUI(f Flow, address, url string) *ContinueWithVerificationUI {
 	return &ContinueWithVerificationUI{
-		Action: ContinueWithActionShowVerificationUI,
+		Action: ContinueWithActionShowVerificationUIString,
 		Flow: ContinueWithVerificationUIFlow{
 			ID:                f.GetID(),
 			VerifiableAddress: address,

--- a/selfservice/hook/session_issuer_test.go
+++ b/selfservice/hook/session_issuer_test.go
@@ -76,8 +76,8 @@ func TestSessionIssuer(t *testing.T) {
 			require.Len(t, f.ContinueWithItems, 1)
 
 			st := f.ContinueWithItems[0]
-			require.IsType(t, &flow.ContinueWithSetToken{}, st)
-			assert.NotEmpty(t, st.(*flow.ContinueWithSetToken).OrySessionToken)
+			require.IsType(t, &flow.ContinueWithSetOrySessionToken{}, st)
+			assert.NotEmpty(t, st.(*flow.ContinueWithSetOrySessionToken).OrySessionToken)
 
 			got, err := reg.SessionPersister().GetSession(context.Background(), s.ID, session.ExpandNothing)
 			require.NoError(t, err)

--- a/spec/api.json
+++ b/spec/api.json
@@ -478,13 +478,12 @@
         "description": "Indicates that a session was issued, and the application should use this token for authenticated requests",
         "properties": {
           "action": {
-            "description": "Action will always be `set_ory_session_token`\nset_ory_session_token ContinueWithActionSetOrySessionToken\nshow_verification_ui ContinueWithActionShowVerificationUI",
+            "description": "Action will always be `set_ory_session_token`\nset_ory_session_token ContinueWithActionSetOrySessionTokenString",
             "enum": [
-              "set_ory_session_token",
-              "show_verification_ui"
+              "set_ory_session_token"
             ],
             "type": "string",
-            "x-go-enum-desc": "set_ory_session_token ContinueWithActionSetOrySessionToken\nshow_verification_ui ContinueWithActionShowVerificationUI"
+            "x-go-enum-desc": "set_ory_session_token ContinueWithActionSetOrySessionTokenString"
           },
           "ory_session_token": {
             "description": "Token is the token of the session",
@@ -501,13 +500,12 @@
         "description": "Indicates, that the UI flow could be continued by showing a verification ui",
         "properties": {
           "action": {
-            "description": "Action will always be `show_verification_ui`\nset_ory_session_token ContinueWithActionSetOrySessionToken\nshow_verification_ui ContinueWithActionShowVerificationUI",
+            "description": "Action will always be `show_verification_ui`\nshow_verification_ui ContinueWithActionShowVerificationUIString",
             "enum": [
-              "set_ory_session_token",
               "show_verification_ui"
             ],
             "type": "string",
-            "x-go-enum-desc": "set_ory_session_token ContinueWithActionSetOrySessionToken\nshow_verification_ui ContinueWithActionShowVerificationUI"
+            "x-go-enum-desc": "show_verification_ui ContinueWithActionShowVerificationUIString"
           },
           "flow": {
             "$ref": "#/components/schemas/continueWithVerificationUiFlow"

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -3519,13 +3519,12 @@
       ],
       "properties": {
         "action": {
-          "description": "Action will always be `set_ory_session_token`\nset_ory_session_token ContinueWithActionSetOrySessionToken\nshow_verification_ui ContinueWithActionShowVerificationUI",
+          "description": "Action will always be `set_ory_session_token`\nset_ory_session_token ContinueWithActionSetOrySessionTokenString",
           "type": "string",
           "enum": [
-            "set_ory_session_token",
-            "show_verification_ui"
+            "set_ory_session_token"
           ],
-          "x-go-enum-desc": "set_ory_session_token ContinueWithActionSetOrySessionToken\nshow_verification_ui ContinueWithActionShowVerificationUI"
+          "x-go-enum-desc": "set_ory_session_token ContinueWithActionSetOrySessionTokenString"
         },
         "ory_session_token": {
           "description": "Token is the token of the session",
@@ -3542,13 +3541,12 @@
       ],
       "properties": {
         "action": {
-          "description": "Action will always be `show_verification_ui`\nset_ory_session_token ContinueWithActionSetOrySessionToken\nshow_verification_ui ContinueWithActionShowVerificationUI",
+          "description": "Action will always be `show_verification_ui`\nshow_verification_ui ContinueWithActionShowVerificationUIString",
           "type": "string",
           "enum": [
-            "set_ory_session_token",
             "show_verification_ui"
           ],
-          "x-go-enum-desc": "set_ory_session_token ContinueWithActionSetOrySessionToken\nshow_verification_ui ContinueWithActionShowVerificationUI"
+          "x-go-enum-desc": "show_verification_ui ContinueWithActionShowVerificationUIString"
         },
         "flow": {
           "$ref": "#/definitions/continueWithVerificationUiFlow"


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->
The generation of the `continue_with` items somehow broke, and I am not sure how it ever worked.

Before we generated 

<details>
<summary>Before</summary>


```typescript
/**
 * @type ContinueWith
 * @export
 */
export declare type ContinueWith = ContinueWithSetOrySessionToken | ContinueWithVerificationUi;
/**
 * Indicates that a session was issued, and the application should use this token for authenticated requests
 * @export
 * @interface ContinueWithSetOrySessionToken
 */
export type ContinueWithSetOrySessionToken {
    /**
     * Action will always be `set_ory_session_token` set_ory_session_token ContinueWithActionSetOrySessionToken show_verification_ui ContinueWithActionShowVerificationUI
     * @type {string}
     * @memberof ContinueWithSetOrySessionToken
     */
    'action': ContinueWithSetOrySessionTokenActionEnum;
    /**
     * Token is the token of the session
     * @type {string}
     * @memberof ContinueWithSetOrySessionToken
     */
    'ory_session_token': string;
}
export declare const ContinueWithSetOrySessionTokenActionEnum: {
    readonly SetOrySessionToken: "set_ory_session_token";
    readonly ShowVerificationUi: "show_verification_ui";
};
export declare type ContinueWithSetOrySessionTokenActionEnum = typeof ContinueWithSetOrySessionTokenActionEnum[keyof typeof ContinueWithSetOrySessionTokenActionEnum];
/**
 * Indicates, that the UI flow could be continued by showing a verification ui
 * @export
 * @interface ContinueWithVerificationUi
 */
export type ContinueWithVerificationUi {
    /**
     * Action will always be `show_verification_ui` set_ory_session_token ContinueWithActionSetOrySessionToken show_verification_ui ContinueWithActionShowVerificationUI
     * @type {string}
     * @memberof ContinueWithVerificationUi
     */
    'action': ContinueWithVerificationUiActionEnum;
    /**
     *
     * @type {ContinueWithVerificationUiFlow}
     * @memberof ContinueWithVerificationUi
     */
    'flow': {s: string};
}


export declare const ContinueWithVerificationUiActionEnum: {
    readonly SetOrySessionToken: "set_ory_session_token";
    readonly ShowVerificationUi: "show_verification_ui";
};
export declare type ContinueWithVerificationUiActionEnum = typeof ContinueWithVerificationUiActionEnum[keyof typeof ContinueWithVerificationUiActionEnum];

function main(c: ContinueWith) {
  if (c.action == "set_ory_session_token") {
    c.ory_session_token
  }
}
``` 



</details>

Which broke the discriminator values:

```typescript
export declare const ContinueWithSetOrySessionTokenActionEnum: {
    readonly SetOrySessionToken: "set_ory_session_token";
    readonly ShowVerificationUi: "show_verification_ui";
};
```

should've been 


```typescript
export declare const ContinueWithSetOrySessionTokenActionEnum: {
    readonly SetOrySessionToken: "set_ory_session_token";
};
```

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [ ] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
