### PR TITLE
docs: Update native recovery code flow docs

### DIFF
--- a/selfservice/flow/recovery/handler.go
+++ b/selfservice/flow/recovery/handler.go
@@ -101,7 +101,11 @@ func (h *Handler) RegisterAdminRoutes(admin *x.RouterAdmin) {
 //
 // This endpoint initiates a recovery flow for API clients such as mobile devices, smart TVs, and so on.
 //
-// If a valid provided session cookie or session token is provided, a 400 Bad Request error.
+// The "code" recovery flow will not work on native devices, unless the
+// [use_continue_with_transitions](https://github.com/ory/kratos/blob/0b32ce113be47aa724d3468062ced09f8f60c52a/contrib/quickstart/kratos/email-password/kratos.yml#L101) feature flag is set in the kratos config file.
+// Otherwise, updating the recovery flow with the code that was sent via E-Mail will lead to a 422 Browser Location Change required error.
+//
+// Providing a valid session cookie or session token will result in a 400 Bad Request error.
 //
 // On an existing recovery flow, use the `getRecoveryFlow` API endpoint.
 //


### PR DESCRIPTION
I added more detailed information about the configuration required to get the native recovery code flow to work. Without a new feature flag, you will run into a "422 Browser location change required" error on your device. That means you won't be able to continue with the settings flow after the recovery flow was completed successfully, because native apps do not support browser redirects.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [ ] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [ ] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](https://github.com/ory/docs).
