### PR TITLE
fix: change return urls in quickstarts

### DIFF
--- a/contrib/quickstart/kratos/email-password/kratos.yml
+++ b/contrib/quickstart/kratos/email-password/kratos.yml
@@ -11,7 +11,7 @@ serve:
     base_url: http://kratos:4434/
 
 selfservice:
-  default_browser_return_url: http://127.0.0.1:4455/
+  default_browser_return_url: http://127.0.0.1:4455/welcome
   allowed_return_urls:
     - http://127.0.0.1:4455
     - http://localhost:19006/Callback
@@ -50,7 +50,7 @@ selfservice:
       ui_url: http://127.0.0.1:4455/verification
       use: code
       after:
-        default_browser_return_url: http://127.0.0.1:4455/
+        default_browser_return_url: http://127.0.0.1:4455/welcome
 
     logout:
       after:

--- a/contrib/quickstart/kratos/passkey/kratos.yml
+++ b/contrib/quickstart/kratos/passkey/kratos.yml
@@ -11,7 +11,7 @@ session:
     required_aal: aal1
 
 selfservice:
-  default_browser_return_url: http://localhost:4455/
+  default_browser_return_url: http://localhost:4455/welcome
   allowed_return_urls:
     - http://localhost:4455
     - http://localhost:19006/Callback

--- a/contrib/quickstart/kratos/phone-password/kratos.yml
+++ b/contrib/quickstart/kratos/phone-password/kratos.yml
@@ -11,7 +11,7 @@ serve:
     base_url: http://kratos:4434/
 
 selfservice:
-  default_browser_return_url: http://127.0.0.1:4455/
+  default_browser_return_url: http://127.0.0.1:4455/welcome
   allowed_return_urls:
     - http://127.0.0.1:4455
     - http://localhost:19006/Callback
@@ -50,7 +50,7 @@ selfservice:
       ui_url: http://127.0.0.1:4455/verification
       use: code
       after:
-        default_browser_return_url: http://127.0.0.1:4455/
+        default_browser_return_url: http://127.0.0.1:4455/welcome
 
     logout:
       after:

--- a/contrib/quickstart/kratos/webauthn/kratos.yml
+++ b/contrib/quickstart/kratos/webauthn/kratos.yml
@@ -11,7 +11,7 @@ serve:
     base_url: http://kratos:4434/
 
 selfservice:
-  default_browser_return_url: http://localhost:4455/
+  default_browser_return_url: http://localhost:4455/welcome
   allowed_return_urls:
     - http://localhost:4455
 
@@ -58,7 +58,7 @@ selfservice:
       ui_url: http://localhost:4455/verification
       use: code
       after:
-        default_browser_return_url: http://localhost:4455/
+        default_browser_return_url: http://localhost:4455/welcome
 
     logout:
       after:


### PR DESCRIPTION
Change the default return url for Quickstarts to welcome page instead of site root.

## Related issue(s)

_Issue:_ Sign In redirects to root page of the self service ui.

_More context:_ The Kratos SelfService UI used by the Quickstarts does not serve a root page but instead returns a json error: `{"error":{"code":404,"status":"Not Found","message":"Requested url does not match any rules"}}`.

Steps to reproduce:
1. Start Kratos and Oathkeeper. Example: `docker compose -f quickstart.yml -f quickstart-oathkeeper.yml up --build --force-recreate` 
2. Go to the welcome page and then Sign Up.
3. Upon completing account creation you are redirected to site root and presented with the json "Not Found" error.
4. Go to the welcome page after creating an account and Sign Out.
5. Go to the welcome page and Sign In. Upon successful sign in you are redirected to site root and presented with the json "Not Found" error.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).
