### PR TITLE
chore: simplify courier

### DIFF
--- a/courier/courier.go
+++ b/courier/courier.go
@@ -65,12 +65,17 @@ func NewCourier(ctx context.Context, deps Dependencies) (Courier, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	expBackoff := backoff.NewExponentialBackOff()
+	// never stop retrying
+	expBackoff.MaxElapsedTime = 0
+
 	return &courier{
 		smsClient:  newSMS(ctx, deps),
 		smtpClient: smtp,
 		httpClient: newHTTP(ctx, deps),
 		deps:       deps,
-		backoff:    backoff.NewExponentialBackOff(),
+		backoff:    expBackoff,
 	}, nil
 }
 
@@ -79,35 +84,28 @@ func (c *courier) FailOnDispatchError() {
 }
 
 func (c *courier) Work(ctx context.Context) error {
-	errChan := make(chan error)
-	defer close(errChan)
-
-	go c.watchMessages(ctx, errChan)
-
-	select {
-	case <-ctx.Done():
-		if errors.Is(ctx.Err(), context.Canceled) {
-			return nil
+	for {
+		select {
+		case <-ctx.Done():
+			if errors.Is(ctx.Err(), context.Canceled) {
+				return nil
+			}
+			return ctx.Err()
+		case <-time.After(time.Second):
+			if err := backoff.Retry(func() error {
+				if err := c.DispatchQueue(ctx); err != nil {
+					return err
+				}
+				// when we succeed, we want to reset the backoff
+				c.backoff.Reset()
+				return nil
+			}, c.backoff); err != nil {
+				return err
+			}
 		}
-		return ctx.Err()
-	case err := <-errChan:
-		return err
 	}
 }
 
 func (c *courier) UseBackoff(b backoff.BackOff) {
 	c.backoff = b
-}
-
-func (c *courier) watchMessages(ctx context.Context, errChan chan error) {
-	c.backoff.Reset()
-	for {
-		if err := backoff.Retry(func() error {
-			return c.DispatchQueue(ctx)
-		}, c.backoff); err != nil {
-			errChan <- err
-			return
-		}
-		time.Sleep(time.Second)
-	}
 }

--- a/courier/courier_dispatcher.go
+++ b/courier/courier_dispatcher.go
@@ -57,13 +57,10 @@ func (c *courier) DispatchQueue(ctx context.Context) error {
 
 	messages, err := c.deps.CourierPersister().NextMessages(ctx, 10)
 	if err != nil {
-		if errors.Is(err, ErrQueueEmpty) {
-			return nil
-		}
 		return err
 	}
 
-	for k, msg := range messages {
+	for _, msg := range messages {
 		if msg.SendCount > maxRetries {
 			if err := c.deps.CourierPersister().SetMessageStatus(ctx, msg.ID, MessageStatusAbandoned); err != nil {
 				c.deps.Logger().
@@ -79,41 +76,33 @@ func (c *courier) DispatchQueue(ctx context.Context) error {
 				WithField("message_id", msg.ID).
 				WithField("message_nid", msg.NID).
 				Warnf(`Message was abandoned because it did not deliver after %d attempts`, msg.SendCount)
-		} else if err := c.DispatchMessage(ctx, msg); err != nil {
+			continue
+		}
+
+		if err := c.DispatchMessage(ctx, msg); err != nil {
 			if err := c.deps.CourierPersister().RecordDispatch(ctx, msg.ID, CourierMessageDispatchStatusFailed, err); err != nil {
 				c.deps.Logger().
 					WithError(err).
 					WithField("message_id", msg.ID).
 					WithField("message_nid", msg.NID).
 					Error(`Unable to record failure log entry.`)
-				if c.failOnDispatchError {
-					return err
-				}
-			}
-
-			for _, replace := range messages[k:] {
-				if err := c.deps.CourierPersister().SetMessageStatus(ctx, replace.ID, MessageStatusQueued); err != nil {
-					c.deps.Logger().
-						WithError(err).
-						WithField("message_id", replace.ID).
-						WithField("message_nid", replace.NID).
-						Error(`Unable to reset the failed message's status to "queued".`)
-					if c.failOnDispatchError {
-						return err
-					}
-				}
+				return err
 			}
 
 			if c.failOnDispatchError {
 				return err
 			}
-		} else if err := c.deps.CourierPersister().RecordDispatch(ctx, msg.ID, CourierMessageDispatchStatusSuccess, nil); err != nil {
+			// an error happened, but we want to ignore it
+			continue
+		}
+
+		if err := c.deps.CourierPersister().RecordDispatch(ctx, msg.ID, CourierMessageDispatchStatusSuccess, nil); err != nil {
 			c.deps.Logger().
 				WithError(err).
 				WithField("message_id", msg.ID).
 				WithField("message_nid", msg.NID).
 				Error(`Unable to record success log entry.`)
-			// continue with execution, as the message was successfully dispatched
+			return err
 		}
 	}
 

--- a/courier/courier_dispatcher_test.go
+++ b/courier/courier_dispatcher_test.go
@@ -44,15 +44,16 @@ func TestDispatchMessageWithInvalidSMTP(t *testing.T) {
 
 	t.Run("case=failed sending", func(t *testing.T) {
 		id := queueNewMessage(t, ctx, c, reg)
-		message, err := reg.CourierPersister().LatestQueuedMessage(ctx)
+		messages, err := reg.CourierPersister().NextMessages(ctx, 10)
 		require.NoError(t, err)
-		require.Equal(t, id, message.ID)
+		require.Len(t, messages, 1)
+		require.Equal(t, id, messages[0].ID)
 
-		err = c.DispatchMessage(ctx, *message)
+		err = c.DispatchMessage(ctx, messages[0])
 		// sending the email fails, because there is no SMTP server at foo.url
 		require.Error(t, err)
 
-		messages, err := reg.CourierPersister().NextMessages(ctx, 10)
+		messages, err = reg.CourierPersister().NextMessages(ctx, 10)
 		require.NoError(t, err)
 		require.Len(t, messages, 1)
 	})

--- a/courier/handler_test.go
+++ b/courier/handler_test.go
@@ -96,7 +96,7 @@ func TestHandler(t *testing.T) {
 	t.Run("case=list messages", func(t *testing.T) {
 		// Arrange test data
 		const msgCount = 10    // total message count
-		const procCount = 5    // how many messages' status should be equal to `processing`
+		const sentCount = 5    // how many messages' status should be equal to `processing`
 		const rcptOryCount = 2 // how many messages' recipient should be equal to `noreply@ory.sh`
 		messages := make([]courier.Message, msgCount)
 
@@ -109,8 +109,8 @@ func TestHandler(t *testing.T) {
 			}
 			require.NoError(t, reg.CourierPersister().AddMessage(context.Background(), &messages[i]))
 		}
-		for i := 0; i < procCount; i++ {
-			require.NoError(t, reg.CourierPersister().SetMessageStatus(context.Background(), messages[i].ID, courier.MessageStatusProcessing))
+		for i := 0; i < sentCount; i++ {
+			require.NoError(t, reg.CourierPersister().SetMessageStatus(context.Background(), messages[i].ID, courier.MessageStatusSent))
 		}
 
 		t.Run("paging", func(t *testing.T) {
@@ -146,7 +146,7 @@ func TestHandler(t *testing.T) {
 				for _, tc := range tss {
 					t.Run("endpoint="+tc.name, func(t *testing.T) {
 						parsed := getList(t, tc.name, qs)
-						assert.Len(t, parsed.Array(), msgCount-procCount)
+						assert.Len(t, parsed.Array(), msgCount-sentCount)
 
 						for _, item := range parsed.Array() {
 							assert.Equal(t, "queued", item.Get("status").String())
@@ -154,16 +154,16 @@ func TestHandler(t *testing.T) {
 					})
 				}
 			})
-			t.Run("case=should return all processing messages", func(t *testing.T) {
-				qs := fmt.Sprintf(`?page_token=%s&page_size=250&status=processing`, defaultPageToken)
+			t.Run("case=should return all sent messages", func(t *testing.T) {
+				qs := fmt.Sprintf(`?page_token=%s&page_size=250&status=sent`, defaultPageToken)
 
 				for _, tc := range tss {
 					t.Run("endpoint="+tc.name, func(t *testing.T) {
 						parsed := getList(t, tc.name, qs)
-						assert.Len(t, parsed.Array(), procCount)
+						assert.Len(t, parsed.Array(), sentCount)
 
 						for _, item := range parsed.Array() {
-							assert.Equal(t, "processing", item.Get("status").String())
+							assert.Equal(t, "sent", item.Get("status").String())
 						}
 					})
 				}

--- a/courier/message.go
+++ b/courier/message.go
@@ -24,15 +24,14 @@ type MessageStatus int
 const (
 	MessageStatusQueued MessageStatus = iota + 1
 	MessageStatusSent
-	MessageStatusProcessing
+	_
 	MessageStatusAbandoned
 )
 
 const (
-	messageStatusQueuedText     = "queued"
-	messageStatusSentText       = "sent"
-	messageStatusProcessingText = "processing"
-	messageStatusAbandonedText  = "abandoned"
+	messageStatusQueuedText    = "queued"
+	messageStatusSentText      = "sent"
+	messageStatusAbandonedText = "abandoned"
 )
 
 func ToMessageStatus(str string) (MessageStatus, error) {
@@ -41,8 +40,6 @@ func ToMessageStatus(str string) (MessageStatus, error) {
 		return MessageStatusQueued, nil
 	case s.AddCase(MessageStatusSent.String()):
 		return MessageStatusSent, nil
-	case s.AddCase(MessageStatusProcessing.String()):
-		return MessageStatusProcessing, nil
 	case s.AddCase(MessageStatusAbandoned.String()):
 		return MessageStatusAbandoned, nil
 	default:
@@ -56,8 +53,6 @@ func (ms MessageStatus) String() string {
 		return messageStatusQueuedText
 	case MessageStatusSent:
 		return messageStatusSentText
-	case MessageStatusProcessing:
-		return messageStatusProcessingText
 	case MessageStatusAbandoned:
 		return messageStatusAbandonedText
 	default:
@@ -67,7 +62,7 @@ func (ms MessageStatus) String() string {
 
 func (ms MessageStatus) IsValid() error {
 	switch ms {
-	case MessageStatusQueued, MessageStatusSent, MessageStatusProcessing, MessageStatusAbandoned:
+	case MessageStatusQueued, MessageStatusSent, MessageStatusAbandoned:
 		return nil
 	default:
 		return errors.WithStack(herodot.ErrBadRequest.WithReason("Message status is not valid"))

--- a/courier/message_test.go
+++ b/courier/message_test.go
@@ -20,10 +20,9 @@ func TestMessageStatusValidity(t *testing.T) {
 func TestToMessageStatus(t *testing.T) {
 	t.Run("case=should return corresponding MessageStatus for given str", func(t *testing.T) {
 		for str, exp := range map[string]courier.MessageStatus{
-			"queued":     courier.MessageStatusQueued,
-			"sent":       courier.MessageStatusSent,
-			"processing": courier.MessageStatusProcessing,
-			"abandoned":  courier.MessageStatusAbandoned,
+			"queued":    courier.MessageStatusQueued,
+			"sent":      courier.MessageStatusSent,
+			"abandoned": courier.MessageStatusAbandoned,
 		} {
 			result, err := courier.ToMessageStatus(str)
 			require.NoError(t, err)

--- a/courier/persistence.go
+++ b/courier/persistence.go
@@ -7,12 +7,9 @@ import (
 	"context"
 
 	"github.com/gofrs/uuid"
-	"github.com/pkg/errors"
 
 	"github.com/ory/x/pagination/keysetpagination"
 )
-
-var ErrQueueEmpty = errors.New("queue is empty")
 
 type (
 	Persister interface {
@@ -21,8 +18,6 @@ type (
 		NextMessages(context.Context, uint8) ([]Message, error)
 
 		SetMessageStatus(context.Context, uuid.UUID, MessageStatus) error
-
-		LatestQueuedMessage(ctx context.Context) (*Message, error)
 
 		IncrementMessageSendCount(context.Context, uuid.UUID) error
 

--- a/persistence/sql/persister_courier.go
+++ b/persistence/sql/persister_courier.go
@@ -5,10 +5,8 @@ package sql
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 
-	"github.com/gobuffalo/pop/v6"
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 
@@ -18,7 +16,6 @@ import (
 	"github.com/ory/x/uuidx"
 
 	"github.com/ory/kratos/courier"
-	"github.com/ory/kratos/persistence/sql/update"
 )
 
 var _ courier.Persister = new(Persister)
@@ -70,66 +67,18 @@ func (p *Persister) NextMessages(ctx context.Context, limit uint8) (messages []c
 	ctx, span := p.r.Tracer(ctx).Tracer().Start(ctx, "persistence.sql.NextMessages")
 	defer span.End()
 
-	if err := p.Transaction(ctx, func(ctx context.Context, tx *pop.Connection) error {
-		var m []courier.Message
-		if err := tx.
-			Where("nid = ? AND status = ?",
-				p.NetworkID(ctx),
-				courier.MessageStatusQueued,
-			).
-			Order("created_at ASC").
-			Limit(int(limit)).
-			All(&m); err != nil {
-			return err
-		}
-
-		if len(m) == 0 {
-			return sql.ErrNoRows
-		}
-
-		for i := range m {
-			message := &m[i]
-			message.Status = courier.MessageStatusProcessing
-			if err := update.Generic(ctx, p.GetConnection(ctx), p.r.Tracer(ctx).Tracer(), message, "status"); err != nil {
-				return err
-			}
-		}
-
-		messages = m
-		return nil
-	}); err != nil {
-		if errors.Cause(err) == sql.ErrNoRows {
-			return nil, errors.WithStack(courier.ErrQueueEmpty)
-		}
-		return nil, sqlcon.HandleError(err)
-	}
-
-	if len(messages) == 0 {
-		return nil, errors.WithStack(courier.ErrQueueEmpty)
-	}
-
-	return messages, nil
-}
-
-func (p *Persister) LatestQueuedMessage(ctx context.Context) (*courier.Message, error) {
-	ctx, span := p.r.Tracer(ctx).Tracer().Start(ctx, "persistence.sql.LatestQueuedMessage")
-	defer span.End()
-
-	var m courier.Message
-	if err := p.GetConnection(ctx).
+	if err := p.Connection(ctx).
 		Where("nid = ? AND status = ?",
 			p.NetworkID(ctx),
 			courier.MessageStatusQueued,
 		).
-		Order("created_at DESC").
-		First(&m); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, errors.WithStack(courier.ErrQueueEmpty)
-		}
+		Order("created_at ASC").
+		Limit(int(limit)).
+		All(&messages); err != nil {
 		return nil, sqlcon.HandleError(err)
 	}
 
-	return &m, nil
+	return messages, nil
 }
 
 func (p *Persister) SetMessageStatus(ctx context.Context, id uuid.UUID, ms courier.MessageStatus) error {

--- a/selfservice/hook/verification_test.go
+++ b/selfservice/hook/verification_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/ory/kratos/courier"
+
 	"github.com/ory/kratos/internal/testhelpers"
 
 	"github.com/stretchr/testify/assert"
@@ -99,6 +100,9 @@ func TestVerifier(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, messages, 2)
 
+			require.NoError(t, reg.CourierPersister().SetMessageStatus(context.Background(), messages[0].ID, courier.MessageStatusSent))
+			require.NoError(t, reg.CourierPersister().SetMessageStatus(context.Background(), messages[1].ID, courier.MessageStatusSent))
+
 			recipients := make([]string, len(messages))
 			for k, m := range messages {
 				recipients[k] = m.Recipient
@@ -131,7 +135,7 @@ func TestVerifier(t *testing.T) {
 
 			require.NoError(t, err)
 			messages, err = reg.CourierPersister().NextMessages(context.Background(), 12)
-			require.EqualError(t, err, courier.ErrQueueEmpty.Error())
+			require.NoError(t, err)
 			assert.Len(t, messages, 0)
 		})
 	}

--- a/selfservice/strategy/code/code_sender_test.go
+++ b/selfservice/strategy/code/code_sender_test.go
@@ -65,6 +65,9 @@ func TestSender(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, messages, 2)
 
+			require.NoError(t, reg.CourierPersister().SetMessageStatus(ctx, messages[0].ID, courier.MessageStatusSent))
+			require.NoError(t, reg.CourierPersister().SetMessageStatus(ctx, messages[1].ID, courier.MessageStatusSent))
+
 			assert.EqualValues(t, "tracked@ory.sh", messages[0].Recipient)
 			assert.Contains(t, messages[0].Subject, "Recover access to your account")
 
@@ -89,6 +92,9 @@ func TestSender(t *testing.T) {
 			messages, err := reg.CourierPersister().NextMessages(ctx, 12)
 			require.NoError(t, err)
 			require.Len(t, messages, 2)
+
+			require.NoError(t, reg.CourierPersister().SetMessageStatus(ctx, messages[0].ID, courier.MessageStatusSent))
+			require.NoError(t, reg.CourierPersister().SetMessageStatus(ctx, messages[1].ID, courier.MessageStatusSent))
 
 			assert.EqualValues(t, "tracked@ory.sh", messages[0].Recipient)
 			assert.Equal(t, messages[0].Subject, subject+" valid")
@@ -121,6 +127,9 @@ func TestSender(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, messages, 2)
 
+			require.NoError(t, reg.CourierPersister().SetMessageStatus(ctx, messages[0].ID, courier.MessageStatusSent))
+			require.NoError(t, reg.CourierPersister().SetMessageStatus(ctx, messages[1].ID, courier.MessageStatusSent))
+
 			assert.EqualValues(t, "tracked@ory.sh", messages[0].Recipient)
 			assert.Contains(t, messages[0].Subject, "Please verify your email address")
 
@@ -145,6 +154,9 @@ func TestSender(t *testing.T) {
 			messages, err := reg.CourierPersister().NextMessages(ctx, 12)
 			require.NoError(t, err)
 			require.Len(t, messages, 2)
+
+			require.NoError(t, reg.CourierPersister().SetMessageStatus(ctx, messages[0].ID, courier.MessageStatusSent))
+			require.NoError(t, reg.CourierPersister().SetMessageStatus(ctx, messages[1].ID, courier.MessageStatusSent))
 
 			assert.EqualValues(t, "tracked@ory.sh", messages[0].Recipient)
 			assert.Equal(t, messages[0].Subject, subject+" valid")
@@ -206,7 +218,7 @@ func TestSender(t *testing.T) {
 
 				messages, err := reg.CourierPersister().NextMessages(ctx, 0)
 
-				require.ErrorIs(t, err, courier.ErrQueueEmpty)
+				require.NoError(t, err)
 				require.Len(t, messages, 0)
 			})
 		}

--- a/selfservice/strategy/link/sender.go
+++ b/selfservice/strategy/link/sender.go
@@ -5,6 +5,7 @@ package link
 
 import (
 	"context"
+	stderrors "errors"
 	"net/url"
 
 	"github.com/hashicorp/go-retryablehttp"
@@ -51,7 +52,7 @@ type (
 	}
 )
 
-var ErrUnknownAddress = errors.New("verification requested for unknown address")
+var ErrUnknownAddress = stderrors.New("verification requested for unknown address")
 
 func NewSender(r senderDependencies) *Sender {
 	return &Sender{r: r}

--- a/selfservice/strategy/link/sender_test.go
+++ b/selfservice/strategy/link/sender_test.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"sync"
 	"testing"
 	"time"
 
@@ -62,6 +61,9 @@ func TestManager(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, messages, 2)
 
+		require.NoError(t, reg.CourierPersister().SetMessageStatus(context.Background(), messages[0].ID, courier.MessageStatusSent))
+		require.NoError(t, reg.CourierPersister().SetMessageStatus(context.Background(), messages[1].ID, courier.MessageStatusSent))
+
 		assert.EqualValues(t, "tracked@ory.sh", messages[0].Recipient)
 		assert.Contains(t, messages[0].Subject, "Recover access to your account")
 		assert.Contains(t, messages[0].Body, urlx.AppendPaths(conf.SelfServiceLinkMethodBaseURL(ctx), recovery.RouteSubmitFlow).String()+"?")
@@ -76,8 +78,6 @@ func TestManager(t *testing.T) {
 	})
 
 	t.Run("method=SendRecoveryLink via HTTP", func(t *testing.T) {
-		var wg sync.WaitGroup
-		wg.Add(2)
 		type requestBody struct {
 			Recipient    string
 			RecoveryURL  string `json:"recovery_url"`
@@ -92,7 +92,6 @@ func TestManager(t *testing.T) {
 			var message requestBody
 			require.NoError(t, json.Unmarshal(b, &message))
 			messages = append(messages, &message)
-			wg.Done()
 		}))
 		t.Cleanup(srv.Close)
 		requestConfig := fmt.Sprintf(`{"url": "%s"}`, srv.URL)
@@ -102,12 +101,6 @@ func TestManager(t *testing.T) {
 		cour, err := reg.Courier(ctx)
 		require.NoError(t, err)
 
-		ctx, cancel := context.WithCancel(ctx)
-		defer t.Cleanup(cancel)
-		go func() {
-			require.NoError(t, cour.Work(ctx))
-		}()
-
 		s, err := reg.RecoveryStrategies(ctx).Strategy("link")
 		require.NoError(t, err)
 		f, err := recovery.NewFlow(conf, time.Hour, "", u, s, flow.TypeBrowser)
@@ -116,9 +109,9 @@ func TestManager(t *testing.T) {
 		require.NoError(t, reg.RecoveryFlowPersister().CreateRecoveryFlow(context.Background(), f))
 
 		require.NoError(t, reg.LinkSender().SendRecoveryLink(context.Background(), f, "email", "tracked@ory.sh"))
-		require.EqualError(t, reg.LinkSender().SendRecoveryLink(context.Background(), f, "email", "not-tracked@ory.sh"), link.ErrUnknownAddress.Error())
+		require.ErrorIs(t, reg.LinkSender().SendRecoveryLink(context.Background(), f, "email", "not-tracked@ory.sh"), link.ErrUnknownAddress)
 
-		wg.Wait()
+		require.NoError(t, cour.DispatchQueue(ctx))
 
 		assert.EqualValues(t, "tracked@ory.sh", messages[0].To)
 		assert.Contains(t, messages[0].Subject, "Recover access to your account")
@@ -139,10 +132,13 @@ func TestManager(t *testing.T) {
 		require.NoError(t, reg.VerificationFlowPersister().CreateVerificationFlow(context.Background(), f))
 
 		require.NoError(t, reg.LinkSender().SendVerificationLink(context.Background(), f, "email", "tracked@ory.sh"))
-		require.EqualError(t, reg.LinkSender().SendVerificationLink(context.Background(), f, "email", "not-tracked@ory.sh"), link.ErrUnknownAddress.Error())
+		require.ErrorIs(t, reg.LinkSender().SendVerificationLink(context.Background(), f, "email", "not-tracked@ory.sh"), link.ErrUnknownAddress)
 		messages, err := reg.CourierPersister().NextMessages(context.Background(), 12)
 		require.NoError(t, err)
 		require.Len(t, messages, 2)
+
+		require.NoError(t, reg.CourierPersister().SetMessageStatus(context.Background(), messages[0].ID, courier.MessageStatusSent))
+		require.NoError(t, reg.CourierPersister().SetMessageStatus(context.Background(), messages[1].ID, courier.MessageStatusSent))
 
 		assert.EqualValues(t, "tracked@ory.sh", messages[0].Recipient)
 		assert.Contains(t, messages[0].Subject, "Please verify")
@@ -207,7 +203,7 @@ func TestManager(t *testing.T) {
 
 				messages, err := reg.CourierPersister().NextMessages(context.Background(), 0)
 
-				require.ErrorIs(t, err, courier.ErrQueueEmpty)
+				require.NoError(t, err)
 				require.Len(t, messages, 0)
 			})
 		}

--- a/selfservice/strategy/profile/strategy_test.go
+++ b/selfservice/strategy/profile/strategy_test.go
@@ -17,6 +17,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ory/kratos/courier"
+
 	"github.com/ory/x/jsonx"
 
 	kratos "github.com/ory/kratos/internal/httpclient"
@@ -531,9 +533,12 @@ func TestStrategyTraits(t *testing.T) {
 			assert.EqualValues(t, flow.StateSuccess, gjson.Get(actual, "state").String(), "%s", actual)
 			assert.Equal(t, newEmail, gjson.Get(actual, "ui.nodes.#(attributes.name==traits.email).attributes.value").Value(), "%s", actual)
 
-			m, err := reg.CourierPersister().LatestQueuedMessage(context.Background())
+			ms, err := reg.CourierPersister().NextMessages(ctx, 10)
 			require.NoError(t, err)
-			assert.Contains(t, m.Subject, "verify your email address")
+			require.Len(t, ms, 1)
+			assert.Contains(t, ms[0].Subject, "verify your email address")
+
+			require.NoError(t, reg.CourierPersister().SetMessageStatus(ctx, ms[0].ID, courier.MessageStatusSent))
 		}
 
 		payload := func(newEmail string) func(v url.Values) {
@@ -550,13 +555,13 @@ func TestStrategyTraits(t *testing.T) {
 		})
 
 		t.Run("type=spa", func(t *testing.T) {
-			newEmail := "update-verify-browser@mail.com"
+			newEmail := "update-verify-browser-1@mail.com"
 			actual := expectSuccess(t, false, true, browserUser1, payload(newEmail))
 			check(t, actual, newEmail)
 		})
 
 		t.Run("type=browser", func(t *testing.T) {
-			newEmail := "update-verify-browser@mail.com"
+			newEmail := "update-verify-browser-2@mail.com"
 			actual := expectSuccess(t, false, false, browserUser1, payload(newEmail))
 			check(t, actual, newEmail)
 		})


### PR DESCRIPTION
The setup code was simplified.

Also, the `courier.MessageStatusProcessing` was removed.
The processing state was intended as a kind of lock to allow running multiple couriers. However, in practice that did not really work because multiple instance would run into transaction conflicts a lot, because they would always try to select & update the same rows. Further, there was no "lock release" strategy, but once the lock was acquired and the worker died without finishing the message, it would never be picked up again. Removing this state means less database writes, and that the worker would pick up half-processed messages.

As a follow-up, we can implement a proper sharding strategy so multiple workers can work in parallel without conflicts or duplicates.