### PR TITLE
fix: properly setup CSRF errors

### DIFF
--- a/driver/registry_default.go
+++ b/driver/registry_default.go
@@ -826,7 +826,7 @@ func (m *RegistryDefault) WithCSRFTokenGenerator(cg x.CSRFToken) {
 
 func (m *RegistryDefault) GenerateCSRFToken(r *http.Request) string {
 	if m.csrfTokenGenerator == nil {
-		m.csrfTokenGenerator = x.DefaultCSRFToken
+		m.csrfTokenGenerator = x.DefaultCSRFTokenGenerator
 	}
 	return m.csrfTokenGenerator(r)
 }

--- a/selfservice/strategy/idfirst/strategy_login_test.go
+++ b/selfservice/strategy/idfirst/strategy_login_test.go
@@ -236,8 +236,7 @@ func TestCompleteLogin(t *testing.T) {
 
 			actual, res := testhelpers.LoginMakeRequest(t, false, false, f, browserClient, values.Encode())
 			assert.EqualValues(t, http.StatusOK, res.StatusCode)
-			assertx.EqualAsJSON(t, x.ErrInvalidCSRFToken,
-				json.RawMessage(actual), "%s", actual)
+			assertx.EqualAsJSON(t, x.ErrInvalidCSRFTokenServerNoCookies, json.RawMessage(actual), "%s", actual)
 		})
 
 		t.Run("case=should fail because of missing CSRF token/type=spa", func(t *testing.T) {

--- a/x/.snapshots/TestSnapshotCsrfErrors.json
+++ b/x/.snapshots/TestSnapshotCsrfErrors.json
@@ -1,0 +1,162 @@
+[
+  {
+    "Id": "ErrInvalidCSRFToken",
+    "Err": {
+      "id": "security_csrf_violation",
+      "code": 403,
+      "status": "Forbidden",
+      "reason": "Please retry the flow and optionally clear your cookies. The request was rejected to protect you from Cross-Site-Request-Forgery (CSRF) which could cause account takeover, leaking personal information, and other serious security issues.",
+      "details": {
+        "docs": "https://www.ory.sh/docs/kratos/debug/csrf",
+        "hint": ""
+      },
+      "message": "The request was rejected to protect you from Cross-Site-Request-Forgery (CSRF) which could cause account takeover, leaking personal information, and other serious security issues."
+    }
+  },
+  {
+    "Id": "ErrInvalidCSRFTokenAJAX",
+    "Err": {
+      "id": "security_csrf_violation",
+      "code": 403,
+      "status": "Forbidden",
+      "reason": "Please retry the flow and optionally clear your cookies. The request was rejected to protect you from Cross-Site-Request-Forgery (CSRF) which could cause account takeover, leaking personal information, and other serious security issues.",
+      "details": {
+        "docs": "https://www.ory.sh/docs/kratos/debug/csrf",
+        "hint": "We detected an AJAX call, please ensure that CORS is enabled and configured correctly, and that your AJAX code sends cookies and has credentials enabled. For further debugging, check your browser's network tab to see what cookies are included or excluded."
+      },
+      "message": "The request was rejected to protect you from Cross-Site-Request-Forgery (CSRF) which could cause account takeover, leaking personal information, and other serious security issues."
+    }
+  },
+  {
+    "Id": "ErrInvalidCSRFTokenAJAXCookieMissing",
+    "Err": {
+      "id": "security_csrf_violation",
+      "code": 403,
+      "status": "Forbidden",
+      "reason": "Please retry the flow and optionally clear your cookies. The request was rejected to protect you from Cross-Site-Request-Forgery (CSRF) which could cause account takeover, leaking personal information, and other serious security issues.",
+      "details": {
+        "docs": "https://www.ory.sh/docs/kratos/debug/csrf",
+        "hint": "We detected an AJAX call, please ensure that CORS is enabled and configured correctly, and that your AJAX code sends cookies and has credentials enabled. For further debugging, check your browser's network tab to see what cookies are included or excluded.",
+        "reject_reason": "The HTTP cookie header was set but did not include the anti-CSRF cookie."
+      },
+      "message": "The request was rejected to protect you from Cross-Site-Request-Forgery (CSRF) which could cause account takeover, leaking personal information, and other serious security issues."
+    }
+  },
+  {
+    "Id": "ErrInvalidCSRFTokenAJAXNoCookies",
+    "Err": {
+      "id": "security_csrf_violation",
+      "code": 403,
+      "status": "Forbidden",
+      "reason": "Please retry the flow and optionally clear your cookies. The request was rejected to protect you from Cross-Site-Request-Forgery (CSRF) which could cause account takeover, leaking personal information, and other serious security issues.",
+      "details": {
+        "docs": "https://www.ory.sh/docs/kratos/debug/csrf",
+        "hint": "We detected an AJAX call, please ensure that CORS is enabled and configured correctly, and that your AJAX code sends cookies and has credentials enabled. For further debugging, check your browser's network tab to see what cookies are included or excluded.",
+        "reject_reason": "The HTTP cookie header is empty or not set."
+      },
+      "message": "The request was rejected to protect you from Cross-Site-Request-Forgery (CSRF) which could cause account takeover, leaking personal information, and other serious security issues."
+    }
+  },
+  {
+    "Id": "ErrInvalidCSRFTokenAJAXTokenMismatch",
+    "Err": {
+      "id": "security_csrf_violation",
+      "code": 403,
+      "status": "Forbidden",
+      "reason": "Please retry the flow and optionally clear your cookies. The request was rejected to protect you from Cross-Site-Request-Forgery (CSRF) which could cause account takeover, leaking personal information, and other serious security issues.",
+      "details": {
+        "docs": "https://www.ory.sh/docs/kratos/debug/csrf",
+        "hint": "We detected an AJAX call, please ensure that CORS is enabled and configured correctly, and that your AJAX code sends cookies and has credentials enabled. For further debugging, check your browser's network tab to see what cookies are included or excluded.",
+        "reject_reason": "The HTTP cookie header was set and a CSRF token was sent but they do not match. We recommend deleting all cookies for this domain and retrying the flow."
+      },
+      "message": "The request was rejected to protect you from Cross-Site-Request-Forgery (CSRF) which could cause account takeover, leaking personal information, and other serious security issues."
+    }
+  },
+  {
+    "Id": "ErrInvalidCSRFTokenAJAXTokenNotSent",
+    "Err": {
+      "id": "security_csrf_violation",
+      "code": 403,
+      "status": "Forbidden",
+      "reason": "Please retry the flow and optionally clear your cookies. The request was rejected to protect you from Cross-Site-Request-Forgery (CSRF) which could cause account takeover, leaking personal information, and other serious security issues.",
+      "details": {
+        "docs": "https://www.ory.sh/docs/kratos/debug/csrf",
+        "hint": "The anti-CSRF cookie was found but the CSRF token was not included in the HTTP request body (csrf_token) nor in the HTTP header (X-CSRF-Token)."
+      },
+      "message": "The request was rejected to protect you from Cross-Site-Request-Forgery (CSRF) which could cause account takeover, leaking personal information, and other serious security issues."
+    }
+  },
+  {
+    "Id": "ErrInvalidCSRFTokenServer",
+    "Err": {
+      "id": "security_csrf_violation",
+      "code": 403,
+      "status": "Forbidden",
+      "reason": "Please retry the flow and optionally clear your cookies. The request was rejected to protect you from Cross-Site-Request-Forgery (CSRF) which could cause account takeover, leaking personal information, and other serious security issues.",
+      "details": {
+        "docs": "https://www.ory.sh/docs/kratos/debug/csrf",
+        "hint": "We detected a regular browser or server-side call. To debug browser calls check your browser's network tab to see what cookies are included or excluded. If you are calling from a server ensure that the appropriate cookies are being forwarded and that the SDK method is called correctly."
+      },
+      "message": "The request was rejected to protect you from Cross-Site-Request-Forgery (CSRF) which could cause account takeover, leaking personal information, and other serious security issues."
+    }
+  },
+  {
+    "Id": "ErrInvalidCSRFTokenServerCookieMissing",
+    "Err": {
+      "id": "security_csrf_violation",
+      "code": 403,
+      "status": "Forbidden",
+      "reason": "Please retry the flow and optionally clear your cookies. The request was rejected to protect you from Cross-Site-Request-Forgery (CSRF) which could cause account takeover, leaking personal information, and other serious security issues.",
+      "details": {
+        "docs": "https://www.ory.sh/docs/kratos/debug/csrf",
+        "hint": "We detected a regular browser or server-side call. To debug browser calls check your browser's network tab to see what cookies are included or excluded. If you are calling from a server ensure that the appropriate cookies are being forwarded and that the SDK method is called correctly.",
+        "reject_reason": "The HTTP cookie header was set but did not include the anti-CSRF cookie."
+      },
+      "message": "The request was rejected to protect you from Cross-Site-Request-Forgery (CSRF) which could cause account takeover, leaking personal information, and other serious security issues."
+    }
+  },
+  {
+    "Id": "ErrInvalidCSRFTokenServerNoCookies",
+    "Err": {
+      "id": "security_csrf_violation",
+      "code": 403,
+      "status": "Forbidden",
+      "reason": "Please retry the flow and optionally clear your cookies. The request was rejected to protect you from Cross-Site-Request-Forgery (CSRF) which could cause account takeover, leaking personal information, and other serious security issues.",
+      "details": {
+        "docs": "https://www.ory.sh/docs/kratos/debug/csrf",
+        "hint": "We detected a regular browser or server-side call. To debug browser calls check your browser's network tab to see what cookies are included or excluded. If you are calling from a server ensure that the appropriate cookies are being forwarded and that the SDK method is called correctly.",
+        "reject_reason": "The HTTP cookie header is empty or not set."
+      },
+      "message": "The request was rejected to protect you from Cross-Site-Request-Forgery (CSRF) which could cause account takeover, leaking personal information, and other serious security issues."
+    }
+  },
+  {
+    "Id": "ErrInvalidCSRFTokenServerTokenMismatch",
+    "Err": {
+      "id": "security_csrf_violation",
+      "code": 403,
+      "status": "Forbidden",
+      "reason": "Please retry the flow and optionally clear your cookies. The request was rejected to protect you from Cross-Site-Request-Forgery (CSRF) which could cause account takeover, leaking personal information, and other serious security issues.",
+      "details": {
+        "docs": "https://www.ory.sh/docs/kratos/debug/csrf",
+        "hint": "We detected a regular browser or server-side call. To debug browser calls check your browser's network tab to see what cookies are included or excluded. If you are calling from a server ensure that the appropriate cookies are being forwarded and that the SDK method is called correctly.",
+        "reject_reason": "The HTTP cookie header was set and a CSRF token was sent but they do not match. We recommend deleting all cookies for this domain and retrying the flow."
+      },
+      "message": "The request was rejected to protect you from Cross-Site-Request-Forgery (CSRF) which could cause account takeover, leaking personal information, and other serious security issues."
+    }
+  },
+  {
+    "Id": "ErrInvalidCSRFTokenServerTokenNotSent",
+    "Err": {
+      "id": "security_csrf_violation",
+      "code": 403,
+      "status": "Forbidden",
+      "reason": "Please retry the flow and optionally clear your cookies. The request was rejected to protect you from Cross-Site-Request-Forgery (CSRF) which could cause account takeover, leaking personal information, and other serious security issues.",
+      "details": {
+        "docs": "https://www.ory.sh/docs/kratos/debug/csrf",
+        "hint": "The anti-CSRF cookie was found but the CSRF token was not included in the HTTP request body (csrf_token) nor in the HTTP header (X-CSRF-Token)."
+      },
+      "message": "The request was rejected to protect you from Cross-Site-Request-Forgery (CSRF) which could cause account takeover, leaking personal information, and other serious security issues."
+    }
+  }
+]


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->
The current implementation frequently returns errors that seem to contradict itself (reason says "no CSRF cookie sent" and detail says "CSRF cookie found but did not match). The reason is as follows: herodot errors are copied in the WithDetail method, and in theory all operations in that method happen on a new struct. The `details` field is a map[string]any, of which only the pointer to it is copied in WithDetail, not the actual contents. This means, that calling `WithDetail` on an existing error, modifies the `details` field on the original error as well. 

And in this specific case, it means that calling WithDetail on ErrInvalidCSRFTokenServer, modifies the details field for all errors that do so, leading to misleading error responses.

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [ ] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
