### PR TITLE
fix: also update identifiers

### DIFF
--- a/identity/identity_test.go
+++ b/identity/identity_test.go
@@ -489,7 +489,7 @@ func TestMergeOIDCCredentials(t *testing.T) {
 			},
 			newCredentials: Credentials{
 				Type:        CredentialsTypeOIDC,
-				Identifiers: []string{"replace:new-subject"},
+				Identifiers: []string{},
 				Config:      sqlxx.JSONRawMessage(`{"providers": [{"provider": "replace", "subject": "new-subject"}]}`),
 			},
 
@@ -548,7 +548,26 @@ func TestMergeOIDCCredentials(t *testing.T) {
 			newCredentials: Credentials{
 				Type:        CredentialsTypeOIDC,
 				Identifiers: []string{"oidc:1234"},
-				Config:      sqlxx.JSONRawMessage(`{"providers": []`),
+				Config:      sqlxx.JSONRawMessage(`{"providers": []}`),
+			},
+
+			assertErr: assert.Error,
+		},
+		{
+			name: "errs if identity credentials are invalid",
+			identity: &Identity{
+				Credentials: map[CredentialsType]Credentials{
+					CredentialsTypeOIDC: {
+						Type:        CredentialsTypeOIDC,
+						Identifiers: []string{"oidc:1234"},
+						Config:      sqlxx.JSONRawMessage("invalid"),
+					},
+				},
+			},
+			newCredentials: Credentials{
+				Type:        CredentialsTypeOIDC,
+				Identifiers: []string{"oidc:1234"},
+				Config:      sqlxx.JSONRawMessage(`{"providers": [{"provider": "replace", "subject": "new-subject"}]}`),
 			},
 
 			assertErr: assert.Error,

--- a/selfservice/strategy/oidc/strategy_login.go
+++ b/selfservice/strategy/oidc/strategy_login.go
@@ -140,56 +140,10 @@ func (s *Strategy) handleConflictingIdentity(ctx context.Context, w http.Respons
 
 	verdict = s.conflictingIdentityPolicy(ctx, existingIdentity, newIdentity, provider, claims)
 	if verdict == ConflictingIdentityVerdictMerge {
-		if _, ok := existingIdentity.Credentials[s.ID()]; !ok {
-			existingIdentity.SetCredentials(s.ID(), *creds)
-		} else {
-			newCreds := existingIdentity.Credentials[s.ID()]
-			var conf identity.CredentialsOIDC
-			if err = json.Unmarshal(newCreds.Config, &conf); err != nil {
-				return ConflictingIdentityVerdictUnknown, nil, nil, s.HandleError(ctx, w, r, loginFlow, provider.Config().ID, newIdentity.Traits, err)
-			}
-			// If there exists a provider in the existing identity for the same provider, we
-			// need to merge the providers, otherwise we just add the new provider.
-			var providerWasUpdated bool
-			var identifierWasUpdated bool
-			newProvider := identity.CredentialsOIDCProvider{
-				Subject:             claims.Subject,
-				Provider:            provider.Config().ID,
-				InitialIDToken:      token.GetIDToken(),
-				InitialAccessToken:  token.GetAccessToken(),
-				InitialRefreshToken: token.GetRefreshToken(),
-				Organization:        provider.Config().OrganizationID,
-			}
-			newIdentifier := identity.OIDCUniqueID(newProvider.Provider, newProvider.Subject)
-			for i, p := range conf.Providers {
-				if p.Provider == newProvider.Provider {
-					conf.Providers[i] = newProvider
-					providerWasUpdated = true
-
-					// Also replace the identifier in the list of identifiers
-					oldIdentifier := identity.OIDCUniqueID(p.Provider, p.Subject)
-					for j, identifier := range newCreds.Identifiers {
-						if identifier == oldIdentifier {
-							newCreds.Identifiers[j] = newIdentifier
-							identifierWasUpdated = true
-							break
-						}
-					}
-
-					break
-				}
-			}
-			if !identifierWasUpdated {
-				newCreds.Identifiers = append(newCreds.Identifiers, newIdentifier)
-			}
-			if !providerWasUpdated {
-				conf.Providers = append(conf.Providers, newProvider)
-			}
-
-			if err = existingIdentity.SetCredentialsWithConfig(s.ID(), newCreds, conf); err != nil {
-				return ConflictingIdentityVerdictUnknown, nil, nil, s.HandleError(ctx, w, r, loginFlow, provider.Config().ID, newIdentity.Traits, err)
-			}
+		if err = existingIdentity.MergeOIDCCredentials(s.ID(), *creds); err != nil {
+			return ConflictingIdentityVerdictUnknown, nil, nil, s.HandleError(ctx, w, r, loginFlow, provider.Config().ID, newIdentity.Traits, err)
 		}
+
 		if err = s.d.PrivilegedIdentityPool().UpdateIdentity(ctx, existingIdentity); err != nil {
 			return ConflictingIdentityVerdictUnknown, nil, nil, s.HandleError(ctx, w, r, loginFlow, provider.Config().ID, newIdentity.Traits, err)
 		}

--- a/selfservice/strategy/oidc/strategy_test.go
+++ b/selfservice/strategy/oidc/strategy_test.go
@@ -1746,13 +1746,13 @@ func TestStrategy(t *testing.T) {
 				})
 				i.SetCredentials(identity.CredentialsTypeOIDC, identity.Credentials{
 					Type:        identity.CredentialsTypeOIDC,
-					Identifiers: []string{subject},
+					Identifiers: []string{"valid:stub", "other:other-identifier"},
 					Config: sqlxx.JSONRawMessage(`{"providers": [{
-	"subject": "",
+	"subject": "stub",
 	"provider": "valid",
 	"use_auto_link": true
 },{
-	"subject": "",
+	"subject": "other-identifier",
 	"provider": "other",
 	"use_auto_link": true
 }]}`),
@@ -1775,6 +1775,8 @@ func TestStrategy(t *testing.T) {
 				i, err = reg.PrivilegedIdentityPool().GetIdentityConfidential(ctx, i.ID)
 				require.NoError(t, err)
 				assert.False(t, gjson.GetBytes(i.Credentials["oidc"].Config, "providers.0.use_auto_link").Bool())
+				assert.NotContains(t, i.Credentials["oidc"].Identifiers, "valid:stub")
+				assert.Contains(t, i.Credentials["oidc"].Identifiers, "valid:user-with-use-auto-link@ory.sh")
 				assert.True(t, gjson.GetBytes(i.Credentials["oidc"].Config, "providers.1.use_auto_link").Bool())
 			})
 		})

--- a/selfservice/strategy/password/validator_test.go
+++ b/selfservice/strategy/password/validator_test.go
@@ -70,7 +70,7 @@ func TestDefaultPasswordValidationStrategy(t *testing.T) {
 			{pw: "hello@example.com", id: "hello@exam", pass: false},
 			{id: "abcd", pw: "9d3c8a1b", pass: true},
 			{id: "a", pw: "kjOklafe", pass: true},
-			{id: "ab", pw: "0000ab0000", pass: true},
+			{id: "ab", pw: "0000ab0000123", pass: true},
 			// longest common substring with long password
 			{id: "d4f6090b-5a84", pw: "d4f6090b-5a84-2184-4404-8d1b-8da3eb00ebbe", pass: true},
 			{id: "asdflasdflasdf", pw: "asdflasdflpiuhefnciluaksdzuföfhg", pass: true},


### PR DESCRIPTION
This fixes a bug where when an identity is merged into another, the identifier of the original identity was not updated.