### PR TITLE
fix: use ID label on login with multiple identifiers

### DIFF
--- a/selfservice/flow/login/extension_identifier_label.go
+++ b/selfservice/flow/login/extension_identifier_label.go
@@ -5,8 +5,6 @@ package login
 
 import (
 	"context"
-	"sort"
-
 	"github.com/ory/kratos/text"
 
 	"github.com/ory/jsonschema/v3"
@@ -59,12 +57,9 @@ func (i *identifierLabelExtension) Run(_ jsonschema.CompilerContext, config sche
 }
 
 func (i *identifierLabelExtension) getLabel() string {
-	if len(i.identifierLabelCandidates) == 0 {
+	if len(i.identifierLabelCandidates) != 1 {
 		// sane default is set elsewhere
 		return ""
 	}
-	// sort the candidates to get a deterministic result
-	sort.Strings(i.identifierLabelCandidates)
-	// just take the first, no good way to decide which one is the best
 	return i.identifierLabelCandidates[0]
 }

--- a/selfservice/flow/login/extension_identifier_label_test.go
+++ b/selfservice/flow/login/extension_identifier_label_test.go
@@ -127,7 +127,7 @@ func TestGetIdentifierLabelFromSchema(t *testing.T) {
 			usernameConfig: func(c *schema.ExtensionConfig) {
 				c.Credentials.Password.Identifier = true
 			},
-			expected: text.NewInfoNodeLabelGenerated("Email"),
+			expected: text.NewInfoNodeLabelID(),
 		},
 		{
 			name:     "no identifiers",


### PR DESCRIPTION
Follow-up for https://github.com/ory/kratos/pull/3645

In case of multiple identifiers, it makes sense to stay with the "old" ID label. UI translations & custom UI are the better way to handle multiple identifiers.