### PR TITLE
fix: explicity set updated_at field when updating identity

### DIFF
--- a/identity/manager_test.go
+++ b/identity/manager_test.go
@@ -677,6 +677,22 @@ func TestManager(t *testing.T) {
 			// That is why we only check the identity in the store.
 			checkExtensionFields(fromStore, "email-updatetraits-1@ory.sh")(t)
 		})
+
+		t.Run("case=should always update updated_at field", func(t *testing.T) {
+			original := identity.NewIdentity(config.DefaultIdentityTraitsSchemaID)
+			original.Traits = newTraits("email-updatetraits-3@ory.sh", "")
+			require.NoError(t, reg.IdentityManager().Create(ctx, original))
+
+			time.Sleep(time.Millisecond)
+
+			require.NoError(t, reg.IdentityManager().UpdateTraits(
+				ctx, original.ID, newTraits("email-updatetraits-4@ory.sh", ""),
+				identity.ManagerAllowWriteProtectedTraits))
+
+			updated, err := reg.IdentityPool().GetIdentity(ctx, original.ID, identity.ExpandNothing)
+			require.NoError(t, err)
+			assert.NotEqual(t, original.UpdatedAt, updated.UpdatedAt, "UpdatedAt field should be updated")
+		})
 	})
 
 	t.Run("method=RefreshAvailableAAL", func(t *testing.T) {

--- a/persistence/sql/identity/persister_identity.go
+++ b/persistence/sql/identity/persister_identity.go
@@ -1072,6 +1072,7 @@ func (p *IdentityPersister) UpdateIdentity(ctx context.Context, i *identity.Iden
 	}
 
 	i.NID = p.NetworkID(ctx)
+	i.UpdatedAt = time.Now().UTC()
 	if err := sqlcon.HandleError(p.Transaction(ctx, func(ctx context.Context, tx *pop.Connection) error {
 		// This returns "ErrNoRows" if the identity does not exist
 		if err := update.Generic(WithTransaction(ctx, tx), tx, p.r.Tracer(ctx).Tracer(), i); err != nil {


### PR DESCRIPTION
### Problem

The updated_at field in the identities table is not being updated when an identity's traits are modified. This is unexpected behavior because the pop library should automatically update the `updated_at` field when a record is modified.

However, in the current implementation, the identity is being saved with the old `updated_at` timestamp, which causes the pop library to skip updating this field. As a result, the `updated_at` field does not reflect recent changes, which can lead to issues with auditing, synchronization, or downstream systems relying on the correct timestamps for updated data.

### Cause

The issue arises because the existing code inadvertently preserves the previous updated_at value during the update operation. When saving the identity, the pop library sees that the field is already set and, as a result, does not overwrite it with the current timestamp.

### Solution

This PR explicitly sets the `updated_at` field when updating an identity. By ensuring the field is updated within the code, we force the correct behavior, even if the underlying pop library does not update the field automatically.


### Steps to manually reproduce:

1.  Update the traits of a user.
2. Check the `updated_at` field in the identities table to confirm that it reflects the recent update.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
