### PR TITLE
feat: update Yandex and VK OIDC

### DIFF
--- a/selfservice/strategy/oidc/provider.go
+++ b/selfservice/strategy/oidc/provider.go
@@ -27,6 +27,7 @@ type Provider interface {
 type OAuth2Provider interface {
 	Provider
 	AuthCodeURLOptions(r ider) []oauth2.AuthCodeOption
+	AccessTokenURLOptions(r *http.Request) []oauth2.AuthCodeOption
 	OAuth2(ctx context.Context) (*oauth2.Config, error)
 	Claims(ctx context.Context, exchange *oauth2.Token, query url.Values) (*Claims, error)
 }

--- a/selfservice/strategy/oidc/provider_apple.go
+++ b/selfservice/strategy/oidc/provider_apple.go
@@ -20,6 +20,8 @@ import (
 	"golang.org/x/oauth2"
 )
 
+var _ OAuth2Provider = (*ProviderApple)(nil)
+
 type ProviderApple struct {
 	*ProviderGenericOIDC
 	JWKSUrl string
@@ -152,7 +154,7 @@ func (a *ProviderApple) DecodeQuery(query url.Values, claims *Claims) {
 	}
 }
 
-var _ IDTokenVerifier = new(ProviderApple)
+var _ IDTokenVerifier = (*ProviderApple)(nil)
 
 const issuerUrlApple = "https://appleid.apple.com"
 
@@ -163,7 +165,7 @@ func (a *ProviderApple) Verify(ctx context.Context, rawIDToken string) (*Claims,
 	return verifyToken(ctx, keySet, a.config, rawIDToken, issuerUrlApple)
 }
 
-var _ NonceValidationSkipper = new(ProviderApple)
+var _ NonceValidationSkipper = (*ProviderApple)(nil)
 
 func (a *ProviderApple) CanSkipNonce(c *Claims) bool {
 	return c.NonceSupported

--- a/selfservice/strategy/oidc/provider_auth0.go
+++ b/selfservice/strategy/oidc/provider_auth0.go
@@ -25,6 +25,8 @@ import (
 	"github.com/ory/herodot"
 )
 
+var _ OAuth2Provider = (*ProviderAuth0)(nil)
+
 type ProviderAuth0 struct {
 	*ProviderGenericOIDC
 }

--- a/selfservice/strategy/oidc/provider_dingtalk.go
+++ b/selfservice/strategy/oidc/provider_dingtalk.go
@@ -6,6 +6,7 @@ package oidc
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"net/url"
 	"strings"
 	"time"
@@ -19,6 +20,8 @@ import (
 
 	"github.com/ory/herodot"
 )
+
+var _ OAuth2Provider = (*ProviderDingTalk)(nil)
 
 type ProviderDingTalk struct {
 	config *Configuration
@@ -59,6 +62,10 @@ func (g *ProviderDingTalk) AuthCodeURLOptions(r ider) []oauth2.AuthCodeOption {
 	return []oauth2.AuthCodeOption{
 		oauth2.SetAuthURLParam("prompt", "consent"),
 	}
+}
+
+func (g *ProviderDingTalk) AccessTokenURLOptions(r *http.Request) []oauth2.AuthCodeOption {
+	return []oauth2.AuthCodeOption{}
 }
 
 func (g *ProviderDingTalk) OAuth2(ctx context.Context) (*oauth2.Config, error) {

--- a/selfservice/strategy/oidc/provider_discord.go
+++ b/selfservice/strategy/oidc/provider_discord.go
@@ -6,6 +6,7 @@ package oidc
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/ory/kratos/x"
@@ -18,6 +19,8 @@ import (
 	"github.com/ory/x/stringslice"
 	"github.com/ory/x/stringsx"
 )
+
+var _ OAuth2Provider = (*ProviderDiscord)(nil)
 
 type ProviderDiscord struct {
 	config *Configuration
@@ -64,6 +67,10 @@ func (d *ProviderDiscord) AuthCodeURLOptions(r ider) []oauth2.AuthCodeOption {
 	return []oauth2.AuthCodeOption{
 		oauth2.SetAuthURLParam("prompt", "none"),
 	}
+}
+
+func (g *ProviderDiscord) AccessTokenURLOptions(r *http.Request) []oauth2.AuthCodeOption {
+	return []oauth2.AuthCodeOption{}
 }
 
 func (d *ProviderDiscord) Claims(ctx context.Context, exchange *oauth2.Token, query url.Values) (*Claims, error) {

--- a/selfservice/strategy/oidc/provider_facebook.go
+++ b/selfservice/strategy/oidc/provider_facebook.go
@@ -24,6 +24,8 @@ import (
 	"github.com/ory/herodot"
 )
 
+var _ OAuth2Provider = (*ProviderFacebook)(nil)
+
 type ProviderFacebook struct {
 	*ProviderGenericOIDC
 }

--- a/selfservice/strategy/oidc/provider_generic_oidc.go
+++ b/selfservice/strategy/oidc/provider_generic_oidc.go
@@ -5,6 +5,7 @@ package oidc
 
 import (
 	"context"
+	"net/http"
 	"net/url"
 
 	"github.com/pkg/errors"
@@ -16,7 +17,8 @@ import (
 	"github.com/ory/x/stringslice"
 )
 
-var _ Provider = new(ProviderGenericOIDC)
+var _ Provider = (*ProviderGenericOIDC)(nil)
+var _ OAuth2Provider = (*ProviderGenericOIDC)(nil)
 
 type ProviderGenericOIDC struct {
 	p      *gooidc.Provider
@@ -94,6 +96,10 @@ func (g *ProviderGenericOIDC) AuthCodeURLOptions(r ider) []oauth2.AuthCodeOption
 	}
 
 	return options
+}
+
+func (g *ProviderGenericOIDC) AccessTokenURLOptions(r *http.Request) []oauth2.AuthCodeOption {
+	return []oauth2.AuthCodeOption{}
 }
 
 func (g *ProviderGenericOIDC) verifyAndDecodeClaimsWithProvider(ctx context.Context, provider *gooidc.Provider, raw string) (*Claims, error) {

--- a/selfservice/strategy/oidc/provider_github.go
+++ b/selfservice/strategy/oidc/provider_github.go
@@ -6,6 +6,7 @@ package oidc
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/ory/kratos/x"
@@ -22,6 +23,8 @@ import (
 
 	"github.com/ory/herodot"
 )
+
+var _ OAuth2Provider = (*ProviderGitHub)(nil)
 
 type ProviderGitHub struct {
 	config *Configuration
@@ -57,6 +60,10 @@ func (g *ProviderGitHub) OAuth2(ctx context.Context) (*oauth2.Config, error) {
 }
 
 func (g *ProviderGitHub) AuthCodeURLOptions(r ider) []oauth2.AuthCodeOption {
+	return []oauth2.AuthCodeOption{}
+}
+
+func (g *ProviderGitHub) AccessTokenURLOptions(r *http.Request) []oauth2.AuthCodeOption {
 	return []oauth2.AuthCodeOption{}
 }
 

--- a/selfservice/strategy/oidc/provider_github_app.go
+++ b/selfservice/strategy/oidc/provider_github_app.go
@@ -6,6 +6,7 @@ package oidc
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/ory/kratos/x"
@@ -19,6 +20,8 @@ import (
 
 	"github.com/ory/herodot"
 )
+
+var _ OAuth2Provider = (*ProviderGitHubApp)(nil)
 
 type ProviderGitHubApp struct {
 	config *Configuration
@@ -54,6 +57,10 @@ func (g *ProviderGitHubApp) OAuth2(ctx context.Context) (*oauth2.Config, error) 
 }
 
 func (g *ProviderGitHubApp) AuthCodeURLOptions(r ider) []oauth2.AuthCodeOption {
+	return []oauth2.AuthCodeOption{}
+}
+
+func (g *ProviderGitHubApp) AccessTokenURLOptions(r *http.Request) []oauth2.AuthCodeOption {
 	return []oauth2.AuthCodeOption{}
 }
 

--- a/selfservice/strategy/oidc/provider_gitlab.go
+++ b/selfservice/strategy/oidc/provider_gitlab.go
@@ -25,6 +25,8 @@ const (
 	defaultEndpoint = "https://gitlab.com"
 )
 
+var _ OAuth2Provider = (*ProviderGitLab)(nil)
+
 type ProviderGitLab struct {
 	*ProviderGenericOIDC
 }

--- a/selfservice/strategy/oidc/provider_google.go
+++ b/selfservice/strategy/oidc/provider_google.go
@@ -12,6 +12,8 @@ import (
 	"github.com/ory/x/stringslice"
 )
 
+var _ OAuth2Provider = (*ProviderGoogle)(nil)
+
 type ProviderGoogle struct {
 	*ProviderGenericOIDC
 	JWKSUrl string
@@ -69,7 +71,7 @@ func (g *ProviderGoogle) AuthCodeURLOptions(r ider) []oauth2.AuthCodeOption {
 	return options
 }
 
-var _ IDTokenVerifier = new(ProviderGoogle)
+var _ IDTokenVerifier = (*ProviderGoogle)(nil)
 
 const issuerUrlGoogle = "https://accounts.google.com"
 
@@ -79,7 +81,7 @@ func (p *ProviderGoogle) Verify(ctx context.Context, rawIDToken string) (*Claims
 	return verifyToken(ctx, keySet, p.config, rawIDToken, issuerUrlGoogle)
 }
 
-var _ NonceValidationSkipper = new(ProviderGoogle)
+var _ NonceValidationSkipper = (*ProviderGoogle)(nil)
 
 func (a *ProviderGoogle) CanSkipNonce(c *Claims) bool {
 	// Not all SDKs support nonce validation, so we skip it if no nonce is present in the claims of the ID Token.

--- a/selfservice/strategy/oidc/provider_lark.go
+++ b/selfservice/strategy/oidc/provider_lark.go
@@ -16,6 +16,8 @@ import (
 	"github.com/ory/x/httpx"
 )
 
+var _ OAuth2Provider = (*ProviderLark)(nil)
+
 type ProviderLark struct {
 	*ProviderGenericOIDC
 }

--- a/selfservice/strategy/oidc/provider_linkedin.go
+++ b/selfservice/strategy/oidc/provider_linkedin.go
@@ -63,6 +63,8 @@ const (
 	IntrospectionURL string = "https://www.linkedin.com/oauth/v2/introspectToken"
 )
 
+var _ OAuth2Provider = (*ProviderLinkedIn)(nil)
+
 type ProviderLinkedIn struct {
 	config *Configuration
 	reg    Dependencies
@@ -97,6 +99,10 @@ func (l *ProviderLinkedIn) OAuth2(ctx context.Context) (*oauth2.Config, error) {
 }
 
 func (l *ProviderLinkedIn) AuthCodeURLOptions(r ider) []oauth2.AuthCodeOption {
+	return []oauth2.AuthCodeOption{}
+}
+
+func (g *ProviderLinkedIn) AccessTokenURLOptions(r *http.Request) []oauth2.AuthCodeOption {
 	return []oauth2.AuthCodeOption{}
 }
 

--- a/selfservice/strategy/oidc/provider_microsoft.go
+++ b/selfservice/strategy/oidc/provider_microsoft.go
@@ -23,6 +23,8 @@ import (
 	"github.com/ory/herodot"
 )
 
+var _ OAuth2Provider = (*ProviderMicrosoft)(nil)
+
 type ProviderMicrosoft struct {
 	*ProviderGenericOIDC
 }

--- a/selfservice/strategy/oidc/provider_netid.go
+++ b/selfservice/strategy/oidc/provider_netid.go
@@ -28,6 +28,8 @@ const (
 	defaultBrokerHost   = "broker.netid.de"
 )
 
+var _ OAuth2Provider = (*ProviderNetID)(nil)
+
 type ProviderNetID struct {
 	*ProviderGenericOIDC
 }

--- a/selfservice/strategy/oidc/provider_patreon.go
+++ b/selfservice/strategy/oidc/provider_patreon.go
@@ -6,6 +6,7 @@ package oidc
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"net/url"
 
 	"github.com/hashicorp/go-retryablehttp"
@@ -17,6 +18,8 @@ import (
 
 	"github.com/ory/herodot"
 )
+
+var _ OAuth2Provider = (*ProviderPatreon)(nil)
 
 type ProviderPatreon struct {
 	config *Configuration
@@ -77,6 +80,10 @@ func (d *ProviderPatreon) AuthCodeURLOptions(r ider) []oauth2.AuthCodeOption {
 	return []oauth2.AuthCodeOption{
 		oauth2.SetAuthURLParam("prompt", "none"),
 	}
+}
+
+func (g *ProviderPatreon) AccessTokenURLOptions(r *http.Request) []oauth2.AuthCodeOption {
+	return []oauth2.AuthCodeOption{}
 }
 
 func (d *ProviderPatreon) Claims(ctx context.Context, exchange *oauth2.Token, query url.Values) (*Claims, error) {

--- a/selfservice/strategy/oidc/provider_salesforce.go
+++ b/selfservice/strategy/oidc/provider_salesforce.go
@@ -25,6 +25,8 @@ import (
 	"github.com/ory/herodot"
 )
 
+var _ OAuth2Provider = (*ProviderSalesforce)(nil)
+
 type ProviderSalesforce struct {
 	*ProviderGenericOIDC
 }

--- a/selfservice/strategy/oidc/provider_slack.go
+++ b/selfservice/strategy/oidc/provider_slack.go
@@ -6,6 +6,7 @@ package oidc
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/ory/herodot"
@@ -18,6 +19,8 @@ import (
 
 	"github.com/slack-go/slack"
 )
+
+var _ OAuth2Provider = (*ProviderSlack)(nil)
 
 type ProviderSlack struct {
 	config *Configuration
@@ -58,6 +61,10 @@ func (d *ProviderSlack) OAuth2(ctx context.Context) (*oauth2.Config, error) {
 }
 
 func (d *ProviderSlack) AuthCodeURLOptions(r ider) []oauth2.AuthCodeOption {
+	return []oauth2.AuthCodeOption{}
+}
+
+func (g *ProviderSlack) AccessTokenURLOptions(r *http.Request) []oauth2.AuthCodeOption {
 	return []oauth2.AuthCodeOption{}
 }
 

--- a/selfservice/strategy/oidc/provider_spotify.go
+++ b/selfservice/strategy/oidc/provider_spotify.go
@@ -6,6 +6,7 @@ package oidc
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"golang.org/x/oauth2/spotify"
@@ -22,6 +23,8 @@ import (
 
 	"github.com/ory/herodot"
 )
+
+var _ OAuth2Provider = (*ProviderSpotify)(nil)
 
 type ProviderSpotify struct {
 	config *Configuration
@@ -57,6 +60,10 @@ func (g *ProviderSpotify) OAuth2(ctx context.Context) (*oauth2.Config, error) {
 }
 
 func (g *ProviderSpotify) AuthCodeURLOptions(r ider) []oauth2.AuthCodeOption {
+	return []oauth2.AuthCodeOption{}
+}
+
+func (g *ProviderSpotify) AccessTokenURLOptions(r *http.Request) []oauth2.AuthCodeOption {
 	return []oauth2.AuthCodeOption{}
 }
 

--- a/selfservice/strategy/oidc/provider_vk.go
+++ b/selfservice/strategy/oidc/provider_vk.go
@@ -6,8 +6,11 @@ package oidc
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
+	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
 
@@ -18,6 +21,8 @@ import (
 
 	"github.com/ory/herodot"
 )
+
+var _ OAuth2Provider = (*ProviderVK)(nil)
 
 type ProviderVK struct {
 	config *Configuration
@@ -34,38 +39,56 @@ func NewProviderVK(
 	}
 }
 
-func (g *ProviderVK) Config() *Configuration {
-	return g.config
+func (p *ProviderVK) Config() *Configuration {
+	return p.config
 }
 
-func (g *ProviderVK) oauth2(ctx context.Context) *oauth2.Config {
-	return &oauth2.Config{
-		ClientID:     g.config.ClientID,
-		ClientSecret: g.config.ClientSecret,
-		Endpoint: oauth2.Endpoint{
+func (p *ProviderVK) oauth2(ctx context.Context) *oauth2.Config {
+	var endpoint oauth2.Endpoint
+	if p.config.PKCE == "force" {
+		endpoint = oauth2.Endpoint{
+			AuthURL:  "https://id.vk.com/authorize",
+			TokenURL: "https://id.vk.com/oauth2/auth",
+		}
+	} else {
+		endpoint = oauth2.Endpoint{
 			AuthURL:  "https://oauth.vk.com/authorize",
 			TokenURL: "https://oauth.vk.com/access_token",
-		},
-		Scopes:      g.config.Scope,
-		RedirectURL: g.config.Redir(g.reg.Config().OIDCRedirectURIBase(ctx)),
+		}
+	}
+	return &oauth2.Config{
+		ClientID:     p.config.ClientID,
+		ClientSecret: p.config.ClientSecret,
+		Endpoint:     endpoint,
+		Scopes:       p.config.Scope,
+		RedirectURL:  p.config.Redir(p.reg.Config().OIDCRedirectURIBase(ctx)),
 	}
 }
 
-func (g *ProviderVK) AuthCodeURLOptions(r ider) []oauth2.AuthCodeOption {
+func (p *ProviderVK) AuthCodeURLOptions(r ider) []oauth2.AuthCodeOption {
 	return []oauth2.AuthCodeOption{}
 }
 
-func (g *ProviderVK) OAuth2(ctx context.Context) (*oauth2.Config, error) {
-	return g.oauth2(ctx), nil
+func (p *ProviderVK) AccessTokenURLOptions(r *http.Request) []oauth2.AuthCodeOption {
+	if p.config.PKCE == "force" {
+		if deviceID := r.URL.Query().Get("device_id"); deviceID != "" {
+			return []oauth2.AuthCodeOption{oauth2.SetAuthURLParam("device_id", deviceID)}
+		}
+	}
+	return []oauth2.AuthCodeOption{}
 }
 
-func (g *ProviderVK) Claims(ctx context.Context, exchange *oauth2.Token, query url.Values) (*Claims, error) {
-	o, err := g.OAuth2(ctx)
+func (p *ProviderVK) OAuth2(ctx context.Context) (*oauth2.Config, error) {
+	return p.oauth2(ctx), nil
+}
+
+func (p *ProviderVK) Claims(ctx context.Context, exchange *oauth2.Token, query url.Values) (*Claims, error) {
+	o, err := p.OAuth2(ctx)
 	if err != nil {
 		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
 	}
 
-	ctx, client := httpx.SetOAuth2(ctx, g.reg.HTTPClient(ctx), o, exchange)
+	ctx, client := httpx.SetOAuth2(ctx, p.reg.HTTPClient(ctx), o, exchange)
 	req, err := retryablehttp.NewRequestWithContext(ctx, "GET", "https://api.vk.com/method/users.get?fields=photo_200,nickname,bdate,sex&access_token="+exchange.AccessToken+"&v=5.103", nil)
 	if err != nil {
 		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
@@ -77,7 +100,7 @@ func (g *ProviderVK) Claims(ctx context.Context, exchange *oauth2.Token, query u
 	}
 	defer resp.Body.Close()
 
-	if err := logUpstreamError(g.reg.Logger(), resp); err != nil {
+	if err := logUpstreamError(p.reg.Logger(), resp); err != nil {
 		return nil, err
 	}
 
@@ -88,6 +111,7 @@ func (g *ProviderVK) Claims(ctx context.Context, exchange *oauth2.Token, query u
 		Nickname  string `json:"nickname,omitempty"`
 		Picture   string `json:"photo_200,omitempty"`
 		Email     string `json:"-"`
+		Phone     string `json:"-"`
 		Gender    int    `json:"sex,omitempty"`
 		BirthDay  string `json:"bdate,omitempty"`
 	}
@@ -106,8 +130,45 @@ func (g *ProviderVK) Claims(ctx context.Context, exchange *oauth2.Token, query u
 
 	user := response.Result[0]
 
-	if email, ok := exchange.Extra("email").(string); ok {
-		user.Email = email
+	if p.config.PKCE == "force" {
+		reqData := strings.NewReader("client_id=" + p.config.ClientID + "&access_token=" + exchange.AccessToken)
+		req, err = retryablehttp.NewRequestWithContext(ctx, "POST", "https://id.vk.com/oauth2/user_info", reqData)
+		if err != nil {
+			return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		resp, err = client.Do(req)
+		if err != nil {
+			return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+		}
+		defer resp.Body.Close()
+
+		if err := logUpstreamError(p.reg.Logger(), resp); err != nil {
+			return nil, err
+		}
+
+		var userInfo struct {
+			User struct {
+				Email string `json:"email,omitempty"`
+				Phone string `json:"phone,omitempty"`
+			} `json:"user,omitempty"`
+		}
+
+		if err := json.NewDecoder(resp.Body).Decode(&userInfo); err != nil {
+			return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+		}
+
+		if len(userInfo.User.Phone) > 0 && userInfo.User.Phone[0] != '+' {
+			userInfo.User.Phone = "+" + userInfo.User.Phone
+		}
+
+		user.Email = userInfo.User.Email
+		user.Phone = userInfo.User.Phone
+	} else {
+		if email, ok := exchange.Extra("email").(string); ok {
+			user.Email = email
+		}
 	}
 
 	gender := ""
@@ -118,15 +179,22 @@ func (g *ProviderVK) Claims(ctx context.Context, exchange *oauth2.Token, query u
 		gender = "male"
 	}
 
+	t, err := time.Parse("2.1.2006", user.BirthDay)
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("%s", err))
+	}
+	birthDay := t.Format("2006-01-02")
+
 	return &Claims{
-		Issuer:     "https://api.vk.com/method/users.get",
-		Subject:    strconv.Itoa(user.Id),
-		GivenName:  user.FirstName,
-		FamilyName: user.LastName,
-		Nickname:   user.Nickname,
-		Picture:    user.Picture,
-		Email:      user.Email,
-		Gender:     gender,
-		Birthdate:  user.BirthDay,
+		Issuer:      "https://api.vk.com/method/users.get",
+		Subject:     strconv.Itoa(user.Id),
+		GivenName:   user.FirstName,
+		FamilyName:  user.LastName,
+		Nickname:    user.Nickname,
+		Picture:     user.Picture,
+		Email:       user.Email,
+		PhoneNumber: user.Phone,
+		Gender:      gender,
+		Birthdate:   birthDay,
 	}, nil
 }

--- a/selfservice/strategy/oidc/strategy.go
+++ b/selfservice/strategy/oidc/strategy.go
@@ -405,7 +405,7 @@ func (s *Strategy) HandleCallback(w http.ResponseWriter, r *http.Request, ps htt
 	var et *identity.CredentialsOIDCEncryptedTokens
 	switch p := provider.(type) {
 	case OAuth2Provider:
-		token, err := s.ExchangeCode(ctx, provider, code, PKCEVerifier(state))
+		token, err := s.ExchangeCode(ctx, provider, code, append(p.AccessTokenURLOptions(r), PKCEVerifier(state)...))
 		if err != nil {
 			s.forwardError(ctx, w, r, req, s.handleError(ctx, w, r, req, state.ProviderId, nil, err))
 			return


### PR DESCRIPTION
## Changes

### VK provider: Support PKCE

It seems like VK doesn't provide `/.well-known/openid-configuration` (VK doesn't support OpenID).
So to use PKCE it's needed to be enabled with:
```
pkce: "force"
```

### VK provider: Support returning `phone_number` in `claims`

VK offers different endpoints for PKCE and non-PKCE configuration.
Token endpoint that is used in non-PKCE configuration can return `email` but not `phone`.
Extra endpoint `https://id.vk.com/oauth2/user_info` can be used to retrieve `email` and `phone`, but it doesn't accept `access_token` that was returned from non-PKCE token endpoint.
So to retrieve a phone, PKCE is required to be enabled:
```diff
  - id: vk
    provider: vk
    mapper_url: "data-mapper.jsonnet"
+   pkce: "force"
    scope:
      - email
+     - phone
```

Additional info:
I added `AccessTokenURLOptions(r *http.Request) []oauth2.AuthCodeOption` to [OAuth2Provider](https://github.com/renom/kratos/blob/update-yandex-and-vk-oidc/selfservice/strategy/oidc/provider.go#L30) interface.
It works like `AuthCodeURLOptions(r ider) []oauth2.AuthCodeOption` but it's dedicated to update a token URL.
VK requires passing `device_id` URL param (that is received by a callback) to PKCE token endpoint. Without this change it's impossible.
I updated all the other OIDC providers to comply with the updated interface.

### Yandex provider: Support returning `phone_number` in `claims`

No extra configuration is needed.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

Fixes: #4147

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

* Everything is tested manually (including backward compatibility).
* I didn't ask about approving the changes in Slack (please let me know if I need to).
* VK seems to have removed the docs about non-PKCE endpoints, so PKCE endpoints is probably the recommended way to use OIDC.

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
