### PR TITLE
fix: validate page tokens for better error codes

### DIFF
--- a/internal/client-go/go.sum
+++ b/internal/client-go/go.sum
@@ -4,6 +4,7 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e h1:bRhVy7zSSasaqNksaRZiA5EEI+Ei4I1nO5Jh72wfHlg=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/persistence/sql/identity/persister_identity.go
+++ b/persistence/sql/identity/persister_identity.go
@@ -799,6 +799,10 @@ func (p *IdentityPersister) ListIdentities(ctx context.Context, params identity.
 		attribute.Stringer("network.id", p.NetworkID(ctx)))...))
 	defer otelx.End(span, &err)
 
+	if _, err := uuid.FromString(paginator.Token().Encode()); err != nil {
+		return nil, nil, errors.WithStack(herodot.ErrBadRequest.WithReason("The page token is invalid, do not craft your own page tokens"))
+	}
+
 	nid := p.NetworkID(ctx)
 	var is []identity.Identity
 

--- a/persistence/sql/identity/persister_identity.go
+++ b/persistence/sql/identity/persister_identity.go
@@ -799,7 +799,7 @@ func (p *IdentityPersister) ListIdentities(ctx context.Context, params identity.
 		attribute.Stringer("network.id", p.NetworkID(ctx)))...))
 	defer otelx.End(span, &err)
 
