### PR TITLE
fix: lower-case recovery & verification emails on import

### DIFF
--- a/identity/.snapshots/TestHandler-case=should_be_able_to_import_users-with_not-normalized_email.json
+++ b/identity/.snapshots/TestHandler-case=should_be_able_to_import_users-with_not-normalized_email.json
@@ -1,0 +1,34 @@
+{
+  "credentials": {
+    "password": {
+      "type": "password",
+      "identifiers": [
+        "uppercased@ory.sh"
+      ],
+      "config": {},
+      "version": 0
+    }
+  },
+  "schema_id": "customer",
+  "state": "active",
+  "traits": {
+    "email": "UpperCased@ory.sh"
+  },
+  "verifiable_addresses": [
+    {
+      "value": "uppercased@ory.sh",
+      "verified": true,
+      "via": "email",
+      "status": "completed"
+    }
+  ],
+  "recovery_addresses": [
+    {
+      "value": "uppercased@ory.sh",
+      "via": "email"
+    }
+  ],
+  "metadata_public": null,
+  "metadata_admin": null,
+  "organization_id": null
+}

--- a/identity/.snapshots/TestHandler-suite=PATCH_identities-case=success-assert=identity_0.json
+++ b/identity/.snapshots/TestHandler-suite=PATCH_identities-case=success-assert=identity_0.json
@@ -16,11 +16,11 @@
   "state": "active",
   "traits": {
     "emails": [
-      "batch-import-0-0@ory.sh",
-      "batch-import-0-1@ory.sh",
-      "batch-import-0-2@ory.sh",
-      "batch-import-0-3@ory.sh"
+      "Batch-Import-0-0@ory.sh",
+      "Batch-Import-0-1@ory.sh",
+      "Batch-Import-0-2@ory.sh",
+      "Batch-Import-0-3@ory.sh"
     ],
-    "username": "batch-import-0-0@ory.sh"
+    "username": "Batch-Import-0-0@ory.sh"
   }
 }

--- a/identity/handler.go
+++ b/identity/handler.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/ory/x/pagination/keysetpagination"
@@ -488,6 +489,13 @@ func (h *Handler) identityFromCreateIdentityBody(ctx context.Context, cr *Create
 		RecoveryAddresses:   cr.RecoveryAddresses,
 		MetadataAdmin:       []byte(cr.MetadataAdmin),
 		MetadataPublic:      []byte(cr.MetadataPublic),
+	}
+	// Lowercase all emails, because the schema extension will otherwise not find them.
+	for k := range i.VerifiableAddresses {
+		i.VerifiableAddresses[k].Value = strings.ToLower(i.VerifiableAddresses[k].Value)
+	}
+	for k := range i.RecoveryAddresses {
+		i.RecoveryAddresses[k].Value = strings.ToLower(i.RecoveryAddresses[k].Value)
 	}
 
 	if err := h.importCredentials(ctx, i, cr.Credentials); err != nil {


### PR DESCRIPTION
Emails that contained upper-case characters would be overwritten by the identity schema extension runner, because there all emails are lower-cased.