### PR TITLE
revert: "fix: do not generate CSRF token for api flows"

### DIFF
--- a/selfservice/strategy/code/strategy_recovery.go
+++ b/selfservice/strategy/code/strategy_recovery.go
@@ -170,6 +170,7 @@ func (s *Strategy) recoveryIssueSession(w http.ResponseWriter, r *http.Request, 
 
 	f.UI.Messages.Clear()
 	f.State = flow.StatePassedChallenge
+	f.SetCSRFToken(s.deps.CSRFHandler().RegenerateToken(w, r))
 	f.RecoveredIdentityID = uuid.NullUUID{
 		UUID:  id.ID,
 		Valid: true,
@@ -190,8 +191,6 @@ func (s *Strategy) recoveryIssueSession(w http.ResponseWriter, r *http.Request, 
 
 	switch f.Type {
 	case flow.TypeBrowser:
-		f.SetCSRFToken(s.deps.CSRFHandler().RegenerateToken(w, r))
-
 		if err := s.deps.SessionManager().UpsertAndIssueCookie(ctx, w, r, sess); err != nil {
 			return s.retryRecoveryFlow(w, r, f.Type, RetryWithError(err))
 		}


### PR DESCRIPTION
Reverts ory/kratos#3704

The CSRF token is now generated too late, and submitting a flow after an error has occurred can fail with a CSRF violation now.