### PR TITLE
feat: allow deleting certain first-factor credentials

### DIFF
--- a/identity/credentials.go
+++ b/identity/credentials.go
@@ -120,6 +120,7 @@ func (c CredentialsType) ToUiNodeGroup() node.UiNodeGroup {
 var AllCredentialTypes = []CredentialsType{
 	CredentialsTypePassword,
 	CredentialsTypeOIDC,
+	CredentialsTypeSAML,
 	CredentialsTypeTOTP,
 	CredentialsTypeLookup,
 	CredentialsTypeWebAuthn,
@@ -136,8 +137,8 @@ const (
 
 // ParseCredentialsType parses a string into a CredentialsType or returns false as the second argument.
 func ParseCredentialsType(in string) (CredentialsType, bool) {
-	for _, t := range []CredentialsType{
-		CredentialsTypePassword,
+	switch t := CredentialsType(in); t {
+	case CredentialsTypePassword,
 		CredentialsTypeOIDC,
 		CredentialsTypeSAML,
 		CredentialsTypeTOTP,
@@ -146,11 +147,8 @@ func ParseCredentialsType(in string) (CredentialsType, bool) {
 		CredentialsTypeCodeAuth,
 		CredentialsTypeRecoveryLink,
 		CredentialsTypeRecoveryCode,
-		CredentialsTypePasskey,
-	} {
-		if t.String() == in {
-			return t, true
-		}
+		CredentialsTypePasskey:
+		return t, true
 	}
 	return "", false
 }

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -564,8 +564,8 @@ func (i *Identity) deleteCredentialOIDCFromIdentity(identifierToDelete string) e
 		return errors.WithStack(herodot.ErrInternalServerError.WithReasonf("Unable to decode identity credentials.").WithDebug(err.Error()))
 	}
 
-	var updatedIdentifiers []string
-	var updatedProviders []CredentialsOIDCProvider
+	updatedIdentifiers := make([]string, 0, len(oidcConfig.Providers))
+	updatedProviders := make([]CredentialsOIDCProvider, 0, len(oidcConfig.Providers))
 	var found bool
 	for _, cfg := range oidcConfig.Providers {
 		if identifierToDelete == OIDCUniqueID(cfg.Provider, cfg.Subject) {


### PR DESCRIPTION
The admin API did not allow to delete passwords and code credentials at all. The restriction is now lifted to only block deletion of the first-factor credential if it is the last one.