### PR TITLE
feat: add oid as subject source for microsoft

### DIFF
--- a/.schemastore/config.schema.json
+++ b/.schemastore/config.schema.json
@@ -519,7 +519,7 @@
           "title": "Microsoft subject source",
           "description": "Controls which source the subject identifier is taken from by microsoft provider. If set to `userinfo` (the default) then the identifier is taken from the `sub` field of OIDC ID token or data received from `/userinfo` standard OIDC endpoint. If set to `me` then the `id` field of data structure received from `https://graph.microsoft.com/v1.0/me` is taken as an identifier.",
           "type": "string",
-          "enum": ["userinfo", "me"],
+          "enum": ["userinfo", "me", "oid"],
           "default": "userinfo",
           "examples": ["userinfo"]
         },

--- a/embedx/config.schema.json
+++ b/embedx/config.schema.json
@@ -519,7 +519,7 @@
           "title": "Microsoft subject source",
           "description": "Controls which source the subject identifier is taken from by microsoft provider. If set to `userinfo` (the default) then the identifier is taken from the `sub` field of OIDC ID token or data received from `/userinfo` standard OIDC endpoint. If set to `me` then the `id` field of data structure received from `https://graph.microsoft.com/v1.0/me` is taken as an identifier.",
           "type": "string",
-          "enum": ["userinfo", "me"],
+          "enum": ["userinfo", "me", "oid"],
           "default": "userinfo",
           "examples": ["userinfo"]
         },

--- a/selfservice/strategy/oidc/provider.go
+++ b/selfservice/strategy/oidc/provider.go
@@ -55,6 +55,7 @@ type NonceValidationSkipper interface {
 type Claims struct {
 	Issuer              string                 `json:"iss,omitempty"`
 	Subject             string                 `json:"sub,omitempty"`
+	Object              string                 `json:"oid,omitempty"`
 	Name                string                 `json:"name,omitempty"`
 	GivenName           string                 `json:"given_name,omitempty"`
 	FamilyName          string                 `json:"family_name,omitempty"`

--- a/selfservice/strategy/oidc/provider_microsoft.go
+++ b/selfservice/strategy/oidc/provider_microsoft.go
@@ -117,6 +117,10 @@ func (m *ProviderMicrosoft) updateSubject(ctx context.Context, claims *Claims, e
 		claims.Subject = user.ID
 	}
 
+	if m.config.SubjectSource == "oid" {
+		claims.Subject = claims.Object
+	}
+	
 	return claims, nil
 }
 

--- a/selfservice/strategy/oidc/provider_microsoft.go
+++ b/selfservice/strategy/oidc/provider_microsoft.go
@@ -120,7 +120,7 @@ func (m *ProviderMicrosoft) updateSubject(ctx context.Context, claims *Claims, e
 	if m.config.SubjectSource == "oid" {
 		claims.Subject = claims.Object
 	}
-	
+
 	return claims, nil
 }
 


### PR DESCRIPTION
In the case of Microsoft, using `sub` as an identifier can lead to problems. Because the use of OIDC at Microsoft is based on an app registration, the content of `sub` changes with every new app registration. `Sub` is therefore not uniquely related to the user. It is therefore not possible to transfer users from one app registration to another without further problems.
https://learn.microsoft.com/en-us/entra/identity-platform/id-token-claims-reference#payload-claims

With the use of `oid` it is possible to identify a user by a unique id.

## Related issue(s)

- #4170

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).