### PR TITLE
feat: add a support for after_submit webhooks in the login flow

### DIFF
--- a/driver/config/config.go
+++ b/driver/config/config.go
@@ -139,6 +139,7 @@ const (
 	ViperKeySelfServiceLoginRequestLifespan                  = "selfservice.flows.login.lifespan"
 	ViperKeySelfServiceLoginAfter                            = "selfservice.flows.login.after"
 	ViperKeySelfServiceLoginBeforeHooks                      = "selfservice.flows.login.before.hooks"
+	ViperKeySelfServiceLoginAfterSubmitHooks                 = "selfservice.flows.login.after_submit.hooks"
 	ViperKeySelfServiceErrorUI                               = "selfservice.flows.error.ui_url"
 	ViperKeySelfServiceLogoutBrowserDefaultReturnTo          = "selfservice.flows.logout.after." + DefaultBrowserReturnURL
 	ViperKeySelfServiceSettingsURL                           = "selfservice.flows.settings.ui_url"
@@ -700,6 +701,10 @@ func (p *Config) SelfServiceFlowRecoveryUse(ctx context.Context) string {
 
 func (p *Config) SelfServiceFlowLoginBeforeHooks(ctx context.Context) []SelfServiceHook {
 	return p.selfServiceHooks(ctx, ViperKeySelfServiceLoginBeforeHooks)
+}
+
+func (p *Config) SelfServiceFlowLoginAfterSubmitHooks(ctx context.Context) []SelfServiceHook {
+	return p.selfServiceHooks(ctx, ViperKeySelfServiceLoginAfterSubmitHooks)
 }
 
 func (p *Config) SelfServiceFlowRecoveryBeforeHooks(ctx context.Context) []SelfServiceHook {

--- a/driver/registry_default_login.go
+++ b/driver/registry_default_login.go
@@ -27,6 +27,15 @@ func (m *RegistryDefault) PreLoginHooks(ctx context.Context) (b []login.PreHookE
 	return
 }
 
+func (m *RegistryDefault) AfterSubmitLoginHooks(ctx context.Context) (b []login.AfterSubmitHookExecutor) {
+	for _, v := range m.getHooks("", m.Config().SelfServiceFlowLoginAfterSubmitHooks(ctx)) {
+		if hook, ok := v.(login.AfterSubmitHookExecutor); ok {
+			b = append(b, hook)
+		}
+	}
+	return
+}
+
 func (m *RegistryDefault) PostLoginHooks(ctx context.Context, credentialsType identity.CredentialsType) (b []login.PostHookExecutor) {
 	for _, v := range m.getHooks(string(credentialsType), m.Config().SelfServiceFlowLoginAfterHooks(ctx, string(credentialsType))) {
 		if hook, ok := v.(login.PostHookExecutor); ok {

--- a/embedx/config.schema.json
+++ b/embedx/config.schema.json
@@ -1309,6 +1309,15 @@
                 },
                 "after": {
                   "$ref": "#/definitions/selfServiceAfterLogin"
+                },
+                "after_submit": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "hooks": {
+                      "$ref": "#/definitions/selfServiceHooks"
+                    }
+                  }
                 }
               }
             },

--- a/selfservice/flow/login/handler.go
+++ b/selfservice/flow/login/handler.go
@@ -846,6 +846,11 @@ func (h *Handler) updateLoginFlow(w http.ResponseWriter, r *http.Request, _ http
 	}
 
 continueLogin:
+	if err := h.d.LoginHookExecutor().AfterSubmitLoginHook(w, r, f); err != nil {
+		h.d.LoginFlowErrorHandler().WriteFlowError(w, r, f, node.DefaultGroup, err)
+		return
+	}
+
 	if err := f.Valid(); err != nil {
 		h.d.LoginFlowErrorHandler().WriteFlowError(w, r, f, node.DefaultGroup, err)
 		return

--- a/selfservice/flow/login/hook_test.go
+++ b/selfservice/flow/login/hook_test.go
@@ -56,6 +56,14 @@ func TestLoginExecutor(t *testing.T) {
 					}
 				})
 
+				router.GET("/login/submit", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+					loginFlow, err := login.NewFlow(conf, time.Minute, "", r, ft)
+					require.NoError(t, err)
+					if testhelpers.SelfServiceHookLoginErrorHandler(t, w, r, reg.LoginHookExecutor().AfterSubmitLoginHook(w, r, loginFlow)) {
+						_, _ = w.Write([]byte("ok"))
+					}
+				})
+
 				router.GET("/login/post", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 					loginFlow, err := login.NewFlow(conf, time.Minute, "", r, ft)
 					require.NoError(t, err)
@@ -357,12 +365,30 @@ func TestLoginExecutor(t *testing.T) {
 					},
 					conf,
 				))
