### PR TITLE
fix: refactor internal API to prevent panics

### DIFF
--- a/internal/client-go/go.sum
+++ b/internal/client-go/go.sum
@@ -4,6 +4,7 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e h1:bRhVy7zSSasaqNksaRZiA5EEI+Ei4I1nO5Jh72wfHlg=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/selfservice/flow/settings/handler_test.go
+++ b/selfservice/flow/settings/handler_test.go
@@ -580,7 +580,7 @@ func TestHandler(t *testing.T) {
 				require.NoError(t, json.Unmarshal(body, &f))
 
 				actual, res := testhelpers.SettingsMakeRequest(t, false, true, &f, primaryUser, fmt.Sprintf(`{"method":"profile", "numby": 15, "csrf_token": "%s"}`, x.FakeCSRFToken))
-				assert.Equal(t, http.StatusOK, res.StatusCode)
+				require.Equal(t, http.StatusOK, res.StatusCode)
 				require.Len(t, primaryUser.Jar.Cookies(urlx.ParseOrPanic(publicTS.URL+login.RouteGetFlow)), 1)
 				require.Contains(t, fmt.Sprintf("%v", primaryUser.Jar.Cookies(urlx.ParseOrPanic(publicTS.URL))), "ory_kratos_session")
 				assert.Equal(t, "Your changes have been saved!", gjson.Get(actual, "ui.messages.0.text").String(), actual)

--- a/selfservice/strategy/lookup/settings_test.go
+++ b/selfservice/strategy/lookup/settings_test.go
@@ -398,7 +398,7 @@ func TestCompleteSettings(t *testing.T) {
 
 					payloadConfirm(values)
 					actual, res := testhelpers.SettingsMakeRequest(t, true, false, f, apiClient, testhelpers.EncodeFormAsJSON(t, true, values))
-					assert.Equal(t, http.StatusOK, res.StatusCode)
+					require.Equal(t, http.StatusOK, res.StatusCode)
 
 					assert.Contains(t, res.Request.URL.String(), publicTS.URL+settings.RouteSubmitFlow)
 					assert.EqualValues(t, flow.StateSuccess, json.RawMessage(gjson.Get(actual, "state").String()))

--- a/selfservice/strategy/oidc/strategy_login.go
+++ b/selfservice/strategy/oidc/strategy_login.go
@@ -351,7 +351,7 @@ func (s *Strategy) PopulateLoginMethodIdentifierFirstCredentials(r *http.Request
 	if o.IdentityHint != nil {
 		var err error
 		// If we have an identity hint we check if the identity has any providers configured.
-		if linked, err = s.linkedProviders(r.Context(), r, conf, o.IdentityHint); err != nil {
+		if linked, err = s.linkedProviders(conf, o.IdentityHint); err != nil {
 			return err
 		}
 	}

--- a/selfservice/strategy/passkey/passkey_settings_test.go
+++ b/selfservice/strategy/passkey/passkey_settings_test.go
@@ -249,6 +249,7 @@ func TestCompleteSettings(t *testing.T) {
 			values.Set("method", "passkey")
 			values.Set(node.PasskeySettingsRegister, string(settingsFixtureSuccessResponse))
 			body, res := testhelpers.SettingsMakeRequest(t, false, spa, f, browserClient, testhelpers.EncodeFormAsJSON(t, spa, values))
+			require.Equal(t, http.StatusOK, res.StatusCode, "%s", body)
 
 			if spa {
 				assert.Contains(t, res.Request.URL.String(), fix.publicTS.URL+settings.RouteSubmitFlow)
@@ -260,7 +261,7 @@ func TestCompleteSettings(t *testing.T) {
 			actual, err := fix.reg.Persister().GetIdentityConfidential(fix.ctx, id.ID)
 			require.NoError(t, err)
 			cred, ok := actual.GetCredentials(identity.CredentialsTypePasskey)
-			assert.True(t, ok)
+			require.True(t, ok)
 			assert.Len(t, gjson.GetBytes(cred.Config, "credentials").Array(), 1)
 
 			actualFlow, err := fix.reg.SettingsFlowPersister().GetSettingsFlow(fix.ctx, uuid.FromStringOrNil(f.Id))

--- a/selfservice/strategy/password/login.go
+++ b/selfservice/strategy/password/login.go
@@ -35,7 +35,7 @@ var _ login.FormHydrator = new(Strategy)
 func (s *Strategy) RegisterLoginRoutes(r *x.RouterPublic) {
 }
 
-func (s *Strategy) handleLoginError(r *http.Request, f *login.Flow, payload *updateLoginFlowWithPasswordMethod, err error) error {
+func (s *Strategy) handleLoginError(r *http.Request, f *login.Flow, payload updateLoginFlowWithPasswordMethod, err error) error {
 	if f != nil {
 		f.UI.Nodes.ResetNodes("password")
 		f.UI.Nodes.SetValueAttribute("identifier", stringsx.Coalesce(payload.Identifier, payload.LegacyIdentifier))
@@ -61,19 +61,19 @@ func (s *Strategy) Login(w http.ResponseWriter, r *http.Request, f *login.Flow, 
 		decoderx.HTTPDecoderSetValidatePayloads(true),
 		decoderx.MustHTTPRawJSONSchemaCompiler(loginSchema),
 		decoderx.HTTPDecoderJSONFollowsFormFormat()); err != nil {
-		return nil, s.handleLoginError(r, f, &p, err)
+		return nil, s.handleLoginError(r, f, p, err)
 	}
 	f.TransientPayload = p.TransientPayload
 
 	if err := flow.EnsureCSRF(s.d, r, f.Type, s.d.Config().DisableAPIFlowEnforcement(r.Context()), s.d.GenerateCSRFToken, p.CSRFToken); err != nil {
-		return nil, s.handleLoginError(r, f, &p, err)
+		return nil, s.handleLoginError(r, f, p, err)
 	}
 
 	identifier := stringsx.Coalesce(p.Identifier, p.LegacyIdentifier)
 	i, c, err := s.d.PrivilegedIdentityPool().FindByCredentialsIdentifier(r.Context(), s.ID(), identifier)
 	if err != nil {
 		time.Sleep(x.RandomDelay(s.d.Config().HasherArgon2(r.Context()).ExpectedDuration, s.d.Config().HasherArgon2(r.Context()).ExpectedDeviation))
-		return nil, s.handleLoginError(r, f, &p, errors.WithStack(schema.NewInvalidCredentialsError()))
+		return nil, s.handleLoginError(r, f, p, errors.WithStack(schema.NewInvalidCredentialsError()))
 	}
 
 	var o identity.CredentialsPassword
@@ -91,27 +91,27 @@ func (s *Strategy) Login(w http.ResponseWriter, r *http.Request, f *login.Flow, 
 		migrationHook := hook.NewPasswordMigrationHook(s.d, pwHook.Config)
 		err = migrationHook.Execute(r.Context(), &hook.PasswordMigrationRequest{Identifier: identifier, Password: p.Password})
 		if err != nil {
-			return nil, s.handleLoginError(r, f, &p, err)
+			return nil, s.handleLoginError(r, f, p, err)
 		}
 
 		if err := s.migratePasswordHash(r.Context(), i.ID, []byte(p.Password)); err != nil {
-			return nil, s.handleLoginError(r, f, &p, err)
+			return nil, s.handleLoginError(r, f, p, err)
 		}
 	} else {
 		if err := hash.Compare(r.Context(), []byte(p.Password), []byte(o.HashedPassword)); err != nil {
-			return nil, s.handleLoginError(r, f, &p, errors.WithStack(schema.NewInvalidCredentialsError()))
+			return nil, s.handleLoginError(r, f, p, errors.WithStack(schema.NewInvalidCredentialsError()))
 		}
 
 		if !s.d.Hasher(r.Context()).Understands([]byte(o.HashedPassword)) {
 			if err := s.migratePasswordHash(r.Context(), i.ID, []byte(p.Password)); err != nil {
-				return nil, s.handleLoginError(r, f, &p, err)
+				return nil, s.handleLoginError(r, f, p, err)
 			}
 		}
 	}
 
 	f.Active = s.ID()
 	if err = s.d.LoginFlowPersister().UpdateLoginFlow(r.Context(), f); err != nil {
-		return nil, s.handleLoginError(r, f, &p, errors.WithStack(herodot.ErrInternalServerError.WithReason("Could not update flow").WithDebug(err.Error())))
+		return nil, s.handleLoginError(r, f, p, errors.WithStack(herodot.ErrInternalServerError.WithReason("Could not update flow").WithDebug(err.Error())))
 	}
 
 	return i, nil

--- a/selfservice/strategy/webauthn/settings_test.go
+++ b/selfservice/strategy/webauthn/settings_test.go
@@ -332,6 +332,7 @@ func TestCompleteSettings(t *testing.T) {
 			values.Set(node.WebAuthnRegister, string(settingsFixtureSuccessResponse))
 			values.Set(node.WebAuthnRegisterDisplayName, "foobar")
 			body, res := testhelpers.SettingsMakeRequest(t, false, spa, f, browserClient, testhelpers.EncodeFormAsJSON(t, spa, values))
+			require.Equal(t, http.StatusOK, res.StatusCode, body)
 
 			if spa {
 				assert.Contains(t, res.Request.URL.String(), publicTS.URL+settings.RouteSubmitFlow)
@@ -343,7 +344,7 @@ func TestCompleteSettings(t *testing.T) {
 			actual, err := reg.Persister().GetIdentityConfidential(context.Background(), id.ID)
 			require.NoError(t, err)
 			cred, ok := actual.GetCredentials(identity.CredentialsTypeWebAuthn)
-			assert.True(t, ok)
+			require.True(t, ok)
 			assert.Len(t, gjson.GetBytes(cred.Config, "credentials").Array(), 1)
 
 			actualFlow, err := reg.SettingsFlowPersister().GetSettingsFlow(context.Background(), uuid.FromStringOrNil(f.Id))


### PR DESCRIPTION
I noticed a nil-pointer dereference panic in `github.com/ory/kratos/selfservice/strategy/code.(*Strategy).handleVerificationError`

The problem really is that the internal API use(d) pointers where it was not necessary, and lacked nil checks elsewhere. This change adds nil checks, and also improves the internal API to avoid pointers when not strictly needed.