### PR TITLE
feat: emit event on Jsonnet claims mapping error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/ory/jsonschema/v3 v3.0.9-0.20250317235931-280c5fc7bf0e
 	github.com/ory/mail/v3 v3.0.0
 	github.com/ory/nosurf v1.2.7
-	github.com/ory/x v0.0.705
+	github.com/ory/x v0.0.710
 	github.com/peterhellberg/link v1.2.0
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -633,6 +633,8 @@ github.com/ory/sessions v1.2.2-0.20220110165800-b09c17334dc2 h1:zm6sDvHy/U9XrGpi
 github.com/ory/sessions v1.2.2-0.20220110165800-b09c17334dc2/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/ory/x v0.0.705 h1:Cjyd+p3P4pV2n49H7xSxOwC7kmNvsI4EdwzUIt4l8uI=
 github.com/ory/x v0.0.705/go.mod h1:by9HRTEZgIS48FIoF/RjYHb2s1eSiycCZy0m/BMhsf8=
+github.com/ory/x v0.0.710 h1:zGxdqk4WPOg4/WUx5jO6VNV0AU4srwnTm1LmZbF6150=
+github.com/ory/x v0.0.710/go.mod h1:gEgiiLvpxJE+rruw8ZlYJT5Ow3nSA1PMSpAVI1e9/Ho=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=

--- a/selfservice/flow/login/handler.go
+++ b/selfservice/flow/login/handler.go
@@ -9,11 +9,14 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/ory/x/otelx"
-
 	"github.com/gofrs/uuid"
 	"github.com/julienschmidt/httprouter"
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/ory/kratos/x/events"
+	"github.com/ory/x/otelx"
+	"github.com/ory/x/otelx/semconv"
 
 	"github.com/ory/herodot"
 	hydraclientgo "github.com/ory/hydra-client-go/v2"