+
+				t.Run("method=AfterSubmitHook", testhelpers.TestSelfServiceAfterSubmitHook(
+					config.ViperKeySelfServiceLoginAfterSubmitHooks,
+					testhelpers.SelfServiceMakeLoginAfterSubmitHookRequest,
+					func(t *testing.T) *httptest.Server {
+						return newServer(t, flow.TypeAPI, nil)
+					},
+					conf,
+				))
 			})
 
 			t.Run("type=browser", func(t *testing.T) {
 				t.Run("method=PreLoginHook", testhelpers.TestSelfServicePreHook(
 					config.ViperKeySelfServiceLoginBeforeHooks,
 					testhelpers.SelfServiceMakeLoginPreHookRequest,
+					func(t *testing.T) *httptest.Server {
+						return newServer(t, flow.TypeBrowser, nil)
+					},
+					conf,
+				))
+
+				t.Run("method=AfterSubmitHook", testhelpers.TestSelfServiceAfterSubmitHook(
+					config.ViperKeySelfServiceLoginAfterSubmitHooks,
+					testhelpers.SelfServiceMakeLoginAfterSubmitHookRequest,
 					func(t *testing.T) *httptest.Server {
 						return newServer(t, flow.TypeBrowser, nil)
 					},

--- a/selfservice/hook/error.go
+++ b/selfservice/hook/error.go
@@ -72,6 +72,10 @@ func (e Error) ExecuteLoginPreHook(w http.ResponseWriter, r *http.Request, a *lo
 	return e.err("ExecuteLoginPreHook", login.ErrHookAbortFlow)
 }
 
+func (e Error) ExecuteAfterSubmitLoginHook(w http.ResponseWriter, r *http.Request, a *login.Flow) error {
+	return e.err("ExecuteAfterSubmitLoginHook", login.ErrHookAbortFlow)
+}
+
 func (e Error) ExecuteRegistrationPreHook(w http.ResponseWriter, r *http.Request, a *registration.Flow) error {
 	return e.err("ExecuteRegistrationPreHook", registration.ErrHookAbortFlow)
 }

--- a/selfservice/hook/web_hook.go
+++ b/selfservice/hook/web_hook.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/textproto"
+	"net/url"
 	"time"
 
 	"github.com/dgraph-io/ristretto"
@@ -84,6 +85,7 @@ type (
 		RequestCookies map[string]string  `json:"request_cookies"`
 		Identity       *identity.Identity `json:"identity,omitempty"`
 		Session        *session.Session   `json:"session,omitempty"`
+		Fields         url.Values         `json:"fields,omitempty"`
 	}
 
 	WebHook struct {
@@ -130,6 +132,25 @@ func (e *WebHook) ExecuteLoginPreHook(_ http.ResponseWriter, req *http.Request, 
 			RequestMethod:  req.Method,
 			RequestURL:     x.RequestURL(req).String(),
 			RequestCookies: cookies(req),
+		})
+	})
+}
+
+func (e *WebHook) ExecuteAfterSubmitLoginHook(_ http.ResponseWriter, req *http.Request, flow *login.Flow) error {
+	if req.Body != nil {
+		if err := req.ParseForm(); err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
+	return otelx.WithSpan(req.Context(), "selfservice.hook.WebHook.ExecuteAfterSubmitLoginHook", func(ctx context.Context) error {
+		return e.execute(ctx, &templateContext{
+			Flow:           flow,
+			RequestHeaders: req.Header,
+			RequestMethod:  req.Method,
+			RequestURL:     x.RequestURL(req).String(),
+			RequestCookies: cookies(req),
+			Fields:         req.Form,
 		})
 	})
 }


### PR DESCRIPTION
Implementation of an `after_submit` webhook that was discussed in #3580
It allows users to implement rate-limiting in the login process.

Example usage:
```
selfservice:
    login:
      after_submit:
        hooks:
          - hook: web_hook
            config:
              url: http://127.0.0.1:8080/rate-limit
              method: POST
              body: file:///etc/config/rate-limit.jsonnet
```

Example jsonnet config:
```
function(ctx) {
  username: if std.objectHas(ctx.fields, "identifier") then ctx.fields.identifier[0] else null,
  ip: if std.objectHas(ctx.request_headers, "Client-Ip") then ctx.request_headers["Client-Ip"][0] else null
}
```

You can also send other form fields to the webhook, like this:
```
function(ctx) {
  method: if std.objectHas(ctx.fields, "method") then ctx.fields.method[0] else null,
  username: if std.objectHas(ctx.fields, "identifier") then ctx.fields.identifier[0] else null,
  ip: if std.objectHas(ctx.request_headers, "Client-Ip") then ctx.request_headers["Client-Ip"][0] else null
}
```
And implement different rules, for different login methods.

## Related issue(s)

Implements #3580 


## Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).
