### PR TITLE
fix: always return relative URLs in the Link header for pagination

### DIFF
--- a/courier/handler.go
+++ b/courier/handler.go
@@ -19,9 +19,11 @@ import (
 	"github.com/ory/kratos/x"
 )
 
-const AdminRouteCourier = "/courier"
-const AdminRouteListMessages = AdminRouteCourier + "/messages"
-const AdminRouteGetMessage = AdminRouteCourier + "/messages/:msgID"
+const (
+	AdminRouteCourier      = "/courier"
+	AdminRouteListMessages = AdminRouteCourier + "/messages"
+	AdminRouteGetMessage   = AdminRouteCourier + "/messages/:msgID"
+)
 
 type (
 	handlerDependencies interface {
@@ -128,7 +130,8 @@ func (h *Handler) listCourierMessages(w http.ResponseWriter, r *http.Request, _ 
 	}
 
 	w.Header().Set("X-Total-Count", fmt.Sprint(tc))
-	keysetpagination.Header(w, r.URL, nextPage)
+	u := *r.URL
+	keysetpagination.Header(w, &u, nextPage)
 	h.r.Writer().Write(w, r, l)
 }
 
@@ -137,7 +140,6 @@ func parseMessagesFilter(r *http.Request) (ListCourierMessagesParameters, []keys
 
 	if r.URL.Query().Has("status") {
 		ms, err := ToMessageStatus(r.URL.Query().Get("status"))
-
 		if err != nil {
 			return ListCourierMessagesParameters{}, nil, err
 		}
@@ -190,7 +192,6 @@ type getCourierMessage struct {
 //		default: errorGeneric
 func (h *Handler) getCourierMessage(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	msgID, err := uuid.FromString(ps.ByName("msgID"))
-
 	if err != nil {
 		h.r.Writer().WriteError(w, r, herodot.ErrBadRequest.WithError(err.Error()).WithDebugf("could not parse parameter {id} as UUID, got %s", ps.ByName("id")))
 		return

--- a/identity/handler.go
+++ b/identity/handler.go
@@ -213,9 +213,11 @@ func (h *Handler) list(w http.ResponseWriter, r *http.Request, _ httprouter.Para
 				return
 			}
 		}
-		pagepagination.PaginationHeader(w, urlx.AppendPaths(h.r.Config().SelfAdminURL(r.Context()), RouteCollection), total, params.PagePagination.Page, params.PagePagination.ItemsPerPage)
+		u := *r.URL
+		pagepagination.PaginationHeader(w, &u, total, params.PagePagination.Page, params.PagePagination.ItemsPerPage)
 	} else {
-		keysetpagination.Header(w, urlx.AppendPaths(h.r.Config().SelfAdminURL(r.Context()), RouteCollection), nextPage)
+		u := *r.URL
+		keysetpagination.Header(w, &u, nextPage)
 	}
 
 	// Identities using the marshaler for including metadata_admin

--- a/identity/handler_test.go
+++ b/identity/handler_test.go
@@ -1553,7 +1553,7 @@ func TestHandler(t *testing.T) {
 			t.Run("using token pagination", func(t *testing.T) {
 				knownIDs := make(map[string]struct{})
 				var pages int
-				path := fmt.Sprintf("/identities?page_size=%d", perPage)
+				path := fmt.Sprintf("/admin/identities?page_size=%d", perPage)
 				for {
 					pages++
 					next, res := run(t, path, knownIDs)
@@ -1573,7 +1573,7 @@ func TestHandler(t *testing.T) {
 			t.Run("using page pagination", func(t *testing.T) {
 				knownIDs := make(map[string]struct{})
 				var pages int
-				path := fmt.Sprintf("/identities?page=0&per_page=%d", perPage)
+				path := fmt.Sprintf("/admin/identities?page=0&per_page=%d", perPage)
 				for {
 					pages++
 					next, res := run(t, path, knownIDs)

--- a/persistence/sql/identity/persister_identity.go
+++ b/persistence/sql/identity/persister_identity.go
@@ -192,9 +192,6 @@ var credentialsTypes = struct {
 }
 
 func (p *IdentityPersister) findIdentityCredentialsType(ctx context.Context, ct identity.CredentialsType) (_ *identity.CredentialsTypeTable, err error) {
-	ctx, span := p.r.Tracer(ctx).Tracer().Start(ctx, "persistence.sql.findIdentityCredentialsType")
-	defer otelx.End(span, &err)
-
 	credentialsTypes.RLock()
 	v, ok := credentialsTypes.m[ct]
 	credentialsTypes.RUnlock()
@@ -202,6 +199,9 @@ func (p *IdentityPersister) findIdentityCredentialsType(ctx context.Context, ct 
 	if ok && v != nil {
 		return v, nil
 	}
+
+	ctx, span := p.r.Tracer(ctx).Tracer().Start(ctx, "persistence.sql.findIdentityCredentialsType")
+	defer otelx.End(span, &err)
 
 	var m identity.CredentialsTypeTable
 	if err := p.GetConnection(ctx).Where("name = ?", ct).First(&m); err != nil {

--- a/schema/handler.go
+++ b/schema/handler.go
@@ -17,8 +17,6 @@ import (
 
 	"github.com/ory/x/pagination/migrationpagination"
 
-	"github.com/ory/x/urlx"
-
 	"github.com/ory/kratos/driver/config"
 
 	"github.com/julienschmidt/httprouter"
@@ -233,7 +231,7 @@ func (h *Handler) getAll(w http.ResponseWriter, r *http.Request, ps httprouter.P
 		})
 	}
 
-	x.PaginationHeader(w, urlx.AppendPaths(h.r.Config().SelfPublicURL(r.Context()), fmt.Sprintf("/%s", SchemasPath)), int64(total), page, itemsPerPage)
+	x.PaginationHeader(w, *r.URL, int64(total), page, itemsPerPage)
 	h.r.Writer().Write(w, r, ss)
 }
 

--- a/selfservice/hook/show_verification_ui.go
+++ b/selfservice/hook/show_verification_ui.go
@@ -15,9 +15,7 @@ import (
 	"github.com/ory/x/otelx"
 )
 
-var (
-	_ registration.PostHookPostPersistExecutor = new(ShowVerificationUIHook)
-)
+var _ registration.PostHookPostPersistExecutor = new(ShowVerificationUIHook)
 
 type (
 	showVerificationUIDependencies interface {
@@ -42,7 +40,7 @@ func NewShowVerificationUIHook(d showVerificationUIDependencies) *ShowVerificati
 // ExecutePostRegistrationPostPersistHook adds redirect headers and status code if the request is a browser request.
 // If the request is not a browser request, this hook does nothing.
 func (e *ShowVerificationUIHook) ExecutePostRegistrationPostPersistHook(_ http.ResponseWriter, r *http.Request, f *registration.Flow, _ *session.Session) error {
-	return otelx.WithSpan(r.Context(), "selfservice.hook.SessionIssuer.ExecutePostRegistrationPostPersistHook", func(ctx context.Context) error {
+	return otelx.WithSpan(r.Context(), "selfservice.hook.ShowVerificationUIHook.ExecutePostRegistrationPostPersistHook", func(ctx context.Context) error {
 		return e.execute(r.WithContext(ctx), f)
 	})
 }

--- a/session/handler.go
+++ b/session/handler.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/ory/x/decoderx"
-	"github.com/ory/x/urlx"
 
 	"github.com/ory/herodot"
 
@@ -409,7 +408,8 @@ func (h *Handler) adminListSessions(w http.ResponseWriter, r *http.Request, ps h
 	}
 
 	w.Header().Set("x-total-count", fmt.Sprint(total))
-	keysetpagination.Header(w, r.URL, nextPage)
+	u := *r.URL
+	keysetpagination.Header(w, &u, nextPage)
 	h.r.Writer().Write(w, r, sess)
 }
 
@@ -616,7 +616,7 @@ func (h *Handler) listIdentitySessions(w http.ResponseWriter, r *http.Request, p
 		return
 	}
 
-	x.PaginationHeader(w, urlx.AppendPaths(h.r.Config().SelfAdminURL(r.Context()), RouteCollection), total, page, perPage)
+	x.PaginationHeader(w, *r.URL, total, page, perPage)
 	h.r.Writer().Write(w, r, sess)
 }
 
@@ -822,7 +822,7 @@ func (h *Handler) listMySessions(w http.ResponseWriter, r *http.Request, _ httpr
 		return
 	}
 
-	x.PaginationHeader(w, urlx.AppendPaths(h.r.Config().SelfAdminURL(r.Context()), RouteCollection), total, page, perPage)
+	x.PaginationHeader(w, *r.URL, total, page, perPage)
 	h.r.Writer().Write(w, r, sess)
 }
 

--- a/x/pagination.go
+++ b/x/pagination.go
@@ -18,8 +18,8 @@ func ParsePagination(r *http.Request) (page, itemsPerPage int) {
 	return migrationpagination.NewDefaultPaginator().ParsePagination(r)
 }
 
-func PaginationHeader(w http.ResponseWriter, u *url.URL, total int64, page, itemsPerPage int) {
-	migrationpagination.PaginationHeader(w, u, total, page, itemsPerPage)
+func PaginationHeader(w http.ResponseWriter, u url.URL, total int64, page, itemsPerPage int) {
+	migrationpagination.PaginationHeader(w, &u, total, page, itemsPerPage)
 }
 
 type Page struct {


### PR DESCRIPTION
This is much less brittle when Kratos is deployed behind a proxy which rewrites the Host header. Example from Ory Network: before this change, when the initial request was made to a CNAME, the Link header of the response contains `<slug>.projects.oryapis.com`.

Another problem with the previous solution was that the `/admin` prefix would occasionally be stripped from the Link header in the response. For example, the first request would go to `/admin/identities?page=0`, and the Link header would contain `</identities?page=1>; rel="next"`.

Now, we always return a modified version of the exact path that was requested. Should solve both of these issues.