### PR TITLE
fix: filter web hook headers

### DIFF
--- a/selfservice/hook/web_hook_integration_test.go
+++ b/selfservice/hook/web_hook_integration_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/sjson"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"golang.org/x/exp/slices"
@@ -117,10 +118,8 @@ func TestWebHooks(t *testing.T) {
 	}
 
 	bodyWithFlowOnly := func(req *http.Request, f flow.Flow) string {
-		h, _ := json.Marshal(req.Header)
-		return fmt.Sprintf(`{
+		body := fmt.Sprintf(`{
 					"flow_id": "%s",
-					"headers": %s,
 					"method": "%s",
 					"url": "%s",
 					"cookies": {
@@ -128,15 +127,22 @@ func TestWebHooks(t *testing.T) {
 						"Some-Cookie-2": "Some-other-Cookie-Value",
 						"Some-Cookie-3": "Third-Cookie-Value"
 					}
-				}`, f.GetID(), string(h), req.Method, "http://www.ory.sh/some_end_point")
+				}`, f.GetID(), req.Method, "http://www.ory.sh/some_end_point")
+		if len(req.Header) != 0 {
+			var err error
+			body, err = sjson.Set(body, "headers", req.Header)
+			if err != nil {
+				panic(err)
+			}
+		}
+
+		return body
 	}
 
 	bodyWithFlowAndIdentityAndTransientPayload := func(req *http.Request, f flow.Flow, s *session.Session, tp json.RawMessage) string {
-		h, _ := json.Marshal(req.Header)
-		return fmt.Sprintf(`{
+		body := fmt.Sprintf(`{
 					"flow_id": "%s",
 					"identity_id": "%s",
-					"headers": %s,
 					"method": "%s",
 					"url": "%s",
 					"cookies": {
@@ -145,16 +151,23 @@ func TestWebHooks(t *testing.T) {
 						"Some-Cookie-3": "Third-Cookie-Value"
 					},
 					"transient_payload": %s
-				}`, f.GetID(), s.Identity.ID, string(h), req.Method, "http://www.ory.sh/some_end_point", string(tp))
+				}`, f.GetID(), s.Identity.ID, req.Method, "http://www.ory.sh/some_end_point", string(tp))
+		if len(req.Header) != 0 {
+			var err error
+			body, err = sjson.Set(body, "headers", req.Header)
+			if err != nil {
+				panic(err)
+			}
+		}
+
+		return body
 	}
 
 	bodyWithFlowAndIdentityAndSessionAndTransientPayload := func(req *http.Request, f flow.Flow, s *session.Session, tp json.RawMessage) string {
-		h, _ := json.Marshal(req.Header)
-		return fmt.Sprintf(`{
+		body := fmt.Sprintf(`{
 					"flow_id": "%s",
 					"identity_id": "%s",
 					"session_id": "%s",
-					"headers": %s,
 					"method": "%s",
 					"url": "%s",
 					"cookies": {
@@ -163,7 +176,16 @@ func TestWebHooks(t *testing.T) {
 						"Some-Cookie-3": "Third-Cookie-Value"
 					},
 					"transient_payload": %s
-				}`, f.GetID(), s.Identity.ID, s.ID, string(h), req.Method, "http://www.ory.sh/some_end_point", string(tp))
+				}`, f.GetID(), s.Identity.ID, s.ID, req.Method, "http://www.ory.sh/some_end_point", string(tp))
+		if len(req.Header) != 0 {
+			var err error
+			body, err = sjson.Set(body, "headers", req.Header)
+			if err != nil {
+				panic(err)
+			}
+		}
+
+		return body
 	}
 
 	for _, tc := range []struct {
@@ -316,8 +338,10 @@ func TestWebHooks(t *testing.T) {
 							req := &http.Request{
 								Host: "www.ory.sh",
 								Header: map[string][]string{
-									"Some-Header": {"Some-Value"},
-									"Cookie":      {"Some-Cookie-1=Some-Cookie-Value; Some-Cookie-2=Some-other-Cookie-Value", "Some-Cookie-3=Third-Cookie-Value"},
+									"Some-Header":    {"Some-Value"},
+									"User-Agent":     {"Foo-Bar-Browser"},
+									"Invalid-Header": {"ignored"},
+									"Cookie":         {"Some-Cookie-1=Some-Cookie-Value; Some-Cookie-2=Some-other-Cookie-Value", "Some-Cookie-3=Third-Cookie-Value"},
 								},
 								RequestURI: "/some_end_point",
 								Method:     http.MethodPost,


### PR DESCRIPTION
This enforces an allow list for the request headers sent to a web hook target.

## Related issue(s)

Related to https://github.com/ory-corp/cloud/issues/6181

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
