### PR TITLE
fix: add fallback to providerLabel

### DIFF
--- a/selfservice/strategy/oidc/strategy.go
+++ b/selfservice/strategy/oidc/strategy.go
@@ -642,6 +642,9 @@ func (s *Strategy) handleError(w http.ResponseWriter, r *http.Request, f flow.Fl
 				provider, _ := s.provider(r.Context(), r, providerID)
 				if provider != nil && provider.Config() != nil {
 					providerLabel = provider.Config().Label
+					if providerLabel == "" {
+						providerLabel = provider.Config().Provider
+					}
 				}
 				lf.UI.Messages.Add(text.NewInfoLoginLinkMessage(dc.DuplicateIdentifier, providerLabel, newLoginURL))
 


### PR DESCRIPTION
This adds a fallback to the provider label when trying to register a duplicate identifier with an oidc.

Current error message:

`Signing in will link your account to "test@test.com" at provider "". If you do not wish to link that account, please start a new login flow.`

The label represents an optional label for the UI, but in my case it's always empty. I suggest we fallback to the provider when the label is not present. In case the label is present, the behaviour won't change.

Fallback to provider:

`Signing in will link your account to "test@test.com" at provider "google". If you do not wish to link that account, please start a new login flow.`

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).
