### PR TITLE
Differentiate between missing sessions and internal server errors

### DIFF
--- a/session/handler.go
+++ b/session/handler.go
@@ -215,13 +215,20 @@ func (h *Handler) whoami(w http.ResponseWriter, r *http.Request, _ httprouter.Pa
 	s, err := h.r.SessionManager().FetchFromRequest(ctx, r)
 	c := h.r.Config()
 	if err != nil {
+		h.r.Audit().WithRequest(r).WithError(err).Info("No valid session found.")
+
 		// We cache errors (and set cache header only when configured) where no session was found.
-		if noSess := new(ErrNoActiveSessionFound); c.SessionWhoAmICaching(ctx) && errors.As(err, &noSess) && noSess.credentialsMissing {
-			w.Header().Set("Ory-Session-Cache-For", fmt.Sprintf("%d", int64(time.Minute.Seconds())))
+		if noSess := new(ErrNoActiveSessionFound); errors.As(err, &noSess) {
+			if c.SessionWhoAmICaching(ctx) && noSess.credentialsMissing {
+				w.Header().Set("Ory-Session-Cache-For", fmt.Sprintf("%d", int64(time.Minute.Seconds())))
+			}
+
+			h.r.Writer().WriteError(w, r, ErrNoSessionFound.WithWrap(err))
+			return
+
 		}
 
-		h.r.Audit().WithRequest(r).WithError(err).Info("No valid session found.")
-		h.r.Writer().WriteError(w, r, ErrNoSessionFound.WithWrap(err))
+		h.r.Writer().WriteError(w, r, herodot.ErrInternalServerError.WithReasonf("Unable to validate session.").WithWrap(err))
 		return
 	}
 


### PR DESCRIPTION
Our consumer of the `whoami` call caches both authorized and unauthorized responses from Kratos. If a session is unauthorized, we should not ping Kratos again for the duration of the cache. However, if Kratos itself had a problem, such as a database error, these responses were coming back as 401s as well. And now we have this potentially false unauthorized response in our cache.

Instead, a 500 is the correct response for a Kratos failure. That way our cache can choose to do nothing with this response and not end up with a poisoned cache.

With this change, an invalid session continued to produce a 401. Valid sessions continue to produce a 200. A Kratos failure, such as a database problem, produces a 500.

```
BREAKING CHANGES: A Kratos failures for `whoami` currently returns a 401. It will now return a 500.
```

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments
