### PR TITLE
fix: increase connection-level timeouts and shutdown timeouts

### DIFF
--- a/cmd/daemon/serve.go
+++ b/cmd/daemon/serve.go
@@ -69,6 +69,10 @@ func WithContext(ctx stdctx.Context) Option {
 	}
 }
 
+func init() {
+	graceful.DefaultShutdownTimeout = 120 * time.Second
+}
+
 func servePublic(r driver.Registry, cmd *cobra.Command, eg *errgroup.Group, slOpts *servicelocatorx.Options, opts []Option) {
 	modifiers := NewOptions(cmd.Context(), opts)
 	ctx := modifiers.ctx
@@ -132,8 +136,12 @@ func servePublic(r driver.Registry, cmd *cobra.Command, eg *errgroup.Group, slOp
 
 	//#nosec G112 -- the correct settings are set by graceful.WithDefaults
 	server := graceful.WithDefaults(&http.Server{
-		Handler:   handler,
-		TLSConfig: &tls.Config{GetCertificate: certs, MinVersion: tls.VersionTLS12},
+		Handler:           handler,
+		TLSConfig:         &tls.Config{GetCertificate: certs, MinVersion: tls.VersionTLS12},
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       15 * time.Second,
+		WriteTimeout:      60 * time.Second,
+		IdleTimeout:       120 * time.Second,
 	})
 	addr := c.PublicListenOn(ctx)
 
@@ -206,8 +214,12 @@ func serveAdmin(r driver.Registry, cmd *cobra.Command, eg *errgroup.Group, slOpt
 
 	//#nosec G112 -- the correct settings are set by graceful.WithDefaults
 	server := graceful.WithDefaults(&http.Server{
-		Handler:   handler,
-		TLSConfig: &tls.Config{GetCertificate: certs, MinVersion: tls.VersionTLS12},
+		Handler:           handler,
+		TLSConfig:         &tls.Config{GetCertificate: certs, MinVersion: tls.VersionTLS12},
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      120 * time.Second,
+		IdleTimeout:       600 * time.Second,
 	})
 
 	addr := c.AdminListenOn(ctx)


### PR DESCRIPTION
The admin API is generally expected to require longer timeouts, for example during bulk identity import. 

Previously, we used `ory/graceful`'s default write timeout (10s). That has a couple of problems:

1. 10s is too short for expensive operations such as bulk identity import.
2. The server-level timeouts of `http.Server` (`WriteTimeout` etc) work in surprising ways. See https://github.com/golang/go/issues/59602. After reaching the timeout, the connection is closed and no more writes will be transported to the client. But there is no way to detect this from the handler. Writing to the `http.ResponseWriter` returns no error, and the request context is not canceled. So until now, for long requests, we would just keep truckin' and perform all the work and finally write a `200 OK` response. Logs and tracing would show no problems, even though the downstream had their connection closed on them much earlier and they received no response.

We could consider adding more advanced timeout detection in the future, for example into `ory/graceful`.