### PR TITLE
fix: additional cleanup of old data

### DIFF
--- a/persistence/sql/persister.go
+++ b/persistence/sql/persister.go
@@ -237,6 +237,12 @@ func (p *Persister) CleanupDatabase(ctx context.Context, wait time.Duration, old
 	}
 	time.Sleep(wait)
 
+	p.r.Logger().Println("Cleaning seen selfservice errors")
+	if err := p.ClearErrorContainers(ctx, older, false); err != nil {
+		return err
+	}
+	time.Sleep(wait)
+
 	p.r.Logger().Println("Successfully cleaned up the latest batch of the SQL database! " +
 		"This should be re-run periodically, to be sure that all expired data is purged.")
 	return nil

--- a/persistence/sql/persister_session.go
+++ b/persistence/sql/persister_session.go
@@ -428,7 +428,7 @@ func (p *Persister) DeleteExpiredSessions(ctx context.Context, expiresAt time.Ti
 
 	//#nosec G201 -- TableName is static
 	err = p.GetConnection(ctx).RawQuery(fmt.Sprintf(
-		"DELETE FROM %s WHERE id in (SELECT id FROM (SELECT id FROM %s c WHERE expires_at <= ? and nid = ? ORDER BY expires_at ASC LIMIT %d ) AS s )",
+		"DELETE FROM %s WHERE id in (SELECT id FROM (SELECT id FROM %s c WHERE (expires_at <= ? or active = false) and nid = ? ORDER BY expires_at ASC LIMIT %d ) AS s )",
 		new(session.Session).TableName(ctx),
 		new(session.Session).TableName(ctx),
 		limit,


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->
During our work with kratos we notices that some data wasn't being cleaned up by the script. It seems that the query for session cleanup didn't remove deactivated sessions and the selfservice_errors table wasn't cleaned up at all.
## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
