### PR TITLE
fix: schema test errors

### DIFF
--- a/identity/.snapshots/TestHandler-case=should_be_able_to_import_users-without_traits.json
+++ b/identity/.snapshots/TestHandler-case=should_be_able_to_import_users-without_traits.json
@@ -3,5 +3,6 @@
   "state": "active",
   "traits": {},
   "metadata_public": null,
-  "metadata_admin": null
+  "metadata_admin": null,
+  "organization_id": null
 }

--- a/test/schema/fixtures/config.schema.test.success/selfServiceAfterSettings.full.yaml
+++ b/test/schema/fixtures/config.schema.test.success/selfServiceAfterSettings.full.yaml
@@ -1,3 +1,3 @@
 default_browser_return_url: "#/definitions/defaultReturnTo"
-password: "#/definitions/selfServiceAfterSettingsMethod"
+password: "#/definitions/selfServiceAfterSettingsAuthMethod"
 profile: "#/definitions/selfServiceAfterSettingsMethod"

--- a/test/schema/fixtures/config.schema.test.success/selfServiceAfterSettingsAuthMethod.full.yaml
+++ b/test/schema/fixtures/config.schema.test.success/selfServiceAfterSettingsAuthMethod.full.yaml
@@ -1,3 +1,4 @@
 default_browser_return_url: "#/definitions/defaultReturnTo"
 hooks:
   - "#/definitions/selfServiceWebHook"
+  - "#/definitions/selfServiceSessionRevokerHook"


### PR DESCRIPTION
Test failures were introduced in https://github.com/ory/kratos/pull/3519.
Outdated snapshots were caused by merging an outdated branch.