### PR TITLE
fix: add return_to parameter to API spec of createRecoveryLinkForIdenity

### DIFF
--- a/internal/client-go/api_identity.go
+++ b/internal/client-go/api_identity.go
@@ -774,9 +774,14 @@ func (a *IdentityApiService) CreateRecoveryCodeForIdentityExecute(r IdentityApiA
 type IdentityApiApiCreateRecoveryLinkForIdentityRequest struct {
 	ctx                               context.Context
 	ApiService                        IdentityApi
+	returnTo                          *string
 	createRecoveryLinkForIdentityBody *CreateRecoveryLinkForIdentityBody
 }
 
+func (r IdentityApiApiCreateRecoveryLinkForIdentityRequest) ReturnTo(returnTo string) IdentityApiApiCreateRecoveryLinkForIdentityRequest {
+	r.returnTo = &returnTo
+	return r
+}
 func (r IdentityApiApiCreateRecoveryLinkForIdentityRequest) CreateRecoveryLinkForIdentityBody(createRecoveryLinkForIdentityBody CreateRecoveryLinkForIdentityBody) IdentityApiApiCreateRecoveryLinkForIdentityRequest {
 	r.createRecoveryLinkForIdentityBody = &createRecoveryLinkForIdentityBody
 	return r
@@ -826,6 +831,9 @@ func (a *IdentityApiService) CreateRecoveryLinkForIdentityExecute(r IdentityApiA
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
+	if r.returnTo != nil {
+		localVarQueryParams.Add("return_to", parameterToString(*r.returnTo, ""))
+	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
 

--- a/internal/httpclient/api_identity.go
+++ b/internal/httpclient/api_identity.go
@@ -774,9 +774,14 @@ func (a *IdentityApiService) CreateRecoveryCodeForIdentityExecute(r IdentityApiA
 type IdentityApiApiCreateRecoveryLinkForIdentityRequest struct {
 	ctx                               context.Context
 	ApiService                        IdentityApi
+	returnTo                          *string
 	createRecoveryLinkForIdentityBody *CreateRecoveryLinkForIdentityBody
 }
 
+func (r IdentityApiApiCreateRecoveryLinkForIdentityRequest) ReturnTo(returnTo string) IdentityApiApiCreateRecoveryLinkForIdentityRequest {
+	r.returnTo = &returnTo
+	return r
+}
 func (r IdentityApiApiCreateRecoveryLinkForIdentityRequest) CreateRecoveryLinkForIdentityBody(createRecoveryLinkForIdentityBody CreateRecoveryLinkForIdentityBody) IdentityApiApiCreateRecoveryLinkForIdentityRequest {
 	r.createRecoveryLinkForIdentityBody = &createRecoveryLinkForIdentityBody
 	return r
@@ -826,6 +831,9 @@ func (a *IdentityApiService) CreateRecoveryLinkForIdentityExecute(r IdentityApiA
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
+	if r.returnTo != nil {
+		localVarQueryParams.Add("return_to", parameterToString(*r.returnTo, ""))
+	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
 

--- a/selfservice/strategy/link/strategy_recovery.go
+++ b/selfservice/strategy/link/strategy_recovery.go
@@ -69,6 +69,8 @@ func (s *Strategy) PopulateRecoveryMethod(r *http.Request, f *recovery.Flow) err
 type createRecoveryLinkForIdentity struct {
 	// in: body
 	Body createRecoveryLinkForIdentityBody
+	// in: query
+	ReturnTo string `json:"return_to"`
 }
 
 // Create Recovery Link for Identity Request Body
@@ -156,7 +158,7 @@ func (s *Strategy) createRecoveryLinkForIdentity(w http.ResponseWriter, r *http.
 		}
 	}
 
-	if time.Now().Add(expiresIn).Before(time.Now()) {
+	if expiresIn <= 0 {
 		s.d.Writer().WriteError(w, r, errors.WithStack(herodot.ErrBadRequest.WithReasonf(`Value from "expires_in" must be result to a future time: %s`, p.ExpiresIn)))
 		return
 	}

--- a/spec/api.json
+++ b/spec/api.json
@@ -4379,6 +4379,15 @@
       "post": {
         "description": "This endpoint creates a recovery link which should be given to the user in order for them to recover\n(or activate) their account.",
         "operationId": "createRecoveryLinkForIdentity",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "return_to",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -934,6 +934,11 @@
             "schema": {
               "$ref": "#/definitions/createRecoveryLinkForIdentityBody"
             }
+          },
+          {
+            "type": "string",
+            "name": "return_to",
+            "in": "query"
           }
         ],
         "responses": {


### PR DESCRIPTION
The parameter is already handled properly, it was just missing in the API spec.

as reported by @francesconi