### PR TITLE
test: enable server-side config from context

### DIFF
--- a/cipher/cipher_test.go
+++ b/cipher/cipher_test.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"testing"
 
+	confighelpers "github.com/ory/kratos/driver/config/testhelpers"
+
 	"github.com/ory/x/configx"
 
 	"github.com/stretchr/testify/assert"
@@ -44,7 +46,7 @@ func TestCipher(t *testing.T) {
 			t.Run("case=encryption_failed", func(t *testing.T) {
 				t.Parallel()
 
-				ctx := config.WithConfigValue(ctx, config.ViperKeySecretsCipher, []string{""})
+				ctx := confighelpers.WithConfigValue(ctx, config.ViperKeySecretsCipher, []string{""})
 
 				// secret have to be set
 				_, err := c.Encrypt(ctx, []byte("not-empty"))
@@ -53,7 +55,7 @@ func TestCipher(t *testing.T) {
 				require.ErrorAs(t, err, &hErr)
 				assert.Equal(t, "Unable to encrypt message because no cipher secrets were configured.", hErr.Reason())
 
-				ctx = config.WithConfigValue(ctx, config.ViperKeySecretsCipher, []string{"bad-length"})
+				ctx = confighelpers.WithConfigValue(ctx, config.ViperKeySecretsCipher, []string{"bad-length"})
 
 				// bad secret length
 				_, err = c.Encrypt(ctx, []byte("not-empty"))
@@ -70,7 +72,7 @@ func TestCipher(t *testing.T) {
 				_, err = c.Decrypt(ctx, "not-empty")
 				require.Error(t, err)
 
-				_, err = c.Decrypt(config.WithConfigValue(ctx, config.ViperKeySecretsCipher, []string{""}), "not-empty")
+				_, err = c.Decrypt(confighelpers.WithConfigValue(ctx, config.ViperKeySecretsCipher, []string{""}), "not-empty")
 				require.Error(t, err)
 			})
 		})

--- a/driver/config/handler_test.go
+++ b/driver/config/handler_test.go
@@ -6,7 +6,7 @@ package config_test
 import (
 	"context"
 	"io"
-	"net/http/httptest"
+	"net/http"
 	"testing"
 
 	"github.com/julienschmidt/httprouter"
@@ -17,21 +17,32 @@ import (
 	"github.com/ory/kratos/internal"
 )
 
+type configProvider struct {
+	cfg *config.Config
+}
+
+func (c *configProvider) Config() *config.Config {
+	return c.cfg
+}
+
 func TestNewConfigHashHandler(t *testing.T) {
 	ctx := context.Background()
-	conf, reg := internal.NewFastRegistryWithMocks(t)
+	cfg := internal.NewConfigurationWithDefaults(t)
 	router := httprouter.New()
-	config.NewConfigHashHandler(reg, router)
-	ts := httptest.NewServer(router)
+	config.NewConfigHashHandler(&configProvider{cfg: cfg}, router)
+	ts := config.NewConfigurableTestServer(router)
 	t.Cleanup(ts.Close)
-	res, err := ts.Client().Get(ts.URL + "/health/config")
+
+	// first request, get baseline hash
+	res, err := ts.Client(ctx).Get(ts.URL + "/health/config")
 	require.NoError(t, err)
 	defer res.Body.Close()
 	require.Equal(t, 200, res.StatusCode)
 	first, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
-	res, err = ts.Client().Get(ts.URL + "/health/config")
+	// second request, no config change
+	res, err = ts.Client(ctx).Get(ts.URL + "/health/config")
 	require.NoError(t, err)
 	defer res.Body.Close()
 	require.Equal(t, 200, res.StatusCode)
@@ -39,13 +50,21 @@ func TestNewConfigHashHandler(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, first, second)
 
-	require.NoError(t, conf.Set(ctx, config.ViperKeySessionDomain, "foobar"))
-
-	res, err = ts.Client().Get(ts.URL + "/health/config")
+	// third request, with config change
+	res, err = ts.Client(config.WithConfigValue(ctx, config.ViperKeySessionDomain, "foobar")).Get(ts.URL + "/health/config")
 	require.NoError(t, err)
 	defer res.Body.Close()
 	require.Equal(t, 200, res.StatusCode)
-	second, err = io.ReadAll(res.Body)
+	third, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
-	assert.NotEqual(t, first, second)
+	assert.NotEqual(t, first, third)
+
+	// fourth request, no config change
+	res, err = http.Get(ts.URL + "/health/config")
+	require.NoError(t, err)
+	defer res.Body.Close()
+	require.Equal(t, 200, res.StatusCode)
+	fourth, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	assert.Equal(t, first, fourth)
 }

--- a/driver/config/test_config.go
+++ b/driver/config/test_config.go
@@ -5,6 +5,10 @@ package config
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/gofrs/uuid"
 
 	"github.com/ory/kratos/embedx"
 	"github.com/ory/x/configx"
@@ -51,14 +55,98 @@ func WithConfigValue(ctx context.Context, key string, value any) context.Context
 	return WithConfigValues(ctx, map[string]any{key: value})
 }
 
-func WithConfigValues(ctx context.Context, setValues map[string]any) context.Context {
+func WithConfigValues(ctx context.Context, setValues ...map[string]any) context.Context {
 	values, ok := ctx.Value(contextConfigKey).([]map[string]any)
 	if !ok {
 		values = make([]map[string]any, 0)
 	}
-	newValues := make([]map[string]any, len(values), len(values)+1)
+	newValues := make([]map[string]any, len(values), len(values)+len(setValues))
 	copy(newValues, values)
-	newValues = append(newValues, setValues)
+	newValues = append(newValues, setValues...)
 
 	return context.WithValue(ctx, contextConfigKey, newValues)
+}
+
+type ConfigurableTestHandler struct {
+	configs map[uuid.UUID][]map[string]any
+	handler http.Handler
+}
+
+func NewConfigurableTestHandler(h http.Handler) *ConfigurableTestHandler {
+	return &ConfigurableTestHandler{
+		configs: make(map[uuid.UUID][]map[string]any),
+		handler: h,
+	}
+}
+
+func (t *ConfigurableTestHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	cID := r.Header.Get("Test-Config-Id")
+	if config, ok := t.configs[uuid.FromStringOrNil(cID)]; ok {
+		r = r.WithContext(WithConfigValues(r.Context(), config...))
+	}
+	t.handler.ServeHTTP(w, r)
+}
+
+func (t *ConfigurableTestHandler) RegisterConfig(config ...map[string]any) uuid.UUID {
+	id := uuid.Must(uuid.NewV4())
+	t.configs[id] = config
+	return id
+}
+
+func (t *ConfigurableTestHandler) UseConfig(r *http.Request, id uuid.UUID) *http.Request {
+	r.Header.Set("Test-Config-Id", id.String())
+	return r
+}
+
+func (t *ConfigurableTestHandler) UseConfigValues(r *http.Request, values ...map[string]any) *http.Request {
+	return t.UseConfig(r, t.RegisterConfig(values...))
+}
+
+type ConfigurableTestServer struct {
+	*httptest.Server
+	handler   *ConfigurableTestHandler
+	transport http.RoundTripper
+}
+
+func NewConfigurableTestServer(h http.Handler) *ConfigurableTestServer {
+	handler := NewConfigurableTestHandler(h)
+	server := httptest.NewServer(handler)
+
+	t := server.Client().Transport
+	cts := &ConfigurableTestServer{
+		handler:   handler,
+		Server:    server,
+		transport: t,
+	}
+	server.Client().Transport = cts
+	return cts
+}
+
+func (t *ConfigurableTestServer) RoundTrip(r *http.Request) (*http.Response, error) {
+	config, ok := r.Context().Value(contextConfigKey).([]map[string]any)
+	if ok && config != nil {
+		r = t.handler.UseConfigValues(r, config...)
+	}
+	return t.transport.RoundTrip(r)
+}
+
+type AutoContextClient struct {
+	*http.Client
+	transport http.RoundTripper
+	ctx       context.Context
+}
+
+func (t *ConfigurableTestServer) Client(ctx context.Context) *AutoContextClient {
+	baseClient := *t.Server.Client()
+	autoClient := &AutoContextClient{
+		Client:    &baseClient,
+		transport: t,
+		ctx:       ctx,
+	}
+	baseClient.Transport = autoClient
+	return autoClient
+}
+
+func (c *AutoContextClient) RoundTrip(r *http.Request) (*http.Response, error) {
+	return c.transport.RoundTrip(r.WithContext(c.ctx))
 }

--- a/driver/config/testhelpers/config.go
+++ b/driver/config/testhelpers/config.go
@@ -1,7 +1,7 @@
 // Copyright © 2024 Ory Corp
 // SPDX-License-Identifier: Apache-2.0
 
-package config
+package testhelpers
 
 import (
 	"context"

--- a/driver/registry_default_test.go
+++ b/driver/registry_default_test.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"testing"
 
+	confighelpers "github.com/ory/kratos/driver/config/testhelpers"
+
 	"github.com/ory/x/contextx"
 
 	"github.com/ory/kratos/selfservice/flow/recovery"
@@ -69,7 +71,7 @@ func TestDriverDefault_Hooks(t *testing.T) {
 			t.Run(fmt.Sprintf("before/uc=%s", tc.uc), func(t *testing.T) {
 				t.Parallel()
 
-				ctx := config.WithConfigValues(ctx, tc.config)
+				ctx := confighelpers.WithConfigValues(ctx, tc.config)
 
 				h := reg.PreVerificationHooks(ctx)
 
@@ -110,7 +112,7 @@ func TestDriverDefault_Hooks(t *testing.T) {
 			t.Run(fmt.Sprintf("after/uc=%s", tc.uc), func(t *testing.T) {
 				t.Parallel()
 
-				ctx := config.WithConfigValues(ctx, tc.config)
+				ctx := confighelpers.WithConfigValues(ctx, tc.config)
 
 				h := reg.PostVerificationHooks(ctx)
 
@@ -152,7 +154,7 @@ func TestDriverDefault_Hooks(t *testing.T) {
 			t.Run(fmt.Sprintf("before/uc=%s", tc.uc), func(t *testing.T) {
 				t.Parallel()
 
-				ctx := config.WithConfigValues(ctx, tc.config)
+				ctx := confighelpers.WithConfigValues(ctx, tc.config)
 
 				h := reg.PreRecoveryHooks(ctx)
 
@@ -191,7 +193,7 @@ func TestDriverDefault_Hooks(t *testing.T) {
 			t.Run(fmt.Sprintf("after/uc=%s", tc.uc), func(t *testing.T) {
 				t.Parallel()
 
-				ctx := config.WithConfigValues(ctx, tc.config)
+				ctx := confighelpers.WithConfigValues(ctx, tc.config)
 
 				h := reg.PostRecoveryHooks(ctx)
 
@@ -238,7 +240,7 @@ func TestDriverDefault_Hooks(t *testing.T) {
 			t.Run(fmt.Sprintf("before/uc=%s", tc.uc), func(t *testing.T) {
 				t.Parallel()
 
-				ctx := config.WithConfigValues(ctx, tc.config)
+				ctx := confighelpers.WithConfigValues(ctx, tc.config)
 
 				h := reg.PreRegistrationHooks(ctx)
 
@@ -342,7 +344,7 @@ func TestDriverDefault_Hooks(t *testing.T) {
 			t.Run(fmt.Sprintf("after/uc=%s", tc.uc), func(t *testing.T) {
 				t.Parallel()
 
-				ctx := config.WithConfigValues(ctx, tc.config)
+				ctx := confighelpers.WithConfigValues(ctx, tc.config)
 
 				h := reg.PostRegistrationPostPersistHooks(ctx, identity.CredentialsTypePassword)
 
@@ -384,7 +386,7 @@ func TestDriverDefault_Hooks(t *testing.T) {
 			t.Run(fmt.Sprintf("before/uc=%s", tc.uc), func(t *testing.T) {
 				t.Parallel()
 
-				ctx := config.WithConfigValues(ctx, tc.config)
+				ctx := confighelpers.WithConfigValues(ctx, tc.config)
 
 				h := reg.PreLoginHooks(ctx)
 
@@ -486,7 +488,7 @@ func TestDriverDefault_Hooks(t *testing.T) {
 			t.Run(fmt.Sprintf("after/uc=%s", tc.uc), func(t *testing.T) {
 				t.Parallel()
 
-				ctx := config.WithConfigValues(ctx, tc.config)
+				ctx := confighelpers.WithConfigValues(ctx, tc.config)
 
 				h := reg.PostLoginHooks(ctx, identity.CredentialsTypePassword)
 
@@ -528,7 +530,7 @@ func TestDriverDefault_Hooks(t *testing.T) {
 			t.Run(fmt.Sprintf("before/uc=%s", tc.uc), func(t *testing.T) {
 				t.Parallel()
 
-				ctx := config.WithConfigValues(ctx, tc.config)
+				ctx := confighelpers.WithConfigValues(ctx, tc.config)
 
 				h := reg.PreSettingsHooks(ctx)
 
@@ -614,7 +616,7 @@ func TestDriverDefault_Hooks(t *testing.T) {
 			t.Run(fmt.Sprintf("after/uc=%s", tc.uc), func(t *testing.T) {
 				t.Parallel()
 
-				ctx := config.WithConfigValues(ctx, tc.config)
+				ctx := confighelpers.WithConfigValues(ctx, tc.config)
 
 				h := reg.PostSettingsPostPersistHooks(ctx, "profile")
 
@@ -685,7 +687,7 @@ func TestDriverDefault_Strategies(t *testing.T) {
 			t.Run(fmt.Sprintf("subcase=%s", tc.name), func(t *testing.T) {
 				t.Parallel()
 
-				ctx := config.WithConfigValues(ctx, tc.config)
+				ctx := confighelpers.WithConfigValues(ctx, tc.config)
 				s := reg.RegistrationStrategies(ctx)
 				require.Len(t, s, len(tc.expect))
 				for k, e := range tc.expect {
@@ -758,7 +760,7 @@ func TestDriverDefault_Strategies(t *testing.T) {
 			t.Run(fmt.Sprintf("run=%s", tc.name), func(t *testing.T) {
 				t.Parallel()
 
-				ctx := config.WithConfigValues(ctx, tc.config)
+				ctx := confighelpers.WithConfigValues(ctx, tc.config)
 				s := reg.LoginStrategies(ctx)
 				require.Len(t, s, len(tc.expect))
 				for k, e := range tc.expect {
@@ -790,7 +792,7 @@ func TestDriverDefault_Strategies(t *testing.T) {
 			t.Run(fmt.Sprintf("run=%d", k), func(t *testing.T) {
 				t.Parallel()
 
-				ctx := config.WithConfigValues(ctx, tc.config)
+				ctx := confighelpers.WithConfigValues(ctx, tc.config)
 
 				s := reg.RecoveryStrategies(ctx)
 				require.Len(t, s, len(tc.expect))
@@ -912,7 +914,7 @@ func TestGetActiveRecoveryStrategy(t *testing.T) {
 	_, reg := internal.NewVeryFastRegistryWithoutDB(t)
 
 	t.Run("returns error if active strategy is disabled", func(t *testing.T) {
-		ctx := config.WithConfigValues(ctx, map[string]any{
+		ctx := confighelpers.WithConfigValues(ctx, map[string]any{
 			"selfservice.methods.code.enabled":    false,
 			config.ViperKeySelfServiceRecoveryUse: "code",
 		})
@@ -926,7 +928,7 @@ func TestGetActiveRecoveryStrategy(t *testing.T) {
 			"code", "link",
 		} {
 			t.Run(fmt.Sprintf("strategy=%s", sID), func(t *testing.T) {
-				ctx := config.WithConfigValues(ctx, map[string]any{
+				ctx := confighelpers.WithConfigValues(ctx, map[string]any{
 					fmt.Sprintf("selfservice.methods.%s.enabled", sID): true,
 					config.ViperKeySelfServiceRecoveryUse:              sID,
 				})
@@ -944,7 +946,7 @@ func TestGetActiveVerificationStrategy(t *testing.T) {
 	ctx := context.Background()
 	_, reg := internal.NewVeryFastRegistryWithoutDB(t)
 	t.Run("returns error if active strategy is disabled", func(t *testing.T) {
-		ctx := config.WithConfigValues(ctx, map[string]any{
+		ctx := confighelpers.WithConfigValues(ctx, map[string]any{
 			"selfservice.methods.code.enabled":        false,
 			config.ViperKeySelfServiceVerificationUse: "code",
 		})
@@ -957,7 +959,7 @@ func TestGetActiveVerificationStrategy(t *testing.T) {
 			"code", "link",
 		} {
 			t.Run(fmt.Sprintf("strategy=%s", sID), func(t *testing.T) {
-				ctx := config.WithConfigValues(ctx, map[string]any{
+				ctx := confighelpers.WithConfigValues(ctx, map[string]any{
 					fmt.Sprintf("selfservice.methods.%s.enabled", sID): true,
 					config.ViperKeySelfServiceVerificationUse:          sID,
 				})

--- a/identity/test/pool.go
+++ b/identity/test/pool.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	confighelpers "github.com/ory/kratos/driver/config/testhelpers"
+
 	"github.com/ory/x/crdbx"
 
 	"github.com/go-faker/faker/v4"
@@ -61,7 +63,7 @@ func TestPool(ctx context.Context, p persistence.Persister, m *identity.Manager,
 			URL:    urlx.ParseOrPanic("file://./stub/handler/multiple_emails.schema.json"),
 			RawURL: "file://./stub/identity-2.schema.json",
 		}
-		ctx := config.WithConfigValues(ctx, map[string]any{
+		ctx := confighelpers.WithConfigValues(ctx, map[string]any{
 			config.ViperKeyPublicBaseURL: exampleServerURL.String(),
 			config.ViperKeyIdentitySchemas: []config.Schema{
 				{

--- a/internal/driver.go
+++ b/internal/driver.go
@@ -9,6 +9,8 @@ import (
 	"runtime"
 	"testing"
 
+	confighelpers "github.com/ory/kratos/driver/config/testhelpers"
+
 	"github.com/ory/x/contextx"
 
 	"github.com/sirupsen/logrus"
@@ -56,7 +58,7 @@ func NewConfigurationWithDefaults(t testing.TB, opts ...configx.OptionModifier) 
 	}, opts...)
 	c := config.MustNew(t, logrusx.New("", ""),
 		os.Stderr,
-		&config.TestConfigProvider{Contextualizer: &contextx.Default{}, Options: configOpts},
+		&confighelpers.TestConfigProvider{Contextualizer: &contextx.Default{}, Options: configOpts},
 		configOpts...,
 	)
 	return c
@@ -91,7 +93,7 @@ func NewRegistryDefaultWithDSN(t testing.TB, dsn string, opts ...configx.OptionM
 	require.NoError(t, err)
 	pool := jsonnetsecure.NewProcessPool(runtime.GOMAXPROCS(0))
 	t.Cleanup(pool.Close)
-	require.NoError(t, reg.Init(context.Background(), &config.TestConfigProvider{Contextualizer: &contextx.Default{}}, driver.SkipNetworkInit, driver.WithDisabledMigrationLogging(), driver.WithJsonnetPool(pool)))
+	require.NoError(t, reg.Init(context.Background(), &confighelpers.TestConfigProvider{Contextualizer: &contextx.Default{}}, driver.SkipNetworkInit, driver.WithDisabledMigrationLogging(), driver.WithJsonnetPool(pool)))
 	require.NoError(t, reg.Persister().MigrateUp(context.Background())) // always migrate up
 
 	actual, err := reg.Persister().DetermineNetwork(context.Background())

--- a/internal/testhelpers/config.go
+++ b/internal/testhelpers/config.go
@@ -8,6 +8,8 @@ import (
 	"encoding/base64"
 	"testing"
 
+	confighelpers "github.com/ory/kratos/driver/config/testhelpers"
+
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/require"
 
@@ -33,7 +35,7 @@ func DefaultIdentitySchemaConfig(url string) map[string]any {
 }
 
 func WithDefaultIdentitySchema(ctx context.Context, url string) context.Context {
-	return config.WithConfigValues(ctx, DefaultIdentitySchemaConfig(url))
+	return confighelpers.WithConfigValues(ctx, DefaultIdentitySchemaConfig(url))
 }
 
 // Deprecated: Use context-based WithDefaultIdentitySchema instead
@@ -58,7 +60,7 @@ func WithAddIdentitySchema(ctx context.Context, t *testing.T, conf *config.Confi
 	schemas, err := conf.IdentityTraitsSchemas(ctx)
 	require.NoError(t, err)
 
-	return config.WithConfigValue(ctx, config.ViperKeyIdentitySchemas, append(schemas, config.Schema{
+	return confighelpers.WithConfigValue(ctx, config.ViperKeyIdentitySchemas, append(schemas, config.Schema{
 		ID:  id,
 		URL: url,
 	})), id

--- a/selfservice/strategy/code/test/persistence.go
+++ b/selfservice/strategy/code/test/persistence.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	confighelpers "github.com/ory/kratos/driver/config/testhelpers"
+
 	"github.com/ory/kratos/internal/testhelpers"
 	"github.com/ory/kratos/persistence"
 	"github.com/ory/kratos/selfservice/flow"
@@ -31,7 +33,7 @@ func TestPersister(ctx context.Context, p interface {
 	return func(t *testing.T) {
 		nid, p := testhelpers.NewNetworkUnlessExisting(t, ctx, p)
 
-		ctx := config.WithConfigValue(ctx, config.ViperKeySecretsDefault, []string{"secret-a", "secret-b"})
+		ctx := confighelpers.WithConfigValue(ctx, config.ViperKeySecretsDefault, []string{"secret-a", "secret-b"})
 
 		t.Run("code=recovery", func(t *testing.T) {
 			newRecoveryCodeDTO := func(t *testing.T, email string) (*code.CreateRecoveryCodeParams, *recovery.Flow, *identity.RecoveryAddress) {
@@ -50,7 +52,7 @@ func TestPersister(ctx context.Context, p interface {
 				require.NoError(t, p.CreateIdentity(ctx, &i))
 
 				return &code.CreateRecoveryCodeParams{
-					RawCode:         string(randx.MustString(8, randx.Numeric)),
+					RawCode:         randx.MustString(8, randx.Numeric),
 					FlowID:          f.ID,
 					RecoveryAddress: &i.RecoveryAddresses[0],
 					ExpiresIn:       time.Minute,

--- a/selfservice/strategy/link/test/persistence.go
+++ b/selfservice/strategy/link/test/persistence.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	confighelpers "github.com/ory/kratos/driver/config/testhelpers"
+
 	"github.com/ory/kratos/internal/testhelpers"
 	"github.com/ory/kratos/persistence"
 	"github.com/ory/kratos/selfservice/flow"
@@ -35,7 +37,7 @@ func TestPersister(ctx context.Context, p interface {
 	return func(t *testing.T) {
 		nid, p := testhelpers.NewNetworkUnlessExisting(t, ctx, p)
 
-		ctx := config.WithConfigValue(ctx, config.ViperKeySecretsDefault, []string{"secret-a", "secret-b"})
+		ctx := confighelpers.WithConfigValue(ctx, config.ViperKeySecretsDefault, []string{"secret-a", "secret-b"})
 
 		t.Run("token=recovery", func(t *testing.T) {
 			newRecoveryToken := func(t *testing.T, email string) (*link.RecoveryToken, *recovery.Flow) {

--- a/session/test/persistence.go
+++ b/session/test/persistence.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	confighelpers "github.com/ory/kratos/driver/config/testhelpers"
+
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 
@@ -609,7 +611,7 @@ func TestPersister(ctx context.Context, conf *config.Config, p interface {
 		})
 
 		t.Run("extend session lifespan but min time is not yet reached", func(t *testing.T) {
-			ctx := config.WithConfigValues(ctx, map[string]any{config.ViperKeySessionRefreshMinTimeLeft: 2 * time.Hour})
+			ctx := confighelpers.WithConfigValues(ctx, map[string]any{config.ViperKeySessionRefreshMinTimeLeft: 2 * time.Hour})
 
 			var expected session.Session
 			require.NoError(t, faker.FakeData(&expected))
@@ -624,7 +626,7 @@ func TestPersister(ctx context.Context, conf *config.Config, p interface {
 		})
 
 		t.Run("extend session lifespan", func(t *testing.T) {
-			ctx := config.WithConfigValues(ctx, map[string]any{config.ViperKeySessionRefreshMinTimeLeft: 2 * time.Hour})
+			ctx := confighelpers.WithConfigValues(ctx, map[string]any{config.ViperKeySessionRefreshMinTimeLeft: 2 * time.Hour})
 
 			var expected session.Session
 			require.NoError(t, faker.FakeData(&expected))
@@ -644,7 +646,7 @@ func TestPersister(ctx context.Context, conf *config.Config, p interface {
 				t.Skip("Skipping test because driver is not CockroachDB")
 			}
 
-			ctx := config.WithConfigValue(ctx, config.ViperKeySessionRefreshMinTimeLeft, 2*time.Hour)
+			ctx := confighelpers.WithConfigValue(ctx, config.ViperKeySessionRefreshMinTimeLeft, 2*time.Hour)
 
 			var expected session.Session
 			require.NoError(t, faker.FakeData(&expected))


### PR DESCRIPTION
With this change we can use the context-based test configs server side, e.g. in integration tests.