### PR TITLE
fix: IDToken nonce should not be checked (PS-385)

### DIFF
--- a/selfservice/strategy/oidc/strategy.go
+++ b/selfservice/strategy/oidc/strategy.go
@@ -726,7 +726,7 @@ func (s *Strategy) CompletedAuthenticationMethod(ctx context.Context, _ session.
 	}
 }
 
-func (s *Strategy) processIDToken(w http.ResponseWriter, r *http.Request, provider Provider, idToken, idTokenNonce string) (*Claims, error) {
+func (s *Strategy) processIDToken(w http.ResponseWriter, r *http.Request, provider Provider, idToken string) (*Claims, error) {
 	verifier, ok := provider.(IDTokenVerifier)
 	if !ok {
 		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("The provider %s does not support id_token verification", provider.Config().Provider))
@@ -750,14 +750,7 @@ func (s *Strategy) processIDToken(w http.ResponseWriter, r *http.Request, provid
 		// If the provider does not support nonces, we don't do validation and return the claim.
 		// This case only applies to Apple, as some of their devices do not support nonces.
 		// https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api/authenticating_users_with_sign_in_with_apple
-	} else if idTokenNonce == "" {
-		// A nonce was present in the JWT token, but no nonce was submitted in the flow
-		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("No nonce was provided but is required by the provider"))
-	} else if idTokenNonce != claims.Nonce {
-		// The nonce from the JWT token does not match the nonce from the flow.
-		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("The supplied nonce does not match the nonce from the id_token"))
 	}
-	// Nonce checking was successful
 
 	return claims, nil
 }

--- a/selfservice/strategy/oidc/strategy_login.go
+++ b/selfservice/strategy/oidc/strategy_login.go
@@ -238,7 +238,7 @@ func (s *Strategy) Login(w http.ResponseWriter, r *http.Request, f *login.Flow, 
 	}
 
 	if p.IDToken != "" {
-		claims, err := s.processIDToken(w, r, provider, p.IDToken, p.IDTokenNonce)
+		claims, err := s.processIDToken(w, r, provider, p.IDToken)
 		if err != nil {
 			return nil, s.handleError(w, r, f, pid, nil, err)
 		}

--- a/selfservice/strategy/oidc/strategy_registration.go
+++ b/selfservice/strategy/oidc/strategy_registration.go
@@ -196,7 +196,7 @@ func (s *Strategy) Register(w http.ResponseWriter, r *http.Request, f *registrat
 	}
 
 	if p.IDToken != "" {
-		claims, err := s.processIDToken(w, r, provider, p.IDToken, p.IDTokenNonce)
+		claims, err := s.processIDToken(w, r, provider, p.IDToken)
 		if err != nil {
 			return s.handleError(w, r, f, pid, nil, err)
 		}

--- a/selfservice/strategy/oidc/strategy_test.go
+++ b/selfservice/strategy/oidc/strategy_test.go
@@ -801,23 +801,6 @@ func TestStrategy(t *testing.T) {
 				},
 			},
 			{
-				name: "should fail if no nonce is supplied in request",
-				idToken: `{
-					"iss": "https://appleid.apple.com",
-					"sub": "{{sub}}",
-					"nonce": "{{nonce}}"
-				}`,
-				v: func(provider, token, _ string) url.Values {
-					return url.Values{
-						"id_token": {token},
-						"provider": {provider},
-					}
-				},
-				expect: func(t *testing.T, res *http.Response, body []byte) {
-					require.Equal(t, "No nonce was provided but is required by the provider", gjson.GetBytes(body, "error.reason").String(), "%s", body)
-				},
-			},
-			{
 				name: "should pass if claims are valid",
 				idToken: `{
 					"iss": "https://appleid.apple.com",
@@ -826,17 +809,6 @@ func TestStrategy(t *testing.T) {
 				}`,
 				expect: func(t *testing.T, res *http.Response, body []byte) {
 					require.NotEmpty(t, gjson.GetBytes(body, "session_token").String(), "%s", body)
-				},
-			},
-			{
-				name: "nonce mismatch",
-				idToken: `{
-					"iss": "https://appleid.apple.com",
-					"sub": "{{sub}}",
-					"nonce": "random-nonce"
-				}`,
-				expect: func(t *testing.T, res *http.Response, body []byte) {
-					require.Equal(t, "The supplied nonce does not match the nonce from the id_token", gjson.GetBytes(body, "error.reason").String(), "%s", body)
 				},
 			},
 		} {


### PR DESCRIPTION
This PR deletes code which checks nonce in passed OIDC IDToken against another string passed in the same request.
Replay protection cannot be based on comparing two strings taken from the same request.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
