### PR TITLE
fix: tolerate more "truthy" values when creating new flows

### DIFF
--- a/selfservice/flow/login/flow.go
+++ b/selfservice/flow/login/flow.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -176,6 +177,8 @@ func NewFlow(conf *config.Config, exp time.Duration, csrf string, r *http.Reques
 		return nil, err
 	}
 
+	refresh, _ := strconv.ParseBool(r.URL.Query().Get("refresh"))
+
 	return &Flow{
 		ID:                   id,
 		OAuth2LoginChallenge: hydraLoginChallenge,
@@ -188,7 +191,7 @@ func NewFlow(conf *config.Config, exp time.Duration, csrf string, r *http.Reques
 		RequestURL: requestURL,
 		CSRFToken:  csrf,
 		Type:       flowType,
-		Refresh:    r.URL.Query().Get("refresh") == "true",
+		Refresh:    refresh,
 		RequestedAAL: identity.AuthenticatorAssuranceLevel(strings.ToLower(stringsx.Coalesce(
 			r.URL.Query().Get("aal"),
 			string(identity.AuthenticatorAssuranceLevel1)))),

--- a/selfservice/flow/login/handler.go
+++ b/selfservice/flow/login/handler.go
@@ -6,6 +6,7 @@ package login
 import (
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -141,7 +142,9 @@ func (h *Handler) NewLoginFlow(w http.ResponseWriter, r *http.Request, ft flow.T
 	sess, err := h.d.SessionManager().FetchFromRequest(r.Context(), r)
 	if e := new(session.ErrNoActiveSessionFound); errors.As(err, &e) {
 		// No session exists yet
-		if ft == flow.TypeAPI && r.URL.Query().Get("return_session_token_exchange_code") == "true" {
+		returnSessionTokenExchangeCode, _ := strconv.ParseBool(r.URL.Query().Get("return_session_token_exchange_code"))
+
+		if ft == flow.TypeAPI && returnSessionTokenExchangeCode {
 			e, err := h.d.SessionTokenExchangePersister().CreateSessionTokenExchanger(r.Context(), f.ID)
 			if err != nil {
 				return nil, nil, errors.WithStack(herodot.ErrInternalServerError.WithWrap(err))

--- a/selfservice/flow/login/handler_test.go
+++ b/selfservice/flow/login/handler_test.go
@@ -546,10 +546,14 @@ func TestFlowLifecycle(t *testing.T) {
 				assert.Empty(t, gjson.GetBytes(body, "session_token_exchange_code").String())
 			})
 
-			t.Run("case=returns session exchange code", func(t *testing.T) {
-				res, body := initFlow(t, urlx.ParseOrPanic("/?return_session_token_exchange_code=true").Query(), true)
-				assert.Contains(t, res.Request.URL.String(), login.RouteInitAPIFlow)
-				assert.NotEmpty(t, gjson.GetBytes(body, "session_token_exchange_code").String())
+			t.Run("case=returns session exchange code with any truthy value", func(t *testing.T) {
+				parameters := []string{"true", "True", "1"}
+
+				for i := range parameters {
+					res, body := initFlow(t, url.Values{"return_session_token_exchange_code": {parameters[i]}}, true)
+					assert.Contains(t, res.Request.URL.String(), login.RouteInitAPIFlow)
+					assert.NotEmpty(t, gjson.GetBytes(body, "session_token_exchange_code").String())
+				}
 			})
 
 			t.Run("case=can not request refresh and aal at the same time on unauthenticated request", func(t *testing.T) {


### PR DESCRIPTION
Use strconv.ParseBool to accept multiple "truthy" values for the `refresh` and `return_session_token_exchange_code` query parameters when creating a new login flow.

For some SDKs (e.g.: Python), these stringification of booleans is not user-controlled and these endpoints could not be used fully due to the backend ignoring any value other than `true` (all lowercase).

Closes #3839.

## Related issue(s)

#3839

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

None
