### PR TITLE
fix: add value code to authentication method enum

### DIFF
--- a/.schema/openapi/patches/session.yaml
+++ b/.schema/openapi/patches/session.yaml
@@ -20,6 +20,7 @@
       - link_recovery
       - code_recovery
       - password
+      - code
       - totp
       - oidc
       - webauthn

--- a/spec/api.json
+++ b/spec/api.json
@@ -1773,6 +1773,7 @@
               "link_recovery",
               "code_recovery",
               "password",
+              "code",
               "totp",
               "oidc",
               "webauthn",


### PR DESCRIPTION
I found an issue in the [current client open api spec (v1.2.10)](https://github.com/ory/sdk/blob/master/spec/client/v1.2.10.json).
Line 5740 - ref: "#/components/schemas/sessionAuthenticationMethod". There is the method "code" missing. For the new one-time code passwordless feature.

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

