### PR TITLE
fix: don't show oidc subject in login hints

### DIFF
--- a/identity/manager.go
+++ b/identity/manager.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"slices"
 	"sort"
+	"strings"
 
 	"github.com/ory/kratos/schema"
 	"github.com/ory/x/sqlcon"
@@ -102,7 +103,7 @@ func (m *Manager) Create(ctx context.Context, i *Identity, opts ...ManagerOption
 	return nil
 }
 
-func (m *Manager) ConflictingIdentity(ctx context.Context, i *Identity) (found *Identity, foundConflictAddress string, err error) {
+func (m *Manager) ConflictingIdentity(ctx context.Context, i *Identity) (found *Identity, foundConflictAddress string, conflictAddressType string, err error) {
 	for ct, cred := range i.Credentials {
 		for _, id := range cred.Identifiers {
 			found, _, err = m.r.PrivilegedIdentityPool().FindByCredentialsIdentifier(ctx, ct, id)
@@ -112,10 +113,10 @@ func (m *Manager) ConflictingIdentity(ctx context.Context, i *Identity) (found *
 
 			// FindByCredentialsIdentifier does not expand identity credentials.
 			if err = m.r.PrivilegedIdentityPool().HydrateIdentityAssociations(ctx, found, ExpandCredentials); err != nil {
-				return nil, "", err
+				return nil, "", "", err
 			}
 
-			return found, id, nil
+			return found, id, ct.String(), nil
 		}
 	}
 
@@ -125,16 +126,16 @@ func (m *Manager) ConflictingIdentity(ctx context.Context, i *Identity) (found *
 		if errors.Is(err, sqlcon.ErrNoRows) {
 			continue
 		} else if err != nil {
-			return nil, "", err
+			return nil, "", "", err
 		}
 
 		foundConflictAddress = conflictingAddress.Value
 		found, err = m.r.PrivilegedIdentityPool().GetIdentity(ctx, conflictingAddress.IdentityID, ExpandCredentials)
 		if err != nil {
-			return nil, "", err
+			return nil, "", "", err
 		}
 
-		return found, foundConflictAddress, nil
+		return found, foundConflictAddress, va.Via, nil
 	}
 
 	// Last option: check the recovery address
@@ -143,19 +144,19 @@ func (m *Manager) ConflictingIdentity(ctx context.Context, i *Identity) (found *
 		if errors.Is(err, sqlcon.ErrNoRows) {
 			continue
 		} else if err != nil {
-			return nil, "", err
+			return nil, "", "", err
 		}
 
 		foundConflictAddress = conflictingAddress.Value
 		found, err = m.r.PrivilegedIdentityPool().GetIdentity(ctx, conflictingAddress.IdentityID, ExpandCredentials)
 		if err != nil {
-			return nil, "", err
+			return nil, "", "", err
 		}
 
-		return found, foundConflictAddress, nil
+		return found, foundConflictAddress, string(va.Via), nil
 	}
 
-	return nil, "", sqlcon.ErrNoRows
+	return nil, "", "", sqlcon.ErrNoRows
 }
 
 func (m *Manager) findExistingAuthMethod(ctx context.Context, e error, i *Identity) (err error) {
@@ -163,7 +164,7 @@ func (m *Manager) findExistingAuthMethod(ctx context.Context, e error, i *Identi
 		return &ErrDuplicateCredentials{error: e}
 	}
 
-	found, foundConflictAddress, err := m.ConflictingIdentity(ctx, i)
+	found, foundConflictAddress, conflictingAddressType, err := m.ConflictingIdentity(ctx, i)
 	if err != nil {
 		if errors.Is(err, sqlcon.ErrNoRows) {
 			return &ErrDuplicateCredentials{error: e}
@@ -181,6 +182,11 @@ func (m *Manager) findExistingAuthMethod(ctx context.Context, e error, i *Identi
 	})
 
 	duplicateCredErr := &ErrDuplicateCredentials{error: e}
+	// OIDC credentials are not email addresses but the sub claim from the OIDC provider.
+	// This is useless for the user, so in that case, we don't set the identifier hint.
+	if conflictingAddressType != CredentialsTypeOIDC.String() {
+		duplicateCredErr.SetIdentifierHint(strings.Trim(foundConflictAddress, " "))
+	}
 
 	for _, cred := range creds {
 		if cred.Config == nil {
@@ -192,11 +198,9 @@ func (m *Manager) findExistingAuthMethod(ctx context.Context, e error, i *Identi
 		// in to the first factor (obviously).
 		switch cred.Type {
 		case CredentialsTypePassword:
-			identifierHint := foundConflictAddress
-			if len(cred.Identifiers) > 0 {
-				identifierHint = cred.Identifiers[0]
+			if duplicateCredErr.IdentifierHint() == "" && len(cred.Identifiers) == 1 {
+				duplicateCredErr.SetIdentifierHint(cred.Identifiers[0])
 			}
-			duplicateCredErr.SetIdentifierHint(identifierHint)
 
 			var cfg CredentialsPassword
 			if err := json.Unmarshal(cred.Config, &cfg); err != nil {
@@ -209,14 +213,7 @@ func (m *Manager) findExistingAuthMethod(ctx context.Context, e error, i *Identi
 			}
 
 			duplicateCredErr.AddCredentialsType(cred.Type)
-
 		case CredentialsTypeCodeAuth:
-			identifierHint := foundConflictAddress
-			if len(cred.Identifiers) > 0 {
-				identifierHint = cred.Identifiers[0]
-			}
-
-			duplicateCredErr.SetIdentifierHint(identifierHint)
 			duplicateCredErr.AddCredentialsType(cred.Type)
 		case CredentialsTypeOIDC:
 			var cfg CredentialsOIDC
@@ -230,7 +227,6 @@ func (m *Manager) findExistingAuthMethod(ctx context.Context, e error, i *Identi
 			}
 
 			duplicateCredErr.AddCredentialsType(cred.Type)
-			duplicateCredErr.SetIdentifierHint(foundConflictAddress)
 			duplicateCredErr.availableOIDCProviders = available
 		case CredentialsTypeWebAuthn:
 			var cfg CredentialsWebAuthnConfig
@@ -238,15 +234,12 @@ func (m *Manager) findExistingAuthMethod(ctx context.Context, e error, i *Identi
 				return errors.WithStack(herodot.ErrInternalServerError.WithReasonf("Unable to JSON decode identity credentials %s for identity %s.", cred.Type, found.ID))
 			}
 
-			identifierHint := foundConflictAddress
-			if len(cred.Identifiers) > 0 {
-				identifierHint = cred.Identifiers[0]
+			if duplicateCredErr.IdentifierHint() == "" && len(cred.Identifiers) == 1 {
+				duplicateCredErr.SetIdentifierHint(cred.Identifiers[0])
 			}
-
 			for _, webauthn := range cfg.Credentials {
 				if webauthn.IsPasswordless {
 					duplicateCredErr.AddCredentialsType(cred.Type)
-					duplicateCredErr.SetIdentifierHint(identifierHint)
 					break
 				}
 			}
@@ -256,15 +249,12 @@ func (m *Manager) findExistingAuthMethod(ctx context.Context, e error, i *Identi
 				return errors.WithStack(herodot.ErrInternalServerError.WithReasonf("Unable to JSON decode identity credentials %s for identity %s.", cred.Type, found.ID))
 			}
 
-			identifierHint := foundConflictAddress
-			if len(cred.Identifiers) > 0 {
-				identifierHint = cred.Identifiers[0]
+			if duplicateCredErr.IdentifierHint() == "" && len(cred.Identifiers) == 1 {
+				duplicateCredErr.SetIdentifierHint(cred.Identifiers[0])
 			}
-
 			for _, webauthn := range cfg.Credentials {
 				if webauthn.IsPasswordless {
 					duplicateCredErr.AddCredentialsType(cred.Type)
-					duplicateCredErr.SetIdentifierHint(identifierHint)
 					break
 				}
 			}
@@ -343,6 +333,7 @@ func (e *CreateIdentitiesError) Error() string {
 	e.init()
 	return fmt.Sprintf("create identities error: %d identities failed", len(e.failedIdentities))
 }
+
 func (e *CreateIdentitiesError) Unwrap() []error {
 	e.init()
 	var errs []error
@@ -356,17 +347,20 @@ func (e *CreateIdentitiesError) AddFailedIdentity(ident *Identity, err *herodot.
 	e.init()
 	e.failedIdentities[ident] = err
 }
+
 func (e *CreateIdentitiesError) Merge(other *CreateIdentitiesError) {
 	e.init()
 	for k, v := range other.failedIdentities {
 		e.failedIdentities[k] = v
 	}
 }
+
 func (e *CreateIdentitiesError) Contains(ident *Identity) bool {
 	e.init()
 	_, found := e.failedIdentities[ident]
 	return found
 }
+
 func (e *CreateIdentitiesError) Find(ident *Identity) *FailedIdentity {
 	e.init()
 	if err, found := e.failedIdentities[ident]; found {
@@ -375,12 +369,14 @@ func (e *CreateIdentitiesError) Find(ident *Identity) *FailedIdentity {
 
 	return nil
 }
+
 func (e *CreateIdentitiesError) ErrOrNil() error {
 	if e == nil || len(e.failedIdentities) == 0 {
 		return nil
 	}
 	return e
 }
+
 func (e *CreateIdentitiesError) init() {
 	if e.failedIdentities == nil {
 		e.failedIdentities = map[*Identity]*herodot.DefaultError{}

--- a/selfservice/flow/registration/hook.go
+++ b/selfservice/flow/registration/hook.go
@@ -330,7 +330,7 @@ func (e *HookExecutor) PostRegistrationHook(w http.ResponseWriter, r *http.Reque
 }
 
 func (e *HookExecutor) getDuplicateIdentifier(ctx context.Context, i *identity.Identity) (string, error) {
-	_, id, err := e.d.IdentityManager().ConflictingIdentity(ctx, i)
+	_, id, _, err := e.d.IdentityManager().ConflictingIdentity(ctx, i)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->
In some configurations, if the identity only has an OIDC credential, the login hint message would contain an OIDC identifier including the subject, which is useless to the user.

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [ ] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
