### PR TITLE
Support for Latvian eID Eparaksts

### DIFF
--- a/.schemastore/config.schema.json
+++ b/.schemastore/config.schema.json
@@ -415,7 +415,7 @@
         },
         "provider": {
           "title": "Provider",
-          "description": "Can be one of github, github-app, gitlab, generic, google, microsoft, discord, slack, facebook, auth0, vk, yandex, apple, spotify, netid, dingtalk, patreon.",
+          "description": "Can be one of github, github-app, gitlab, generic, google, microsoft, discord, slack, facebook, auth0, vk, yandex, apple, spotify, netid, dingtalk, patreon, eparaksts, eparaksts-mobile.",
           "type": "string",
           "enum": [
             "github",
@@ -436,7 +436,9 @@
             "dingtalk",
             "patreon",
             "linkedin",
-            "lark"
+            "lark",
+            "eparaksts",
+            "eparaksts-mobile"
           ],
           "examples": ["google"]
         },

--- a/embedx/config.schema.json
+++ b/embedx/config.schema.json
@@ -415,7 +415,7 @@
         },
         "provider": {
           "title": "Provider",
-          "description": "Can be one of github, github-app, gitlab, generic, google, microsoft, discord, slack, facebook, auth0, vk, yandex, apple, spotify, netid, dingtalk, patreon.",
+          "description": "Can be one of github, github-app, gitlab, generic, google, microsoft, discord, slack, facebook, auth0, vk, yandex, apple, spotify, netid, dingtalk, patreon, eparaksts, eparaksts-mobile.",
           "type": "string",
           "enum": [
             "github",
@@ -438,7 +438,9 @@
             "linkedin",
             "linkedin_v2",
             "lark",
-            "x"
+            "x",
+            "eparaksts",
+            "eparaksts-mobile"
           ],
           "examples": ["google"]
         },

