### PR TITLE
fix: consider OIDC registration flows errored with duplicate credential to be completed by strategy

### DIFF
--- a/selfservice/strategy/oidc/strategy.go
+++ b/selfservice/strategy/oidc/strategy.go
@@ -552,7 +552,7 @@ func (s *Strategy) handleError(w http.ResponseWriter, r *http.Request, f flow.Fl
 			// return a new login flow with the error message embedded in the login flow.
 			x.AcceptToRedirectOrJSON(w, r, s.d.Writer(), lf, lf.AppendTo(s.d.Config().SelfServiceFlowLoginUI(r.Context())).String())
 			// ensure the function does not continue to execute
-			return registration.ErrHookAbortFlow
+			return flow.ErrCompletedByStrategy
 		}
 
 		rf.UI.Nodes = node.Nodes{}


### PR DESCRIPTION
Returning anything else here may cause Kratos to respond with two concatenated JSON objects: new login flow with actual error message as the first one and a very confusing '500, aborted registration hook execution' as the second one.

## Related issue(s)

To reproduce this bug on current `master`:

1. Launch Kratos where default identity has email as identifier and allows registration via password and some OIDC provider (e.g. Google).
2. Register using password, providing the same email as the one from the Google account that will be used in the next step.
3. Try to register using Google account with matching email, using API flow and sending `id_token` in the request body to avoid webview/redirections.

This will trigger the code path designed to handle [`identity.ErrDuplicateCredentials`](https://github.com/ory/kratos/blob/32d8306e82224cf6beda239e87b62e2a8f25bfb4/selfservice/strategy/oidc/strategy.go#L541) and [try to convert the registration to a login flow](https://github.com/ory/kratos/blob/32d8306e82224cf6beda239e87b62e2a8f25bfb4/selfservice/strategy/oidc/strategy.go#L543) containing the expected `An account with the same identifier (email, phone, username, ...) exists already.` message, then [write this new login flow into HTTP response body](https://github.com/ory/kratos/blob/32d8306e82224cf6beda239e87b62e2a8f25bfb4/selfservice/strategy/oidc/strategy.go#L548). However, because [`registration.ErrHookAbortFlow` is returned](https://github.com/ory/kratos/blob/32d8306e82224cf6beda239e87b62e2a8f25bfb4/selfservice/strategy/oidc/strategy.go#L550) just a bit further, [the outer request handler will write another object to the response body](https://github.com/ory/kratos/blob/32d8306e82224cf6beda239e87b62e2a8f25bfb4/selfservice/flow/registration/handler.go#L590), this one containing very confusing "500, aborted registration hook execution" error.

As far as I can tell, this is a malformed JSON.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

I discovered this when rebasing #3416 because I ran into it while investigating why e2e tests related to settings flows are suddenly failing. Even though applying this fix this didn't fix those tests for me, I realized that this issue wasn't caused by my code and can be also be reproduced on current `master` when I prepare the request in a way that avoids the OIDC redirection by other means, e.g. passing the `id_token` from native Google SDK.

Here's a picture with request made using Postman, showing an example of such malformed response:

![Screenshot_20230920_140846](https://github.com/ory/kratos/assets/26201033/8a2a652f-f8ae-4553-a814-242e8ccb002b)

By the way, is it actually allowed for Kratos to reply with a totally different kind of flow (in this case, login one) when calling POST / Update on another flow directly in the response body rather than always issuing a redirect, either via HTTP 303 or 422 with `{"error":{"id":"browser_location_change_required","code":422,"status":"Unprocessable Entity","message":"browser location change required"},"redirect_browser_to":"…/login?flow=…"}`? Because the reference React / SPA client used in e2e tests doesn't seem to handle this well and never displays the `An account with the same identifier (email, phone, username, ...) exists already.` message to the user, instead simply returning to main/welcome page.