### PR TITLE
fix: always issue session last

### DIFF
--- a/driver/registry_default_hooks.go
+++ b/driver/registry_default_hooks.go
@@ -62,10 +62,12 @@ func (m *RegistryDefault) WithHooks(hooks map[string]func(config.SelfServiceHook
 }
 
 func (m *RegistryDefault) getHooks(credentialsType string, configs []config.SelfServiceHook) (i []interface{}) {
+	var addSessionIssuer bool
 	for _, h := range configs {
 		switch h.Name {
 		case hook.KeySessionIssuer:
-			i = append(i, m.HookSessionIssuer())
+			// The session issuer hook always needs to come last.
+			addSessionIssuer = true
 		case hook.KeySessionDestroyer:
 			i = append(i, m.HookSessionDestroyer())
 		case hook.KeyWebHook:
@@ -95,6 +97,9 @@ func (m *RegistryDefault) getHooks(credentialsType string, configs []config.Self
 				WithField("hook", h.Name).
 				Errorf("A unknown hook was requested and can therefore not be used")
 		}
+	}
+	if addSessionIssuer {
+		i = append(i, m.HookSessionIssuer())
 	}
 
 	return i


### PR DESCRIPTION
In post persist hooks, the session issuance hook always needs to come last. This fixes the getHooks function to ensure this.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [ ] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