-	if _, err := uuid.FromString(paginator.Token().Encode()); err != nil {
+	if _, err := uuid.FromString(paginator.Token().Parse("id")["id"]); err != nil {
 		return nil, nil, errors.WithStack(x.PageTokenInvalid)
 	}
 

--- a/persistence/sql/identity/persister_identity.go
+++ b/persistence/sql/identity/persister_identity.go
@@ -800,7 +800,7 @@ func (p *IdentityPersister) ListIdentities(ctx context.Context, params identity.
 	defer otelx.End(span, &err)
 
 	if _, err := uuid.FromString(paginator.Token().Encode()); err != nil {
-		return nil, nil, errors.WithStack(herodot.ErrBadRequest.WithReason("The page token is invalid, do not craft your own page tokens"))
+		return nil, nil, errors.WithStack(x.PageTokenInvalid)
 	}
 
 	nid := p.NetworkID(ctx)

--- a/persistence/sql/persister_courier.go
+++ b/persistence/sql/persister_courier.go
@@ -57,6 +57,10 @@ func (p *Persister) ListMessages(ctx context.Context, filter courier.ListCourier
 	opts = append(opts, keysetpagination.WithColumn("created_at", "DESC"))
 	paginator := keysetpagination.GetPaginator(opts...)
 
+	if _, err := uuid.FromString(paginator.Token().Encode()); err != nil {
+		return nil, 0, nil, errors.WithStack(herodot.ErrBadRequest.WithReason("The page token is invalid, do not craft your own page tokens"))
+	}
+
 	messages := make([]courier.Message, paginator.Size())
 	if err := q.Scope(keysetpagination.Paginate[courier.Message](paginator)).
 		All(&messages); err != nil {

--- a/persistence/sql/persister_courier.go
+++ b/persistence/sql/persister_courier.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/ory/kratos/courier"
 	"github.com/ory/kratos/persistence/sql/update"
+	"github.com/ory/kratos/x"
 )
 
 var _ courier.Persister = new(Persister)
@@ -58,7 +59,7 @@ func (p *Persister) ListMessages(ctx context.Context, filter courier.ListCourier
 	paginator := keysetpagination.GetPaginator(opts...)
 
 	if _, err := uuid.FromString(paginator.Token().Encode()); err != nil {
-		return nil, 0, nil, errors.WithStack(herodot.ErrBadRequest.WithReason("The page token is invalid, do not craft your own page tokens"))
+		return nil, 0, nil, errors.WithStack(x.PageTokenInvalid)
 	}
 
 	messages := make([]courier.Message, paginator.Size())

--- a/persistence/sql/persister_courier.go
+++ b/persistence/sql/persister_courier.go
@@ -58,7 +58,7 @@ func (p *Persister) ListMessages(ctx context.Context, filter courier.ListCourier
 	opts = append(opts, keysetpagination.WithColumn("created_at", "DESC"))
 	paginator := keysetpagination.GetPaginator(opts...)
 
-	if _, err := uuid.FromString(paginator.Token().Encode()); err != nil {
+	if _, err := uuid.FromString(paginator.Token().Parse("id")["id"]); err != nil {
 		return nil, 0, nil, errors.WithStack(x.PageTokenInvalid)
 	}
 

--- a/persistence/sql/persister_session.go
+++ b/persistence/sql/persister_session.go
@@ -82,6 +82,10 @@ func (p *Persister) ListSessions(ctx context.Context, active *bool, paginatorOpt
 	paginatorOpts = append(paginatorOpts, keysetpagination.WithColumn("created_at", "DESC"))
 	paginator := keysetpagination.GetPaginator(paginatorOpts...)
 
+	if _, err := uuid.FromString(paginator.Token().Encode()); err != nil {
+		return nil, 0, nil, errors.WithStack(herodot.ErrBadRequest.WithReason("The page token is invalid, do not craft your own page tokens"))
+	}
+
 	if err := p.Transaction(ctx, func(ctx context.Context, c *pop.Connection) error {
 		q := c.Where("nid = ?", nid)
 		if active != nil {

--- a/persistence/sql/persister_session.go
+++ b/persistence/sql/persister_session.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/ory/kratos/identity"
 	"github.com/ory/kratos/session"
+	"github.com/ory/kratos/x"
 	"github.com/ory/kratos/x/events"
 	"github.com/ory/x/otelx"
 	"github.com/ory/x/pagination/keysetpagination"
@@ -83,7 +84,7 @@ func (p *Persister) ListSessions(ctx context.Context, active *bool, paginatorOpt
 	paginator := keysetpagination.GetPaginator(paginatorOpts...)
 
 	if _, err := uuid.FromString(paginator.Token().Encode()); err != nil {
-		return nil, 0, nil, errors.WithStack(herodot.ErrBadRequest.WithReason("The page token is invalid, do not craft your own page tokens"))
+		return nil, 0, nil, errors.WithStack(x.PageTokenInvalid)
 	}
 
 	if err := p.Transaction(ctx, func(ctx context.Context, c *pop.Connection) error {

--- a/persistence/sql/persister_session.go
+++ b/persistence/sql/persister_session.go
@@ -83,7 +83,7 @@ func (p *Persister) ListSessions(ctx context.Context, active *bool, paginatorOpt
 	paginatorOpts = append(paginatorOpts, keysetpagination.WithColumn("created_at", "DESC"))
 	paginator := keysetpagination.GetPaginator(paginatorOpts...)
 
-	if _, err := uuid.FromString(paginator.Token().Encode()); err != nil {
+	if _, err := uuid.FromString(paginator.Token().Parse("id")["id"]); err != nil {
 		return nil, 0, nil, errors.WithStack(x.PageTokenInvalid)
 	}
 

--- a/x/err.go
+++ b/x/err.go
@@ -10,12 +10,15 @@ import (
 	"github.com/ory/herodot"
 )
 
-var PseudoPanic = herodot.DefaultError{
-	StatusField: http.StatusText(http.StatusInternalServerError),
-	ErrorField:  "Code Bug Detected",
-	ReasonField: "The code ended up at a place where it should not have. Please report this as an issue at https://github.com/ory/kratos",
-	CodeField:   http.StatusInternalServerError,
-}
+var (
+	PseudoPanic = herodot.DefaultError{
+		StatusField: http.StatusText(http.StatusInternalServerError),
+		ErrorField:  "Code Bug Detected",
+		ReasonField: "The code ended up at a place where it should not have. Please report this as an issue at https://github.com/ory/kratos",
+		CodeField:   http.StatusInternalServerError,
+	}
+	PageTokenInvalid = herodot.ErrBadRequest.WithReason("The page token is invalid, do not craft your own page tokens")
+)
 
 func RecoverStatusCode(err error, fallback int) int {
 	var sc herodot.StatusCodeCarrier


### PR DESCRIPTION
Currently the error returned is similar to `unable to fetch records: ERROR: error in argument for $2: could not parse "1" as type uuid: could not parse "1" as type uuid: uuid: incorrect UUID length: 1 (SQLSTATE 22P02)`.