### PR TITLE
feat: redirect to OIDC providers only once in registration flows

### DIFF
--- a/oryx/watcherx/directory.go
+++ b/oryx/watcherx/directory.go
@@ -53,7 +53,7 @@ type directoryWatcher struct {
 	// potentially by external callers (e.g. tests) concurrently.
 	subDirsMtx sync.RWMutex
 	subDirs    map[string]struct{}
-	w       *fsnotify.Watcher
+	w          *fsnotify.Watcher
 }
 
 func (w *directoryWatcher) handleEvent(ctx context.Context, e fsnotify.Event) {

--- a/selfservice/strategy/oidc/strategy_registration.go
+++ b/selfservice/strategy/oidc/strategy_registration.go
@@ -49,6 +49,12 @@ var jsonnetCache, _ = ristretto.NewCache(&ristretto.Config[[]byte, []byte]{
 
 type MetadataType string
 
+type OIDCProviderData struct {
+	Provider string                                   `json:"provider"`
+	Tokens   *identity.CredentialsOIDCEncryptedTokens `json:"tokens"`
+	Claims   Claims                                   `json:"claims"`
+}
+
 type VerifiedAddress struct {
 	Value string `json:"value"`
 	Via   string `json:"via"`
@@ -59,6 +65,8 @@ const (
 
 	PublicMetadata MetadataType = "identity.metadata_public"
 	AdminMetadata  MetadataType = "identity.metadata_admin"
+
+	InternalContextKeyProviderData = "provider_data"
 )
 
 func (s *Strategy) PopulateRegistrationMethod(r *http.Request, f *registration.Flow) error {
@@ -230,6 +238,27 @@ func (s *Strategy) Register(w http.ResponseWriter, r *http.Request, f *registrat
 		return errors.WithStack(flow.ErrCompletedByStrategy)
 	}
 
+	providerDataKey := flow.PrefixInternalContextKey(s.ID(), InternalContextKeyProviderData)
+	if oidcProviderData := gjson.GetBytes(f.InternalContext, providerDataKey); oidcProviderData.IsObject() {
+		var providerData OIDCProviderData
+		if err = json.Unmarshal([]byte(oidcProviderData.Raw), &providerData); err != nil {
+			return s.HandleError(ctx, w, r, f, pid, nil, errors.WithStack(herodot.ErrInternalServerError().WithReasonf("Expected OIDC provider data in internal context to be an object but got: %s", err)))
+		}
+		if pid != providerData.Provider {
+			return s.HandleError(ctx, w, r, f, pid, nil, errors.WithStack(herodot.ErrInternalServerError().WithReasonf("Expected OIDC provider data in internal context to have matching provider but got: %s", providerData.Provider)))
+		}
+		container := &AuthCodeContainer{
+			FlowID:           f.ID.String(),
+			Traits:           p.Traits,
+			TransientPayload: f.TransientPayload,
+		}
+		_, err = s.processRegistration(ctx, w, r, f, providerData.Tokens, &providerData.Claims, provider, container)
+		if err != nil {
+			return s.HandleError(ctx, w, r, f, pid, container.Traits, err)
+		}
+		return errors.WithStack(flow.ErrCompletedByStrategy)
+	}
+
 	state, pkce, err := s.GenerateState(ctx, provider, f)
 	if err != nil {
 		return s.HandleError(ctx, w, r, f, pid, nil, err)
@@ -357,6 +386,13 @@ func (s *Strategy) processRegistration(ctx context.Context, w http.ResponseWrite
 		return nil, s.HandleError(ctx, w, r, rf, provider.Config().ID, nil, err)
 	}
 
+	providerDataKey := flow.PrefixInternalContextKey(s.ID(), InternalContextKeyProviderData)
+	if hasOIDCProviderData := gjson.GetBytes(rf.InternalContext, providerDataKey).IsObject(); !hasOIDCProviderData {
+		if internalContext, err := sjson.SetBytes(rf.InternalContext, providerDataKey, &OIDCProviderData{Provider: provider.Config().ID, Tokens: token, Claims: *claims}); err == nil {
+			rf.InternalContext = internalContext
+		}
+	}
+
 	// Validate the identity itself
 	if err := s.d.IdentityValidator().Validate(ctx, i); err != nil {
 		return nil, s.HandleError(ctx, w, r, rf, provider.Config().ID, i.Traits, err)
@@ -389,6 +425,10 @@ func (s *Strategy) processRegistration(ctx context.Context, w http.ResponseWrite
 		UpstreamAMR:  claims.AMR,
 	}); err != nil {
 		return nil, s.HandleError(ctx, w, r, rf, provider.Config().ID, i.Traits, err)
+	}
+
+	if internalContext, err := sjson.DeleteBytes(rf.InternalContext, providerDataKey); err == nil {
+		rf.InternalContext = internalContext
 	}
 
 	return nil, nil

--- a/test/e2e/cypress/integration/profiles/oidc/registration/success.spec.ts
+++ b/test/e2e/cypress/integration/profiles/oidc/registration/success.spec.ts
@@ -94,7 +94,56 @@ context("Social Sign Up Successes", () => {
         cy.triggerOidc(app)
 
         cy.location("pathname").should((loc) => {
-          expect(loc).to.be.oneOf(["/welcome", "/", "/sessions"])
+          expect(loc).to.be.oneOf([
+            "/welcome",
+            "/",
+            "/sessions",
+            "/verification",
+          ])
+        })
+
+        cy.getSession().should((session) => {
+          shouldSession(email)(session)
+          expect(session.identity.traits.consent).to.equal(true)
+        })
+      })
+
+      it("should redirect to oidc provider only once", () => {
+        const email = gen.email()
+
+        cy.registerOidc({
+          app,
+          email,
+          expectSession: false,
+          route: registration,
+        })
+
+        cy.get(appPrefix(app) + '[name="traits.email"]').should(
+          "have.value",
+          email,
+        )
+
+        cy.get('[name="traits.consent"][type="checkbox"]')
+          .siblings("label")
+          .click()
+        cy.get('[name="traits.newsletter"][type="checkbox"]')
+          .siblings("label")
+          .click()
+        cy.get('[name="traits.website"]').type(website)
+
+        cy.intercept("GET", "http://*/oauth2/auth*").as("additionalRedirect")
+
+        cy.triggerOidc(app)
+
+        cy.get("@additionalRedirect.all").should("have.length", 0)
+
+        cy.location("pathname").should((loc) => {
+          expect(loc).to.be.oneOf([
+            "/welcome",
+            "/",
+            "/sessions",
+            "/verification",
+          ])
         })
 
         cy.getSession().should((session) => {

--- a/test/e2e/cypress/integration/profiles/oidc/settings/success.spec.ts
+++ b/test/e2e/cypress/integration/profiles/oidc/settings/success.spec.ts
@@ -42,12 +42,24 @@ context("Social Sign In Settings Success", () => {
         cy.get("#accept").click()
 
         cy.get('input[name="traits.website"]').clear().type(website)
+
+        cy.intercept("POST", "**/self-service/registration*").as(
+          "registrationCall",
+        )
         cy.triggerOidc(app, "hydra")
 
-        cy.get('[data-testid="ui/message/1010016"]').should(
-          "contain.text",
-          "as another way to sign in.",
-        )
+        if (app === "react") {
+          cy.wait("@registrationCall").should((intercept) => {
+            expect(intercept.response.body.ui.messages[0].text).contain(
+              "as another way to sign in.",
+            )
+          })
+        } else {
+          cy.get('[data-testid="ui/message/1010016"]').should(
+            "contain.text",
+            "as another way to sign in.",
+          )
+        }
 
         cy.noSession()
       }


### PR DESCRIPTION
When doing a social sign-in, but some required identity fields are not provided by the social provider, Kratos switches to a registration flow in order to fill the missing data.

As https://github.com/ory/kratos/issues/2863 describes it, the idea is that instead of redirecting back to the social provider when submitting the registration form, we handle the registration directly by Kratos and the previously stored OIDC data.

The main rationale is that it feels very unusual for users to select twice your Google account (for instance) during social sign-in. Or even more if more errors occur on the registration form.

Three steps fix this issue:
1. Store OIDC data when processing the registration: provider ID, tokens and claims are stored
2. When submitting an OIDC registration form, when OIDC data is stored, do not redirect to the provider, but instead load this data to process the registration. ⚠️ This has the side-effect that API calls (in e2e tests for instance) that previously were redirected to the social provider and became browser calls, now remain API calls.
3. When completed, delete the OIDC data from .

## Related issue(s)

Fixes https://github.com/ory/kratos/issues/2863

Core code based on https://github.com/ory/kratos/pull/3416

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage ensuring OIDC-triggered registration redirects complete once and accept "/verification"
  * Enhanced assertions to verify persisted session traits (including consent)
  * Made UI message checks conditional for different app variants to improve cross-platform reliability

* **Refactor**
  * Improved internal OIDC registration callback data handling to reduce duplicated redirects and limit data lifetime during the flow
<!-- end of auto-generated comment: release notes by coderabbit.ai -->