### PR TITLE
fix: move password migration hook config

### DIFF
--- a/driver/config/config.go
+++ b/driver/config/config.go
@@ -203,7 +203,7 @@ const (
 	ViperKeyClientHTTPPrivateIPExceptionURLs                 = "clients.http.private_ip_exception_urls"
 	ViperKeyPreviewDefaultReadConsistencyLevel               = "preview.default_read_consistency_level"
 	ViperKeyVersion                                          = "version"
-	ViperKeyPasswordMigrationHook                            = "selfservice.flows.login.password_migration"
+	ViperKeyPasswordMigrationHook                            = "selfservice.methods.password.config.migrate_hook"
 )
 
 const (

--- a/driver/config/config_test.go
+++ b/driver/config/config_test.go
@@ -218,7 +218,7 @@ func TestViperProvider(t *testing.T) {
 				config  string
 				enabled bool
 			}{
-				{id: "password", enabled: true, config: `{"haveibeenpwned_host":"api.pwnedpasswords.com","haveibeenpwned_enabled":true,"ignore_network_errors":true,"max_breaches":0,"min_password_length":8,"identifier_similarity_check_enabled":true}`},
+				{id: "password", enabled: true, config: `{"haveibeenpwned_host":"api.pwnedpasswords.com","haveibeenpwned_enabled":true,"ignore_network_errors":true,"max_breaches":0,"migrate_hook":{"config":{"emit_analytics_event":true,"method":"POST"},"enabled":false},"min_password_length":8,"identifier_similarity_check_enabled":true}`},
 				{id: "oidc", enabled: true, config: `{"providers":[{"client_id":"a","client_secret":"b","id":"github","provider":"github","mapper_url":"http://test.kratos.ory.sh/default-identity.schema.json"}]}`},
 				{id: "totp", enabled: true, config: `{"issuer":"issuer.ory.sh"}`},
 			} {

--- a/embedx/config.schema.json
+++ b/embedx/config.schema.json
@@ -1303,61 +1303,6 @@
                   "enum": ["one_step", "identifier_first"],
                   "default": "one_step"
                 },
-                "password_migration": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "enabled": {
-                      "type": "boolean",
-                      "title": "Enable Password Migration",
-                      "description": "If set to true will enable password migration.",
-                      "default": false
-                    },
-                    "config": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "properties": {
-                        "url": {
-                          "type": "string",
-                          "description": "The URL the password migration hook should call",
-                          "format": "uri"
-                        },
-                        "method": {
-                          "type": "string",
-                          "description": "The HTTP method to use (GET, POST, etc).",
-                          "const": "POST",
-                          "default": "POST"
-                        },
-                        "headers": {
-                          "type": "object",
-                          "description": "The HTTP headers that must be applied to the password migration hook.",
-                          "additionalProperties": {
-                            "type": "string"
-                          }
-                        },
-                        "emit_analytics_event": {
-                          "type": "boolean",
-                          "default": true,
-                          "description": "Emit tracing events for this hook on delivery or error"
-                        },
-                        "auth": {
-                          "type": "object",
-                          "title": "Auth mechanisms",
-                          "description": "Define which auth mechanism the Web-Hook should use",
-                          "oneOf": [
-                            {
-                              "$ref": "#/definitions/webHookAuthApiKeyProperties"
-                            },
-                            {
-                              "$ref": "#/definitions/webHookAuthBasicAuthProperties"
-                            }
-                          ]
-                        },
-                        "additionalProperties": false
-                      }
-                    }
-                  }
-                },
                 "before": {
                   "$ref": "#/definitions/selfServiceBeforeLogin"
                 },
@@ -1691,6 +1636,61 @@
                       "description": "If set to false the password validation does not check for similarity between the password and the user identifier.",
                       "type": "boolean",
                       "default": true
+                    },
+                    "migrate_hook": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "enabled": {
+                          "type": "boolean",
+                          "title": "Enable Password Migration",
+                          "description": "If set to true will enable password migration.",
+                          "default": false
+                        },
+                        "config": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "properties": {
+                            "url": {
+                              "type": "string",
+                              "description": "The URL the password migration hook should call",
+                              "format": "uri"
+                            },
+                            "method": {
+                              "type": "string",
+                              "description": "The HTTP method to use (GET, POST, etc).",
+                              "const": "POST",
+                              "default": "POST"
+                            },
+                            "headers": {
+                              "type": "object",
+                              "description": "The HTTP headers that must be applied to the password migration hook.",
+                              "additionalProperties": {
+                                "type": "string"
+                              }
+                            },
+                            "emit_analytics_event": {
+                              "type": "boolean",
+                              "default": true,
+                              "description": "Emit tracing events for this hook on delivery or error"
+                            },
+                            "auth": {
+                              "type": "object",
+                              "title": "Auth mechanisms",
+                              "description": "Define which auth mechanism the Web-Hook should use",
+                              "oneOf": [
+                                {
+                                  "$ref": "#/definitions/webHookAuthApiKeyProperties"
+                                },
+                                {
+                                  "$ref": "#/definitions/webHookAuthBasicAuthProperties"
+                                }
+                              ]
+                            },
+                            "additionalProperties": false
+                          }
+                        }
+                      }
                     }
                   },
                   "additionalProperties": false


### PR DESCRIPTION
This moves the password migration hook to

```yaml
selfservice:
  methods:
    password:
      config:
        migrate_hook:
          ...
```