### PR TITLE
feat: add attributes to webhook events for better debugging

### DIFF
--- a/courier/http_channel.go
+++ b/courier/http_channel.go
@@ -61,7 +61,7 @@ func (c *httpChannel) Dispatch(ctx context.Context, msg Message) (err error) {
 	ctx, span := c.d.Tracer(ctx).Tracer().Start(ctx, "courier.httpChannel.Dispatch")
 	defer otelx.End(span, &err)
 
-	builder, err := request.NewBuilder(ctx, c.requestConfig, c.d, nil)
+	builder, err := request.NewBuilder(ctx, c.requestConfig, c.d)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/embedx/config.schema.json
+++ b/embedx/config.schema.json
@@ -225,6 +225,10 @@
           "title": "Web-Hook Configuration",
           "description": "Define what the hook should do",
           "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the hook. Used to identify the hook in logs and errors. For debugging purposes only."
+            },
             "response": {
               "title": "Response Handling",
               "description": "How the web hook should handle the response",
@@ -2274,7 +2278,7 @@
               "id": {
                 "type": "string",
                 "title": "Channel id",
-                "description": "The channel id. Corresponds to the .via property of the identity schema for recovery, verification, etc. Currently only phone is supported.",
+                "description": "The channel id. Corresponds to the .via property of the identity schema for recovery, verification, etc. Currently only sms is supported.",
                 "maxLength": 32,
                 "enum": ["sms"]
               },

--- a/request/builder_test.go
+++ b/request/builder_test.go
@@ -245,7 +245,7 @@ func TestBuildRequest(t *testing.T) {
 	} {
 		t.Run(
 			"request-type="+tc.name, func(t *testing.T) {
-				rb, err := NewBuilder(context.Background(), json.RawMessage(tc.rawConfig), newTestDependencyProvider(t), nil)
+				rb, err := NewBuilder(context.Background(), json.RawMessage(tc.rawConfig), newTestDependencyProvider(t))
 				require.NoError(t, err)
 
 				assert.Equal(t, tc.bodyTemplateURI, rb.Config.TemplateURI)
@@ -279,7 +279,7 @@ func TestBuildRequest(t *testing.T) {
 	"method": "POST",
 	"body": "file://./stub/cancel_body.jsonnet"
 }`,
-			), newTestDependencyProvider(t), nil)
+			), newTestDependencyProvider(t))
 			require.NoError(t, err)
 
 			_, err = rb.BuildRequest(context.Background(), json.RawMessage(`{}`))

--- a/selfservice/hook/password_migration_hook.go
+++ b/selfservice/hook/password_migration_hook.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ory/herodot"
 	"github.com/ory/kratos/request"
 	"github.com/ory/kratos/schema"
+	"github.com/ory/kratos/x"
 	"github.com/ory/x/otelx"
 )
 
@@ -52,9 +53,9 @@ func (p *PasswordMigration) Execute(ctx context.Context, data *PasswordMigration
 	defer otelx.End(span, &err)
 
 	if emitEvent {
-		instrumentHTTPClientForEvents(ctx, httpClient)
+		instrumentHTTPClientForEvents(ctx, httpClient, x.NewUUID(), "password_migration_hook")
 	}
-	builder, err := request.NewBuilder(ctx, p.conf, p.deps, nil)
+	builder, err := request.NewBuilder(ctx, p.conf, p.deps)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/x/events/events.go
+++ b/x/events/events.go
@@ -41,81 +41,91 @@ const (
 )
 
 const (
-	attributeKeySessionID                       semconv.AttributeKey = "SessionID"
-	attributeKeySessionAAL                      semconv.AttributeKey = "SessionAAL"
-	attributeKeySessionExpiresAt                semconv.AttributeKey = "SessionExpiresAt"
-	attributeKeySelfServiceFlowType             semconv.AttributeKey = "SelfServiceFlowType"
-	attributeKeySelfServiceMethodUsed           semconv.AttributeKey = "SelfServiceMethodUsed"
-	attributeKeySelfServiceSSOProviderUsed      semconv.AttributeKey = "SelfServiceSSOProviderUsed"
-	attributeKeyLoginRequestedAAL               semconv.AttributeKey = "LoginRequestedAAL"
-	attributeKeyLoginRequestedPrivilegedSession semconv.AttributeKey = "LoginRequestedPrivilegedSession"
-	attributeKeyTokenizedSessionTTL             semconv.AttributeKey = "TokenizedSessionTTL"
-	attributeKeyWebhookURL                      semconv.AttributeKey = "WebhookURL"
-	attributeKeyWebhookRequestBody              semconv.AttributeKey = "WebhookRequestBody"
-	attributeKeyWebhookResponseBody             semconv.AttributeKey = "WebhookResponseBody"
-	attributeKeyWebhookResponseStatusCode       semconv.AttributeKey = "WebhookResponseStatusCode"
-	attributeKeyWebhookAttemptNumber            semconv.AttributeKey = "WebhookAttemptNumber"
-	attributeKeyWebhookRequestID                semconv.AttributeKey = "WebhookRequestID"
+	AttributeKeySessionID                       semconv.AttributeKey = "SessionID"
+	AttributeKeySessionAAL                      semconv.AttributeKey = "SessionAAL"
+	AttributeKeySessionExpiresAt                semconv.AttributeKey = "SessionExpiresAt"
+	AttributeKeySelfServiceFlowType             semconv.AttributeKey = "SelfServiceFlowType"
+	AttributeKeySelfServiceMethodUsed           semconv.AttributeKey = "SelfServiceMethodUsed"
+	AttributeKeySelfServiceSSOProviderUsed      semconv.AttributeKey = "SelfServiceSSOProviderUsed"
+	AttributeKeyLoginRequestedAAL               semconv.AttributeKey = "LoginRequestedAAL"
+	AttributeKeyLoginRequestedPrivilegedSession semconv.AttributeKey = "LoginRequestedPrivilegedSession"
+	AttributeKeyTokenizedSessionTTL             semconv.AttributeKey = "TokenizedSessionTTL"
+	AttributeKeyWebhookID                       semconv.AttributeKey = "WebhookID"
+	AttributeKeyWebhookURL                      semconv.AttributeKey = "WebhookURL"
+	AttributeKeyWebhookRequestBody              semconv.AttributeKey = "WebhookRequestBody"
+	AttributeKeyWebhookResponseBody             semconv.AttributeKey = "WebhookResponseBody"
+	AttributeKeyWebhookResponseStatusCode       semconv.AttributeKey = "WebhookResponseStatusCode"
+	AttributeKeyWebhookAttemptNumber            semconv.AttributeKey = "WebhookAttemptNumber"
+	AttributeKeyWebhookRequestID                semconv.AttributeKey = "WebhookRequestID"
+	AttributeKeyWebhookTriggerID                semconv.AttributeKey = "WebhookTriggerID"
 )
 
 func attrSessionID(val uuid.UUID) otelattr.KeyValue {
-	return otelattr.String(attributeKeySessionID.String(), val.String())
+	return otelattr.String(AttributeKeySessionID.String(), val.String())
 }
 
 func attrTokenizedSessionTTL(ttl time.Duration) otelattr.KeyValue {
-	return otelattr.String(attributeKeyTokenizedSessionTTL.String(), ttl.String())
+	return otelattr.String(AttributeKeyTokenizedSessionTTL.String(), ttl.String())
 }
 
 func attrSessionAAL(val string) otelattr.KeyValue {
-	return otelattr.String(attributeKeySessionAAL.String(), val)
+	return otelattr.String(AttributeKeySessionAAL.String(), val)
 }
 
 func attLoginRequestedAAL(val string) otelattr.KeyValue {
-	return otelattr.String(attributeKeyLoginRequestedAAL.String(), val)
+	return otelattr.String(AttributeKeyLoginRequestedAAL.String(), val)
 }
 
 func attSessionExpiresAt(expiresAt time.Time) otelattr.KeyValue {
-	return otelattr.String(attributeKeySessionExpiresAt.String(), expiresAt.String())
+	return otelattr.String(AttributeKeySessionExpiresAt.String(), expiresAt.String())
 }
 
 func attLoginRequestedPrivilegedSession(val bool) otelattr.KeyValue {
-	return otelattr.Bool(attributeKeyLoginRequestedPrivilegedSession.String(), val)
+	return otelattr.Bool(AttributeKeyLoginRequestedPrivilegedSession.String(), val)
 }
 
 func attrSelfServiceFlowType(val string) otelattr.KeyValue {
-	return otelattr.String(attributeKeySelfServiceFlowType.String(), val)
+	return otelattr.String(AttributeKeySelfServiceFlowType.String(), val)
 }
 
 func attrSelfServiceMethodUsed(val string) otelattr.KeyValue {
-	return otelattr.String(attributeKeySelfServiceMethodUsed.String(), val)
+	return otelattr.String(AttributeKeySelfServiceMethodUsed.String(), val)
 }
 
 func attrSelfServiceSSOProviderUsed(val string) otelattr.KeyValue {
-	return otelattr.String(attributeKeySelfServiceSSOProviderUsed.String(), val)
+	return otelattr.String(AttributeKeySelfServiceSSOProviderUsed.String(), val)
+}
+
+func attrWebhookID(id string) otelattr.KeyValue {
+	return otelattr.String(AttributeKeyWebhookID.String(), id)
 }
 
 func attrWebhookURL(URL *url.URL) otelattr.KeyValue {
-	return otelattr.String(attributeKeyWebhookURL.String(), URL.Redacted())
+	return otelattr.String(AttributeKeyWebhookURL.String(), URL.Redacted())
 }
 
 func attrWebhookReq(body []byte) otelattr.KeyValue {
-	return otelattr.String(attributeKeyWebhookRequestBody.String(), string(body))
+	return otelattr.String(AttributeKeyWebhookRequestBody.String(), string(body))
 }
 
 func attrWebhookRes(body []byte) otelattr.KeyValue {
-	return otelattr.String(attributeKeyWebhookResponseBody.String(), string(body))
+	return otelattr.String(AttributeKeyWebhookResponseBody.String(), string(body))
 }
 
 func attrWebhookStatus(status int) otelattr.KeyValue {
-	return otelattr.Int(attributeKeyWebhookResponseStatusCode.String(), status)
+	return otelattr.Int(AttributeKeyWebhookResponseStatusCode.String(), status)
 }
 
 func attrWebhookAttempt(n int) otelattr.KeyValue {
-	return otelattr.Int(attributeKeyWebhookAttemptNumber.String(), n)
+	return otelattr.Int(AttributeKeyWebhookAttemptNumber.String(), n)
 }
 
 func attrWebhookRequestID(id uuid.UUID) otelattr.KeyValue {
-	return otelattr.String(attributeKeyWebhookRequestID.String(), id.String())
+	return otelattr.String(AttributeKeyWebhookRequestID.String(), id.String())
+}
+
+func attrWebhookTriggerID(id uuid.UUID) otelattr.KeyValue {
+	return otelattr.String(AttributeKeyWebhookTriggerID.String(), id.String())
 }
 
 func NewSessionIssued(ctx context.Context, aal string, sessionID, identityID uuid.UUID) (string, trace.EventOption) {
@@ -327,7 +337,7 @@ func NewSessionJWTIssued(ctx context.Context, sessionID, identityID uuid.UUID, t
 		)
 }
 
-func NewWebhookDelivered(ctx context.Context, URL *url.URL, reqBody []byte, status int, resBody []byte, attempt int, requestID uuid.UUID) (string, trace.EventOption) {
+func NewWebhookDelivered(ctx context.Context, URL *url.URL, reqBody []byte, status int, resBody []byte, attempt int, requestID, triggerID uuid.UUID, webhookID string) (string, trace.EventOption) {
 	return WebhookDelivered.String(),
 		trace.WithAttributes(
 			append(
@@ -338,20 +348,29 @@ func NewWebhookDelivered(ctx context.Context, URL *url.URL, reqBody []byte, stat
 				attrWebhookURL(URL),
 				attrWebhookAttempt(attempt),
 				attrWebhookRequestID(requestID),
+				attrWebhookID(webhookID),
+				attrWebhookTriggerID(triggerID),
 			)...,
 		)
 }
 
-func NewWebhookSucceeded(ctx context.Context) (string, trace.EventOption) {
+func NewWebhookSucceeded(ctx context.Context, triggerID uuid.UUID, webhookID string) (string, trace.EventOption) {
 	return WebhookSucceeded.String(),
-		trace.WithAttributes(semconv.AttributesFromContext(ctx)...)
+		trace.WithAttributes(
+			append(
+				semconv.AttributesFromContext(ctx),
+				attrWebhookID(webhookID),
+				attrWebhookTriggerID(triggerID),
+			)...)
 }
 
-func NewWebhookFailed(ctx context.Context, err error) (string, trace.EventOption) {
+func NewWebhookFailed(ctx context.Context, err error, triggerID uuid.UUID, id string) (string, trace.EventOption) {
 	return WebhookFailed.String(),
 		trace.WithAttributes(
 			append(
 				semconv.AttributesFromContext(ctx),
+				attrWebhookID(id),
+				attrWebhookTriggerID(triggerID),
 				otelattr.String("Error", err.Error()),
 			)...,
 		)


### PR DESCRIPTION
With this change we add two attributes to webhook events:

- `WebhookID`: a string that can be set in the config and that helps to identify the actual webhook config that was used
- `TriggerID`: a random string that helps to correlate requests across retries