--- a/selfservice/strategy/oidc/provider_config.go
+++ b/selfservice/strategy/oidc/provider_config.go
@@ -39,6 +39,8 @@ type Configuration struct {
 	// - dingtalk
 	// - linkedin
 	// - patreon
+	// - eparaksts
+	// - eparaksts-mobile
 	Provider string `json:"provider"`
 
 	// Label represents an optional label which can be used in the UI generation.
@@ -141,27 +143,29 @@ type ConfigurationCollection struct {
 // If you add a provider here, please also add a test to
 // provider_private_net_test.go
 var supportedProviders = map[string]func(config *Configuration, reg Dependencies) Provider{
-	"generic":     NewProviderGenericOIDC,
-	"google":      NewProviderGoogle,
-	"github":      NewProviderGitHub,
-	"github-app":  NewProviderGitHubApp,
-	"gitlab":      NewProviderGitLab,
-	"microsoft":   NewProviderMicrosoft,
-	"discord":     NewProviderDiscord,
-	"slack":       NewProviderSlack,
-	"facebook":    NewProviderFacebook,
-	"auth0":       NewProviderAuth0,
-	"vk":          NewProviderVK,
-	"yandex":      NewProviderYandex,
-	"apple":       NewProviderApple,
-	"spotify":     NewProviderSpotify,
-	"netid":       NewProviderNetID,
-	"dingtalk":    NewProviderDingTalk,
-	"linkedin":    NewProviderLinkedIn,
-	"linkedin_v2": NewProviderLinkedInV2,
-	"patreon":     NewProviderPatreon,
-	"lark":        NewProviderLark,
-	"x":           NewProviderX,
+	"generic":          NewProviderGenericOIDC,
+	"google":           NewProviderGoogle,
+	"github":           NewProviderGitHub,
+	"github-app":       NewProviderGitHubApp,
+	"gitlab":           NewProviderGitLab,
+	"microsoft":        NewProviderMicrosoft,
+	"discord":          NewProviderDiscord,
+	"slack":            NewProviderSlack,
+	"facebook":         NewProviderFacebook,
+	"auth0":            NewProviderAuth0,
+	"vk":               NewProviderVK,
+	"yandex":           NewProviderYandex,
+	"apple":            NewProviderApple,
+	"spotify":          NewProviderSpotify,
+	"netid":            NewProviderNetID,
+	"dingtalk":         NewProviderDingTalk,
+	"linkedin":         NewProviderLinkedIn,
+	"linkedin_v2":      NewProviderLinkedInV2,
+	"patreon":          NewProviderPatreon,
+	"lark":             NewProviderLark,
+	"x":                NewProviderX,
+	"eparaksts":        NewProviderEParaksts,
+	"eparaksts-mobile": NewProviderEParakstsMobile,
 }
 
 func (c ConfigurationCollection) Provider(id string, reg Dependencies) (Provider, error) {

--- a/selfservice/strategy/oidc/provider_eparaksts.go
+++ b/selfservice/strategy/oidc/provider_eparaksts.go
@@ -1,0 +1,152 @@
+// Copyright © 2023 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package oidc
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+	"path"
+	"strings"
+
+	"github.com/hashicorp/go-retryablehttp"
+
+	"github.com/ory/x/httpx"
+
+	"github.com/pkg/errors"
+	"golang.org/x/oauth2"
+
+	"github.com/ory/herodot"
+)
+
+type ProviderEParaksts struct {
+	config   *Configuration
+	reg      Dependencies
+	acrValue string
+}
+
+func NewProviderEParaksts(
+	config *Configuration,
+	reg Dependencies,
+) Provider {
+	return &ProviderEParaksts{
+		config:   config,
+		reg:      reg,
+		acrValue: "urn:eparaksts:authentication:flow:sc_plugin",
+	}
+}
+
+func NewProviderEParakstsMobile(
+	config *Configuration,
+	reg Dependencies,
+) Provider {
+	return &ProviderEParaksts{
+		config:   config,
+		reg:      reg,
+		acrValue: "urn:eparaksts:authentication:flow:mobileid",
+	}
+}
+
+func (g *ProviderEParaksts) Config() *Configuration {
+	return g.config
+}
+
+func (g *ProviderEParaksts) oauth2(ctx context.Context) (*oauth2.Config, error) {
+	endpoint, err := url.Parse(g.config.IssuerURL)
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+
+	authUrl := *endpoint
+	authUrl.Path = path.Join(authUrl.Path, "/trustedx-authserver/oauth/lvrtc-eipsign-as")
+
+	values := url.Values{}
+	values.Add("prompt", "login")
+	values.Add("acr_values", g.acrValue)
+	values.Add("ui_locales", "lv")
+	authUrl.RawQuery = values.Encode()
+
+	tokenUrl := *endpoint
+	tokenUrl.Path = path.Join(tokenUrl.Path, "/trustedx-authserver/oauth/lvrtc-eipsign-as/token")
+
+	c := &oauth2.Config{
+		ClientID:     g.config.ClientID,
+		ClientSecret: g.config.ClientSecret,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  authUrl.String(),
+			TokenURL: tokenUrl.String(),
+		},
+		Scopes:      g.config.Scope,
+		RedirectURL: g.config.Redir(g.reg.Config().OIDCRedirectURIBase(ctx)),
+	}
+	return c, nil
+}
+
+func (g *ProviderEParaksts) AuthCodeURLOptions(r ider) []oauth2.AuthCodeOption {
+	return []oauth2.AuthCodeOption{}
+}
+
+func (g *ProviderEParaksts) OAuth2(ctx context.Context) (*oauth2.Config, error) {
+	return g.oauth2(ctx)
+}
+
+func (g *ProviderEParaksts) Claims(ctx context.Context, exchange *oauth2.Token, query url.Values) (*Claims, error) {
+	o, err := g.OAuth2(ctx)
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+
+	u, err := url.Parse(g.config.IssuerURL)
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+	u.Path = path.Join(u.Path, "/trustedx-resources/openid/v1/users/me")
+
+	ctx, client := httpx.SetOAuth2(ctx, g.reg.HTTPClient(ctx), o, exchange)
+	req, err := retryablehttp.NewRequestWithContext(ctx, "GET", u.String(), nil)
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+	defer resp.Body.Close()
+
+	if err := logUpstreamError(g.reg.Logger(), resp); err != nil {
+		return nil, err
+	}
+
+	type User struct {
+		Subject      string `json:"sub,omitempty"`
+		GivenName    string `json:"given_name,omitempty"`
+		FamilyName   string `json:"family_name,omitempty"`
+		SerialNumber string `json:"serial_number,omitempty"`
+	}
+	var user User
+
+	if err := json.NewDecoder(resp.Body).Decode(&user); err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+
+	g.ParseSerialNumber(user.SerialNumber)
+
+	return &Claims{
+		Issuer:  "https://eidas-demo.eparaksts.lv/trustedx-resources/openid/v1/users/me",
+		Subject: user.Subject,
+		RawClaims: map[string]interface{}{
+			"serial_number": user.SerialNumber,
+		},
+		GivenName:  user.GivenName,
+		FamilyName: user.FamilyName,
+	}, nil
+}
+
+func (g *ProviderEParaksts) ParseSerialNumber(serialNumber string) string {
+	serialNumber = serialNumber[6:]
+	return strings.Replace(serialNumber, "-", "", -1)
+}

--- a/selfservice/strategy/oidc/provider_eparaksts.go
+++ b/selfservice/strategy/oidc/provider_eparaksts.go
@@ -136,7 +136,7 @@ func (g *ProviderEParaksts) Claims(ctx context.Context, exchange *oauth2.Token, 
 	g.ParseSerialNumber(user.SerialNumber)
 
 	return &Claims{
-		Issuer:  "https://eidas-demo.eparaksts.lv/trustedx-resources/openid/v1/users/me",
+		Issuer:  g.config.IssuerURL,
 		Subject: user.Subject,
 		RawClaims: map[string]interface{}{
 			"serial_number": user.SerialNumber,

--- a/selfservice/strategy/oidc/provider_eparaksts_unit_test.go
+++ b/selfservice/strategy/oidc/provider_eparaksts_unit_test.go
@@ -2,6 +2,8 @@ package oidc
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type User struct {
@@ -9,19 +11,12 @@ type User struct {
 	ParseSerialNumber (ProviderEParaksts)
 }
 
-func TestSerialNumberModification(t *testing.T) {
-	expectedSerialNumber := "1234678900"
-	user := &User{SerialNumber: "PVOLV-12346-78900"}
+func TestParseSerialNumber(t *testing.T) {
+	expected := "1234678900"
+	serialNumber := "PVOLV-12346-78900"
 
 	g := &ProviderEParaksts{}
 
-	actualSerialNumber := g.ParseSerialNumber(user.SerialNumber)
-
-	if actualSerialNumber != expectedSerialNumber {
-		t.Errorf("Expected SerialNumber to be "+expectedSerialNumber+", but got ", user.SerialNumber)
-	}
-}
-
-func ParseSerialNumber(s string, provider ProviderEParaksts) {
-	panic("unimplemented")
+	actual := g.ParseSerialNumber(serialNumber)
+	assert.Equal(t, expected, actual)
 }

--- a/selfservice/strategy/oidc/provider_eparaksts_unit_test.go
+++ b/selfservice/strategy/oidc/provider_eparaksts_unit_test.go
@@ -1,0 +1,27 @@
+package oidc
+
+import (
+	"testing"
+)
+
+type User struct {
+	SerialNumber      string
+	ParseSerialNumber (ProviderEParaksts)
+}
+
+func TestSerialNumberModification(t *testing.T) {
+	expectedSerialNumber := "1234678900"
+	user := &User{SerialNumber: "PVOLV-12346-78900"}
+
+	g := &ProviderEParaksts{}
+
+	actualSerialNumber := g.ParseSerialNumber(user.SerialNumber)
+
+	if actualSerialNumber != expectedSerialNumber {
+		t.Errorf("Expected SerialNumber to be "+expectedSerialNumber+", but got ", user.SerialNumber)
+	}
+}
+
+func ParseSerialNumber(s string, provider ProviderEParaksts) {
+	panic("unimplemented")
+}


### PR DESCRIPTION
This change is the implementation of Latvian electronic ID provider [eParaksts](https://www.eparaksts.lv/en/). It features two authentication methods and two identity providers (implemented in a single file) eparaksts - authentication with ID card and card reader, eparaksts-mobile - with [eParaksts mobile app](https://www.eparaksts.lv/en/Produkti/Privatpersonam/mid/apraksts)
Eparaksts developer documentation [here](https://developers.eparaksts.lv/docs/oauth20-authorization-api).
I have read, but not following commit prefixes, let me know if this is a showstopper.
I haven`t created a design document as this seems like a straightforward implementation.

Configuration needed for this identity provider:
scope: "urn:lvrtc:fpeil:aa"
issuerURL: "https://eidas.eparaksts.lv"

Let us know whan needs to be added./changed/

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [ ] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).
