### PR TITLE
Introducing Ory Kratos Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
     <a href="https://opencollective.com/ory" alt="sponsors on Open Collective"><img src="https://opencollective.com/ory/backers/badge.svg" /></a>
     <a href="https://opencollective.com/ory" alt="Sponsors on Open Collective"><img src="https://opencollective.com/ory/sponsors/badge.svg" /></a>
     <a href="https://github.com/ory/kratos/blob/master/CODE_OF_CONDUCT.md" alt="Ory Code of Conduct"><img src="https://img.shields.io/badge/ory-code%20of%20conduct-green" /></a>
+    <a href="https://gurubase.io/g/ory-kratos" alt="Gurubase"><img src="https://img.shields.io/badge/Gurubase-Ask%20Ory%20Kratos%20Guru-006BFF" /></a>
 </>
 
 Ory Kratos is _the_ developer-friendly, security-hardened and battle-tested


### PR DESCRIPTION
Hello Team,

This PR is a friendly notification that the [Ory Kratos Guru](https://gurubase.io/g/ory-kratos) has been added to Gurubase. The Ory Kratos Guru uses data from this repository and the [documentation](https://www.ory.sh/kratos/docs/) to answer questions by leveraging the LLM.

Gurubase is a centralized, RAG-based learning and troubleshooting assistant platform. Each "Guru" is equipped with custom knowledge to answer user questions based on data collected for that tool. More information can be found in [this repo](https://github.com/getanteon/gurubase).

This PR updates the README to indicate that Ory Kratos users can now ask questions to Ory Kratos Guru. As shown in the [Used By](https://github.com/getanteon/gurubase?tab=readme-ov-file#used-by) section, over 100 open-source repositories currently showcase their Guru in their README.md.

By default, there are three possible actions:
1. If you dislike it, we can immediately disable Ory Kratos Guru in Gurubase and remove this PR.
2. If you like it but don’t want to add it to the README, we can remove this PR or include it in another place you prefer.
3. If you’re happy with it, we can keep it as is and merge the PR. You can then start managing Ory Kratos Guru as described [here](https://github.com/getanteon/gurubase?tab=readme-ov-file#how-to-claim-a-guru).

Although this PR is created by the Gurubase Notifier account, the team monitors it and will answer any questions you may have.

**Note:** If you consider this PR a time-waster, apologize for the inconvenience. Developers often request us to create a Guru for the tools they use. Once we create it, we notify the maintainers to inform them and seek their approval.
