### PR TITLE
feat: gracefully handle failing password rehashing during login

### DIFF
--- a/hash/hash_comparator.go
+++ b/hash/hash_comparator.go
@@ -551,10 +551,11 @@ func compareCryptHelper(password []byte, hash string) error {
 	return errors.WithStack(ErrMismatchedHashAndPassword)
 }
 
+var regexSSHA = regexp.MustCompile(`\{([^}]*)\}`)
+
 // decodeSSHAHash decodes SSHA[1|256|512] encoded password hash in usual {SSHA...} format.
 func decodeSSHAHash(encodedHash string) (hasher string, salt, hash []byte, err error) {
-	re := regexp.MustCompile(`\{([^}]*)\}`)
-	match := re.FindStringSubmatch(string(encodedHash))
+	match := regexSSHA.FindStringSubmatch(string(encodedHash))
 
 	var index_of_salt_begin int
 	var index_of_hash_begin int

--- a/selfservice/strategy/password/login.go
+++ b/selfservice/strategy/password/login.go
@@ -112,7 +112,7 @@ func (s *Strategy) Login(w http.ResponseWriter, r *http.Request, f *login.Flow, 
 
 		if !s.d.Hasher(ctx).Understands([]byte(o.HashedPassword)) {
 			if err := s.migratePasswordHash(ctx, i.ID, []byte(p.Password)); err != nil {
-				return nil, s.handleLoginError(r, f, p, err)
+				s.d.Logger().Warnf("Unable to migrate password hash for identity %s: %s Keeping existing password hash and continuing.", i.ID, err)
 			}
 		}
 	}


### PR DESCRIPTION
This fixes an issue where we would successfully import long passwords (>72 chars), but fail when the user attempts to login with the correct password because we can't rehash it. In this case, we simply issue a warning to the logs, keep the old hash intact, and continue logging in the user.