### PR TITLE
fix: ignore CSRF middleware on Apple OIDC callback

### DIFF
--- a/internal/testhelpers/session.go
+++ b/internal/testhelpers/session.go
@@ -251,3 +251,13 @@ func (ct *TransportWithHeader) RoundTrip(req *http.Request) (*http.Response, err
 	}
 	return ct.RoundTripper.RoundTrip(req)
 }
+
+func AssertNoCSRFCookieInResponse(t *testing.T, _ *httptest.Server, _ *http.Client, r *http.Response) {
+	found := false
+	for _, c := range r.Cookies() {
+		if strings.HasPrefix(c.Name, "csrf_token") {
+			found = true
+		}
+	}
+	require.False(t, found)
+}

--- a/selfservice/strategy/oidc/strategy.go
+++ b/selfservice/strategy/oidc/strategy.go
@@ -210,9 +210,9 @@ func (s *Strategy) setRoutes(r *x.RouterPublic) {
 	// Apple can use the POST request method when calling the callback
 	if handle, _, _ := r.Lookup("POST", RouteCallback); handle == nil {
 		// Hardcoded path to Apple provider, I don't have a better way of doing it right now.
-		// Also this exempt disables CSRF checks for both GET and POST requests. Unfortunately
+		// Also this ignore disables CSRF checks for both GET and POST requests. Unfortunately
 		// CSRF handler does not allow to define a rule based on the request method, at least not yet.
-		s.d.CSRFHandler().ExemptPath(RouteBase + "/callback/apple")
+		s.d.CSRFHandler().IgnorePath(RouteBase + "/callback/apple")
 
 		// When handler is called using POST method, the cookies are not attached to the request
 		// by the browser. So here we just redirect the request to the same location rewriting the

--- a/session/handler_test.go
+++ b/session/handler_test.go
@@ -51,16 +51,6 @@ func send(code int) httprouter.Handle {
 	}
 }
 
-func assertNoCSRFCookieInResponse(t *testing.T, _ *httptest.Server, _ *http.Client, r *http.Response) {
-	found := false
-	for _, c := range r.Cookies() {
-		if strings.HasPrefix(c.Name, "csrf_token") {
-			found = true
-		}
-	}
-	require.False(t, found)
-}
-
 func TestSessionWhoAmI(t *testing.T) {
 	conf, reg := internal.NewFastRegistryWithMocks(t)
 	ts, _, r, _ := testhelpers.NewKratosServerWithCSRFAndRouters(t, reg)
@@ -156,7 +146,7 @@ func TestSessionWhoAmI(t *testing.T) {
 			// No cookie yet -> 401
 			res, err := client.Get(ts.URL + RouteWhoami)
 			require.NoError(t, err)
-			assertNoCSRFCookieInResponse(t, ts, client, res) // Test that no CSRF cookie is ever set here.
+			testhelpers.AssertNoCSRFCookieInResponse(t, ts, client, res) // Test that no CSRF cookie is ever set here.
 
 			if cacheEnabled {
 				assert.NotEmpty(t, res.Header.Get("Ory-Session-Cache-For"))
@@ -183,7 +173,7 @@ func TestSessionWhoAmI(t *testing.T) {
 					require.NoError(t, err)
 					body, err := io.ReadAll(res.Body)
 					require.NoError(t, err)
-					assertNoCSRFCookieInResponse(t, ts, client, res) // Test that no CSRF cookie is ever set here.
+					testhelpers.AssertNoCSRFCookieInResponse(t, ts, client, res) // Test that no CSRF cookie is ever set here.
 
 					assert.EqualValues(t, http.StatusOK, res.StatusCode)
 					assert.NotEmpty(t, res.Header.Get("X-Kratos-Authenticated-Identity-Id"))


### PR DESCRIPTION
This change ensures that CSRF middleware is ignored on `/self-service/oidc/callback/apple` (previously it was only exempted).

After a user authenticates on Apple, Apple redirects the user back to Kratos using a form POST. Since this is a POST, the CSRF cookie is not passed (since the cookie's SameSite attribute is set to Lax). This causes Kratos to add a different CSRF cookie.

While this doesn't break the registration flow itself, it causes a problem if we want to send the user back to the original login flow. In some cases, we may want to do this to cancel the registration and allow the user to log in with different credentials. It may be important to maintain the existing login flow in case the login originated from an OAuth2 client via Hydra instead of simply creating a new login flow.

## Related issue(s)

Not reported separately. Steps to reproduce: 

1. Configure Kratos with Apple OIDC provider.
2. Attempt to login with an Apple account that hasn't been registered in Kratos previously.
3. After Apple redirects back to Kratos, you will reach the registration page. 
4. On the registration page, redirect the user back to original login flow. 
5. The login flow cannot be accessed since the CSRF cookie has been overridden.

This issue does not impact other OIDC providers such as Google or Facebook since they do not rely on form POST when redirecting to the Kratos callback endpoint.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
