### PR TITLE
fix: claims.update_at is float64

### DIFF
--- a/selfservice/strategy/oidc/provider_github.go
+++ b/selfservice/strategy/oidc/provider_github.go
@@ -84,7 +84,7 @@ func (g *ProviderGitHub) Claims(ctx context.Context, exchange *oauth2.Token, que
 		Website:   user.GetBlog(),
 		Picture:   user.GetAvatarURL(),
 		Profile:   user.GetHTMLURL(),
-		UpdatedAt: user.GetUpdatedAt().Unix(),
+		UpdatedAt: Timestamp(user.GetUpdatedAt().UnixMilli()),
 	}
 
 	// GitHub does not provide the user's private emails in the call to `/user`. Therefore, if scope "user:email" is set,

--- a/selfservice/strategy/oidc/provider_github_app.go
+++ b/selfservice/strategy/oidc/provider_github_app.go
@@ -74,7 +74,7 @@ func (g *ProviderGitHubApp) Claims(ctx context.Context, exchange *oauth2.Token, 
 		Website:   user.GetBlog(),
 		Picture:   user.GetAvatarURL(),
 		Profile:   user.GetHTMLURL(),
-		UpdatedAt: user.GetUpdatedAt().Unix(),
+		UpdatedAt: Timestamp(user.GetUpdatedAt().UnixMilli()),
 	}
 
 	// GitHub does not provide the user's private emails in the call to `/user`. Therefore, if scope "user:email" is set,


### PR DESCRIPTION
## Related issue(s)

https://community.ory.sh/t/failed-to-unmarshal-updated-at-for-generic-oidc-provider-auth0/2004

When using one ory+hydra as OIDC provider to authenticated another kratos, I got an error that it is unable to unmarshal Claims.updated_at, because kratos-selfservice-ui-node returns the session and convert updated_at to a float64, because javascript/typescript doesn't have int64 type.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

The proposed fix makes it competible with multiple types of updated_at field.