### PR TITLE
fix: transient_payload lost in API flow with session token exchange code (PS-482)

### DIFF
--- a/selfservice/flow/transient_payload.go
+++ b/selfservice/flow/transient_payload.go
@@ -1,0 +1,38 @@
+package flow
+
+import (
+	"github.com/ory/x/sqlxx"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+const internalContextTransientPayloadPath = "transient_payload"
+
+func SetTransientPayloadIntoInternalContext(flow InternalContexter, transientPayload sqlxx.JSONRawMessage) error {
+	if flow.GetInternalContext() == nil {
+		flow.EnsureInternalContext()
+	}
+	bytes, err := sjson.SetBytes(
+		flow.GetInternalContext(),
+		internalContextTransientPayloadPath,
+		transientPayload,
+	)
+	if err != nil {
+		return err
+	}
+	flow.SetInternalContext(bytes)
+
+	return nil
+}
+
+func GetTransientPayloadFromInternalContext(flow InternalContexter) (sqlxx.JSONRawMessage, error) {
+	if flow.GetInternalContext() == nil {
+		flow.EnsureInternalContext()
+	}
+	raw := gjson.GetBytes(flow.GetInternalContext(), internalContextTransientPayloadPath)
+	if !raw.IsObject() {
+		return nil, nil
+	}
+
+	return sqlxx.JSONRawMessage(raw.Raw), nil
+}

--- a/selfservice/strategy/oidc/strategy.go
+++ b/selfservice/strategy/oidc/strategy.go
@@ -333,6 +333,14 @@ func (s *Strategy) ValidateCallback(w http.ResponseWriter, r *http.Request) (flo
 		}
 		cntnr.State = stateParam
 		cntnr.FlowID = state.FlowID
+		internalContexter, ok := f.(flow.InternalContexter)
+		if ok {
+			transientPayload, err := flow.GetTransientPayloadFromInternalContext(internalContexter)
+			if err != nil {
+				return nil, &cntnr, err
+			}
+			cntnr.TransientPayload = json.RawMessage(transientPayload)
+		}
 	}
 
 	if errorParam != "" {

--- a/selfservice/strategy/oidc/strategy_registration.go
+++ b/selfservice/strategy/oidc/strategy_registration.go
@@ -164,6 +164,12 @@ func (s *Strategy) Register(w http.ResponseWriter, r *http.Request, f *registrat
 	f.TransientPayload = p.TransientPayload
 	f.IDToken = p.IDToken
 	f.RawIDTokenNonce = p.IDTokenNonce
+	if err := flow.SetTransientPayloadIntoInternalContext(f, sqlxx.JSONRawMessage(p.TransientPayload)); err != nil {
+		return s.handleError(w, r, f, pid, nil, err)
+	}
+	if err := s.d.RegistrationFlowPersister().UpdateRegistrationFlow(ctx, f); err != nil {
+		return s.handleError(w, r, f, pid, nil, err)
+	}
 
 	if !strings.EqualFold(strings.ToLower(p.Method), s.SettingsStrategyID()) && p.Method != "" {
 		// the user is sending a method that is not oidc, but the payload includes a provider

--- a/selfservice/strategy/oidc/strategy_test.go
+++ b/selfservice/strategy/oidc/strategy_test.go
@@ -187,11 +187,13 @@ func TestStrategy(t *testing.T) {
 		return res, body
 	}
 
-	makeAPICodeFlowRequest := func(t *testing.T, provider, action string) (returnToURL *url.URL) {
-		res, err := testhelpers.NewDebugClient(t).Post(action, "application/json", strings.NewReader(fmt.Sprintf(`{
-	"method": "oidc",
-	"provider": %q
-}`, provider)))
+	makeAPICodeFlowRequest := func(t *testing.T, provider, action string, transientPayload string) (returnToURL *url.URL) {
+		res, err := testhelpers.NewDebugClient(t).Post(action, "application/json",
+			strings.NewReader(fmt.Sprintf(`{
+												"method": "oidc",
+												"provider": %q,
+												"transient_payload": %q
+											}`, provider, transientPayload)))
 		require.NoError(t, err)
 		require.Equal(t, http.StatusUnprocessableEntity, res.StatusCode)
 		var changeLocation flow.BrowserLocationChangeRequiredError
@@ -650,14 +652,25 @@ func TestStrategy(t *testing.T) {
 	})
 
 	t.Run("suite=API with session token exchange code", func(t *testing.T) {
+		postRegistrationWebhook := hooktest.NewServer()
+		t.Cleanup(postRegistrationWebhook.Close)
+		postRegistrationWebhook.SetConfig(t, conf.GetProvider(ctx),
+			config.HookStrategyKey(config.ViperKeySelfServiceRegistrationAfter, identity.CredentialsTypeOIDC.String()))
+
+		postLoginWebhook := hooktest.NewServer()
+		t.Cleanup(postLoginWebhook.Close)
+		postLoginWebhook.SetConfig(t, conf.GetProvider(ctx),
+			config.HookStrategyKey(config.ViperKeySelfServiceLoginAfter, config.HookGlobal))
+
 		scope = []string{"openid"}
+		transientPayload := `{"data": "registration"}`
 
 		loginOrRegister := func(t *testing.T, flowID uuid.UUID, code string) {
 			_, err := exchangeCodeForToken(t, sessiontokenexchange.Codes{InitCode: code})
 			require.Error(t, err)
 
 			action := assertFormValues(t, flowID, "valid")
-			returnToURL := makeAPICodeFlowRequest(t, "valid", action)
+			returnToURL := makeAPICodeFlowRequest(t, "valid", action, transientPayload)
 			returnToCode := returnToURL.Query().Get("code")
 			assert.NotEmpty(t, code, "code query param was empty in the return_to URL")
 
@@ -673,10 +686,22 @@ func TestStrategy(t *testing.T) {
 		performRegistration := func(t *testing.T) {
 			f := newAPIRegistrationFlow(t, returnTS.URL+"?return_session_token_exchange_code=true&return_to=/app_code", 1*time.Minute)
 			loginOrRegister(t, f.ID, f.SessionTokenExchangeCode)
+			postRegistrationWebhook.AssertTransientPayload(t, transientPayload)
+		}
+		startRegistrationButLogin := func(t *testing.T) {
+			f := newAPIRegistrationFlow(t, returnTS.URL+"?return_session_token_exchange_code=true&return_to=/app_code", 1*time.Minute)
+			loginOrRegister(t, f.ID, f.SessionTokenExchangeCode)
+			postLoginWebhook.AssertTransientPayload(t, transientPayload)
 		}
 		performLogin := func(t *testing.T) {
 			f := newAPILoginFlow(t, returnTS.URL+"?return_session_token_exchange_code=true&return_to=/app_code", 1*time.Minute)
 			loginOrRegister(t, f.ID, f.SessionTokenExchangeCode)
+			postLoginWebhook.AssertTransientPayload(t, transientPayload)
+		}
+		startLoginButRegister := func(t *testing.T) {
+			f := newAPILoginFlow(t, returnTS.URL+"?return_session_token_exchange_code=true&return_to=/app_code", 1*time.Minute)
+			loginOrRegister(t, f.ID, f.SessionTokenExchangeCode)
+			postRegistrationWebhook.AssertTransientPayload(t, transientPayload)
 		}
 
 		for _, tc := range []struct {
@@ -684,16 +709,16 @@ func TestStrategy(t *testing.T) {
 			first, then func(*testing.T)
 		}{{
 			name:  "login-twice",
-			first: performLogin, then: performLogin,
+			first: startLoginButRegister, then: performLogin,
 		}, {
 			name:  "login-then-register",
-			first: performLogin, then: performRegistration,
+			first: startLoginButRegister, then: startRegistrationButLogin,
 		}, {
 			name:  "register-then-login",
 			first: performRegistration, then: performLogin,
 		}, {
 			name:  "register-twice",
-			first: performRegistration, then: performRegistration,
+			first: performRegistration, then: startRegistrationButLogin,
 		}} {
 			t.Run("case="+tc.name, func(t *testing.T) {
 				subject = tc.name + "-api-code-testing@ory.sh"
@@ -718,7 +743,7 @@ func TestStrategy(t *testing.T) {
 			require.Error(t, err)
 
 			action := assertFormValues(t, f.ID, "valid")
-			returnToURL := makeAPICodeFlowRequest(t, "valid", action)
+			returnToURL := makeAPICodeFlowRequest(t, "valid", action, "{}")
 			returnedFlow := returnToURL.Query().Get("flow")
 
 			require.NotEmpty(t, returnedFlow, "flow query param was empty in the return_to URL")


### PR DESCRIPTION
When starting oidc api flow with session token exchange code, transient_payload data is lost.
This PR fixes this issue.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x ] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x ] I have read the [security policy](../security/policy).
- [x ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
