### PR TITLE
fix: allow ory suite in selfhosted mode to live in the same schema. [postgresql]

### DIFF
--- a/persistence/sql/migrations/sql/20150100000001000000_networks.postgres.up.sql
+++ b/persistence/sql/migrations/sql/20150100000001000000_networks.postgres.up.sql
@@ -1,4 +1,4 @@
-CREATE TABLE "networks" (
+CREATE TABLE IF NOT EXISTS "networks" (
 "id" UUID NOT NULL,
 PRIMARY KEY("id"),
 "created_at" timestamp NOT NULL,


### PR DESCRIPTION
## Checklist

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
This small change will allow deploying both kratos and hydra in the same schema. 
This is useful when person do not have privilege to create another schema in postgresql .

This will not affect existing databases and should be transparent in any new release.

I will open similar PR in hydra if this PR is considered.

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

