### PR TITLE
fix: drop trigram index on identifiers

### DIFF
--- a/internal/client-go/go.sum
+++ b/internal/client-go/go.sum
@@ -4,6 +4,7 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e h1:bRhVy7zSSasaqNksaRZiA5EEI+Ei4I1nO5Jh72wfHlg=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/persistence/sql/identity/persister_identity.go
+++ b/persistence/sql/identity/persister_identity.go
@@ -824,7 +824,7 @@ func (p *IdentityPersister) ListIdentities(ctx context.Context, params identity.
 		identifier := params.CredentialsIdentifier
 		identifierOperator := "="
 		if identifier == "" && params.CredentialsIdentifierSimilar != "" {
-			identifier = strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(params.CredentialsIdentifierSimilar, "\\", "\\\\"), "%", "\\%"), "_", "\\_") + "%"
+			identifier = x.EscapeLikePattern(params.CredentialsIdentifierSimilar) + "%"
 			identifierOperator = "LIKE"
 		}
 

--- a/persistence/sql/identity/persister_identity.go
+++ b/persistence/sql/identity/persister_identity.go
@@ -265,7 +265,7 @@ INNER JOIN identity_credentials
     AND identity_credentials.identity_credential_type_id = (
         SELECT id
         FROM identity_credential_types
-        WHERE name = ? 
+        WHERE name = ?
      )
 WHERE identity_credentials.config ->> '%s' = ?
   AND identities.nid = ?
@@ -824,14 +824,8 @@ func (p *IdentityPersister) ListIdentities(ctx context.Context, params identity.
 		identifier := params.CredentialsIdentifier
 		identifierOperator := "="
 		if identifier == "" && params.CredentialsIdentifierSimilar != "" {
-			identifier = params.CredentialsIdentifierSimilar
-			identifierOperator = "%"
-			switch con.Dialect.Name() {
-			case "postgres", "cockroach":
-			default:
-				identifier = "%" + identifier + "%"
-				identifierOperator = "LIKE"
-			}
+			identifier = strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(params.CredentialsIdentifierSimilar, "\\", "\\\\"), "%", "\\%"), "_", "\\_") + "%"
+			identifierOperator = "LIKE"
 		}
 
 		if len(identifier) > 0 {

--- a/persistence/sql/migrations/sql/20240318143139000000_drop_identity_search_index.down.sql
+++ b/persistence/sql/migrations/sql/20240318143139000000_drop_identity_search_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX identity_credential_identifiers_nid_identifier_gin;

--- a/persistence/sql/migrations/sql/20240318143139000000_drop_identity_search_index.down.sql
+++ b/persistence/sql/migrations/sql/20240318143139000000_drop_identity_search_index.down.sql
@@ -1,1 +1,0 @@
-DROP INDEX identity_credential_identifiers_nid_identifier_gin;

--- a/persistence/sql/migrations/sql/20240318143139000000_drop_identity_search_index.postgres.down.sql
+++ b/persistence/sql/migrations/sql/20240318143139000000_drop_identity_search_index.postgres.down.sql
@@ -1,0 +1,4 @@
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE EXTENSION IF NOT EXISTS btree_gin;
+
+CREATE INDEX identity_credential_identifiers_nid_identifier_gin ON identity_credential_identifiers USING GIN (nid, identifier gin_trgm_ops);

--- a/persistence/sql/migrations/sql/20240318143139000000_drop_identity_search_index.postgres.up.sql
+++ b/persistence/sql/migrations/sql/20240318143139000000_drop_identity_search_index.postgres.up.sql
@@ -1,0 +1,1 @@
+DROP INDEX identity_credential_identifiers_nid_identifier_gin;

--- a/x/sql.go
+++ b/x/sql.go
@@ -1,0 +1,10 @@
+// Copyright © 2024 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package x
+
+import "strings"
+
+func EscapeLikePattern(s string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(s, "\\", "\\\\"), "%", "\\%"), "_", "\\_")
+}

--- a/x/sql_test.go
+++ b/x/sql_test.go
@@ -1,0 +1,34 @@
+// Copyright © 2024 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package x
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEscapeLikePattern(t *testing.T) {
+	for name, tc := range map[string]struct {
+		input    string
+		expected string
+	}{
+		"empty": {
+			input:    "",
+			expected: "",
+		},
+		"no escape": {
+			input:    "foo",
+			expected: "foo",
+		},
+		"escape": {
+			input:    "foo%bar_baz\\",
+			expected: "foo\\%bar\\_baz\\\\",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.expected, EscapeLikePattern(tc.input))
+		})
+	}
+}


### PR DESCRIPTION
The trigram GIN index takes up a significant amount of database storage. Fuzzy search should instead be build using a dedicated external service. This will allow indexing other traits as well, based on needs.