@@ -793,6 +796,7 @@ type updateLoginFlowBody struct{}
 func (h *Handler) updateLoginFlow(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	var err error
 	ctx, span := h.d.Tracer(r.Context()).Tracer().Start(r.Context(), "selfservice.flow.login.updateLoginFlow")
+	ctx = semconv.ContextWithAttributes(ctx, attribute.String(events.AttributeKeySelfServiceStrategyUsed.String(), "login"))
 	r = r.WithContext(ctx)
 	defer otelx.End(span, &err)
 

--- a/selfservice/flow/registration/handler.go
+++ b/selfservice/flow/registration/handler.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/ory/herodot"
 	hydraclientgo "github.com/ory/hydra-client-go/v2"
@@ -24,7 +25,9 @@ import (
 	"github.com/ory/kratos/text"
 	"github.com/ory/kratos/ui/node"
 	"github.com/ory/kratos/x"
+	"github.com/ory/kratos/x/events"
 	"github.com/ory/nosurf"
+	"github.com/ory/x/otelx/semconv"
 	"github.com/ory/x/sqlxx"
 	"github.com/ory/x/urlx"
 )
@@ -629,6 +632,10 @@ type updateRegistrationFlowBody struct{}
 //	  422: errorBrowserLocationChangeRequired
 //	  default: errorGeneric
 func (h *Handler) updateRegistrationFlow(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	ctx := r.Context()
+	ctx = semconv.ContextWithAttributes(ctx, attribute.String(events.AttributeKeySelfServiceStrategyUsed.String(), "registration"))
+	r = r.WithContext(ctx)
+
 	rid, err := flow.GetFlowID(r)
 	if err != nil {
 		h.d.RegistrationFlowErrorHandler().WriteFlowError(w, r, nil, node.DefaultGroup, err)

--- a/selfservice/strategy/oidc/strategy_registration.go
+++ b/selfservice/strategy/oidc/strategy_registration.go
@@ -376,7 +376,7 @@ func (s *Strategy) newIdentityFromClaims(ctx context.Context, claims *Claims, pr
 
 	defer func() {
 		if err != nil {
-			trace.SpanFromContext(ctx).AddEvent(events.NewClaimsMappingFailed(
+			trace.SpanFromContext(ctx).AddEvent(events.NewOIDCClaimsMappingFailed(
 				ctx, err, jsonClaims.Bytes(), evaluated, provider.Config().Provider,
 			))
 		}

--- a/selfservice/strategy/oidc/strategy_registration.go
+++ b/selfservice/strategy/oidc/strategy_registration.go
@@ -376,8 +376,8 @@ func (s *Strategy) newIdentityFromClaims(ctx context.Context, claims *Claims, pr
 
 	defer func() {
 		if err != nil {
-			trace.SpanFromContext(ctx).AddEvent(events.NewOIDCClaimsMappingFailed(
-				ctx, err, jsonClaims.Bytes(), evaluated, provider.Config().Provider,
+			trace.SpanFromContext(ctx).AddEvent(events.NewJsonnetMappingFailed(
+				ctx, err, jsonClaims.Bytes(), evaluated, provider.Config().Provider, s.ID(),
 			))
 		}
 	}()

--- a/x/events/events.go
+++ b/x/events/events.go
@@ -48,11 +48,19 @@ const (
 )
 
 const (
-	AttributeKeySessionID                       semconv.AttributeKey = "SessionID"
-	AttributeKeySessionAAL                      semconv.AttributeKey = "SessionAAL"
-	AttributeKeySessionExpiresAt                semconv.AttributeKey = "SessionExpiresAt"
-	AttributeKeySelfServiceFlowType             semconv.AttributeKey = "SelfServiceFlowType"
-	AttributeKeySelfServiceMethodUsed           semconv.AttributeKey = "SelfServiceMethodUsed"
+	AttributeKeySessionID        semconv.AttributeKey = "SessionID"
+	AttributeKeySessionAAL       semconv.AttributeKey = "SessionAAL"
+	AttributeKeySessionExpiresAt semconv.AttributeKey = "SessionExpiresAt"
+
+	// AttributeKeySelfServiceFlowType is the type of self-service flow, e.g. "api" or "browser".
+	AttributeKeySelfServiceFlowType semconv.AttributeKey = "SelfServiceFlowType"
+
+	// AttributeKeySelfServiceMethodUsed is the method used in the self-service flow, e.g. "oidc" or "password".
+	AttributeKeySelfServiceMethodUsed semconv.AttributeKey = "SelfServiceMethodUsed"
+
+	// AttributeKeySelfServiceStrategyUsed is the strategy used in the self-service flow, e.g. "login" or "registration".
+	AttributeKeySelfServiceStrategyUsed semconv.AttributeKey = "SelfServiceStrategyUsed"
+
 	AttributeKeySelfServiceSSOProviderUsed      semconv.AttributeKey = "SelfServiceSSOProviderUsed"
 	AttributeKeyLoginRequestedAAL               semconv.AttributeKey = "LoginRequestedAAL"
 	AttributeKeyLoginRequestedPrivilegedSession semconv.AttributeKey = "LoginRequestedPrivilegedSession"
@@ -102,6 +110,10 @@ func attrSelfServiceFlowType(val string) otelattr.KeyValue {
 
 func attrSelfServiceMethodUsed(val string) otelattr.KeyValue {
 	return otelattr.String(AttributeKeySelfServiceMethodUsed.String(), val)
+}
+
+func attrSelfServiceStrategyUsed(val string) otelattr.KeyValue {
+	return otelattr.String(AttributeKeySelfServiceStrategyUsed.String(), val)
 }
 
 func attrSelfServiceSSOProviderUsed(val string) otelattr.KeyValue {

--- a/x/events/events.go
+++ b/x/events/events.go
@@ -43,7 +43,7 @@ const (
 	WebhookDelivered         semconv.Event = "WebhookDelivered"
 	WebhookSucceeded         semconv.Event = "WebhookSucceeded"
 	WebhookFailed            semconv.Event = "WebhookFailed"
-	ClaimsMappingFailed      semconv.Event = "ClaimsMappingFailed"
+	OIDCClaimsMappingFailed  semconv.Event = "OIDCClaimsMappingFailed"
 )
 
 const (
@@ -440,9 +440,9 @@ func NewWebhookFailed(ctx context.Context, err error, triggerID uuid.UUID, id st
 		)
 }
 
-// NewClaimsMappingFailed is used to log errors that occur during the claims
+// NewOIDCClaimsMappingFailed is used to log errors that occur during the claims
 // mapping process. The claims are anonymized before emitting the event.
-func NewClaimsMappingFailed(ctx context.Context, err error, claims []byte, jsonnetOutput, provider string) (string, trace.EventOption) {
+func NewOIDCClaimsMappingFailed(ctx context.Context, err error, claims []byte, jsonnetOutput, provider string) (string, trace.EventOption) {
 	attrs := append(
 		semconv.AttributesFromContext(ctx),
 		attrErrorReason(err),
@@ -452,7 +452,7 @@ func NewClaimsMappingFailed(ctx context.Context, err error, claims []byte, jsonn
 	if jsonnetOutput != "" {
 		attrs = append(attrs, attrJsonnetOutput(jsonnetOutput))
 	}
-	return ClaimsMappingFailed.String(),
+	return OIDCClaimsMappingFailed.String(),
 		trace.WithAttributes(
 			attrs...,
 		)

--- a/x/events/events.go
+++ b/x/events/events.go
@@ -112,10 +112,6 @@ func attrSelfServiceMethodUsed(val string) otelattr.KeyValue {
 	return otelattr.String(AttributeKeySelfServiceMethodUsed.String(), val)
 }
 
-func attrSelfServiceStrategyUsed(val string) otelattr.KeyValue {
-	return otelattr.String(AttributeKeySelfServiceStrategyUsed.String(), val)
-}
-
 func attrSelfServiceSSOProviderUsed(val string) otelattr.KeyValue {
 	return otelattr.String(AttributeKeySelfServiceSSOProviderUsed.String(), val)
 }

--- a/x/events/events_test.go
+++ b/x/events/events_test.go
@@ -1,3 +1,6 @@
+// Copyright © 2025 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
 package events_test
 
 import (

--- a/x/events/events_test.go
+++ b/x/events/events_test.go
@@ -1,0 +1,73 @@
+package events_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/ory/kratos/identity"
+	"github.com/ory/kratos/x/events"
+)
+
+func TestNewJsonnetMappingFailed(t *testing.T) {
+	tests := []struct {
+		name          string
+		err           error
+		jsonnetInput  []byte
+		jsonnetOutput string
+		provider      string
+		method        identity.CredentialsType
+		expectedAttrs []attribute.KeyValue
+	}{
+		{
+			name:          "With all attributes",
+			err:           errors.New("test error"),
+			jsonnetInput:  []byte(`{"key": "PII value"}`),
+			jsonnetOutput: `{"key": 123}`,
+			provider:      "test-provider",
+			method:        identity.CredentialsTypeOIDC,
+			expectedAttrs: []attribute.KeyValue{
+				attribute.String("SelfServiceSSOProviderUsed", "test-provider"),
+				attribute.String("SelfServiceMethodUsed", "oidc"),
+				attribute.String("ErrorReason", "test error"),
+				attribute.String("JsonnetInput", `{
+  "key": "string"
+}`),
+				attribute.String("JsonnetOutput", `{
+  "key": "number"
+}`),
+			},
+		},
+		{
+			name:          "Without JsonnetOutput",
+			err:           errors.New("another error"),
+			jsonnetInput:  []byte(`{"key": "PII value"}`),
+			jsonnetOutput: "",
+			provider:      "another-provider",
+			method:        identity.CredentialsTypeSAML,
+			expectedAttrs: []attribute.KeyValue{
+				attribute.String("SelfServiceSSOProviderUsed", "another-provider"),
+				attribute.String("SelfServiceMethodUsed", "saml"),
+				attribute.String("ErrorReason", "another error"),
+				attribute.String("JsonnetInput", `{
+  "key": "string"
+}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			eventName, opts := events.NewJsonnetMappingFailed(ctx, tt.err, tt.jsonnetInput, tt.jsonnetOutput, tt.provider, tt.method)
+
+			assert.Equal(t, events.JsonnetMappingFailed.String(), eventName)
+
+			eventConfig := trace.NewEventConfig(opts)
+			assert.ElementsMatch(t, tt.expectedAttrs, eventConfig.Attributes())
+		})
+	}
+}


### PR DESCRIPTION
We now emit an event containing the Jsonnet input and output in anonymized form when mapping the claims in the OIDC flow fails.