### PR TITLE
fix: auto migrate old accounts to use code credential

### DIFF
--- a/driver/config/config.go
+++ b/driver/config/config.go
@@ -231,8 +231,7 @@ type (
 	}
 	SelfServiceStrategyCode struct {
 		*SelfServiceStrategy
-		PasswordlessEnabled              bool `json:"passwordless_enabled"`
-		PasswordlessLoginFallbackEnabled bool `json:"passwordless_login_fallback_enabled"`
+		PasswordlessEnabled bool `json:"passwordless_enabled"`
 	}
 	Schema struct {
 		ID  string `json:"id" koanf:"id"`
@@ -764,8 +763,7 @@ func (p *Config) SelfServiceCodeStrategy(ctx context.Context) *SelfServiceStrate
 			Enabled: pp.BoolF(basePath+".enabled", true),
 			Config:  config,
 		},
-		PasswordlessEnabled:              pp.BoolF(basePath+".passwordless_enabled", false),
-		PasswordlessLoginFallbackEnabled: pp.BoolF(basePath+".passwordless_login_fallback_enabled", false),
+		PasswordlessEnabled: pp.BoolF(basePath+".passwordless_enabled", false),
 	}
 }
 

--- a/driver/config/config_test.go
+++ b/driver/config/config_test.go
@@ -567,7 +567,6 @@ func TestViperProvider_Defaults(t *testing.T) {
 			assert.True(t, p.SelfServiceStrategy(ctx, "code").Enabled)
 			assert.False(t, p.SelfServiceStrategy(ctx, "oidc").Enabled)
 			assert.False(t, p.SelfServiceCodeStrategy(ctx).PasswordlessEnabled)
-			assert.False(t, p.SelfServiceCodeStrategy(ctx).PasswordlessLoginFallbackEnabled)
 			assert.False(t, p.SelfServiceFlowRecoveryNotifyUnknownRecipients(ctx))
 			assert.False(t, p.SelfServiceFlowVerificationNotifyUnknownRecipients(ctx))
 		})
@@ -1090,6 +1089,23 @@ func TestPasswordless(t *testing.T) {
 	assert.True(t, conf.WebAuthnForPasswordless(ctx))
 	conf.MustSet(ctx, config.ViperKeyWebAuthnPasswordless, false)
 	assert.False(t, conf.WebAuthnForPasswordless(ctx))
+}
+
+func TestPasswordlessCode(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	conf, err := config.New(ctx, logrusx.New("", ""), os.Stderr,
+		configx.SkipValidation(),
+		configx.WithValue(config.ViperKeySelfServiceStrategyConfig+".code", map[string]interface{}{
+			"passwordless_enabled":                true,
+			"passwordless_login_fallback_enabled": true,
+			"config":                              map[string]interface{}{},
+		}))
+	require.NoError(t, err)
+
+	assert.True(t, conf.SelfServiceCodeStrategy(ctx).PasswordlessEnabled)
 }
 
 func TestChangeMinPasswordLength(t *testing.T) {

--- a/selfservice/strategy/code/stub/code.identity.schema.json
+++ b/selfservice/strategy/code/stub/code.identity.schema.json
@@ -16,6 +16,9 @@
               "code": {
                 "identifier": true,
                 "via": "email"
+              },
+              "password": {
+                "identifier": true
               }
             },
             "verification": {

--- a/selfservice/strategy/password/stub/registration.schema.json
+++ b/selfservice/strategy/password/stub/registration.schema.json
@@ -22,10 +22,7 @@
           }
         }
       },
-      "required": [
-        "foobar",
-        "username"
-      ]
+      "required": ["foobar", "username"]
     }
   },
   "additionalProperties": false

--- a/test/e2e/cypress/integration/profiles/code/login/error.spec.ts
+++ b/test/e2e/cypress/integration/profiles/code/login/error.spec.ts
@@ -1,7 +1,7 @@
 // Copyright © 2023 Ory Corp
 // SPDX-License-Identifier: Apache-2.0
 
-import { appPrefix, APP_URL, gen, MOBILE_URL } from "../../../../helpers"
+import { gen, MOBILE_URL } from "../../../../helpers"
 import { routes as express } from "../../../../helpers/express"
 import { routes as react } from "../../../../helpers/react"
 

--- a/test/e2e/profiles/code/.kratos.yml
+++ b/test/e2e/profiles/code/.kratos.yml
@@ -36,6 +36,7 @@ selfservice:
       enabled: true
     code:
       passwordless_enabled: true
+      passwordless_login_fallback_enabled: false
       enabled: true
       config:
         lifespan: 1h


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

When the Identity schema contains the `code` extension, a `code` credential is automatically applied on other authentication methods, such as registering with password.

For old accounts that registered before the `code` extension, they will need to automatically migrate to have the credential added to their account. For this there is a fallback mechanism that automatically kicks in.

Since old and new accounts should share the same behavior, I have removed the `passwordless_login_fallback_enabled` config key, since its use is redundant and will only prevent old accounts from also logging in with one-time code.

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [ ] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
