### PR TITLE
feat: extend recovery flow by adding the FlowID

### DIFF
--- a/courier/template/email/recovery_code_valid.go
+++ b/courier/template/email/recovery_code_valid.go
@@ -19,6 +19,7 @@ type (
 	}
 	RecoveryCodeValidModel struct {
 		To           string
+		FlowID       string
 		RecoveryCode string
 		Identity     map[string]interface{}
 	}

--- a/selfservice/strategy/code/code_sender.go
+++ b/selfservice/strategy/code/code_sender.go
@@ -228,6 +228,7 @@ func (s *Sender) SendRecoveryCodeTo(ctx context.Context, i *identity.Identity, c
 
 	emailModel := email.RecoveryCodeValidModel{
 		To:           code.RecoveryAddress.Value,
+		FlowID:       code.FlowID.String(),
 		RecoveryCode: codeString,
 		Identity:     model,
 	}

--- a/selfservice/strategy/code/code_sender_test.go
+++ b/selfservice/strategy/code/code_sender_test.go
@@ -6,12 +6,14 @@ package code_test
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
 	"time"
 
 	"github.com/ory/kratos/courier"
+	"github.com/ory/kratos/courier/template/email"
 	"github.com/ory/kratos/internal/testhelpers"
 
 	"github.com/stretchr/testify/assert"
@@ -64,6 +66,16 @@ func TestSender(t *testing.T) {
 			messages, err := reg.CourierPersister().NextMessages(ctx, 12)
 			require.NoError(t, err)
 			require.Len(t, messages, 2)
+
+			// verify correct templateData
+			var templateData = string(messages[0].TemplateData[:])
+			var data = email.RecoveryCodeValidModel{}
+			err = json.Unmarshal([]byte(templateData), &data)
+			require.NoError(t, err)
+			require.NotEmpty(t, data.To)
+			require.NotEmpty(t, data.FlowID)
+			require.NotEmpty(t, data.RecoveryCode)
+			require.NotEmpty(t, data.Identity)
 
 			assert.EqualValues(t, "tracked@ory.sh", messages[0].Recipient)
 			assert.Contains(t, messages[0].Subject, "Recover access to your account")


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

- the pw recovery flow has been extended
- specifically the `RecoveryCodeValidModel` now also holds the FlowID
- context: the FlowID is both persisted and associated to the `RecoveryCode` data model already
- 🚀 when a Courier sends a new email for the pw recovery flow (valid), the `Message.TemplateData` now includes all the props as before + the FlowID
  - this was implemented and asserted in `code_sender_test.go`
  - having this `FlowID` parameter gives more flexible ways to design the recovery flow with a custom UI: when a user first triggers a pw recovery flow in the UI (a FlowID is already created), the user can close this Browser Tab and later on opens the email with the link that includes both the original FlowID and the recovery code _(instead of keeping the Browser tab open and copy over the code manually)_, which all match to one Flow of the user 

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
