### PR TITLE
fix: ensure `make quickstart-dev` works without options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ export PATH               := .bin:${PATH}
 export PWD                := $(shell pwd)
 export BUILD_DATE         := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 export VCS_REF            := $(shell git rev-parse HEAD)
-export QUICKSTART_OPTIONS ?= ""
+export QUICKSTART_OPTIONS ?=
 export IMAGE_TAG 					:= $(if $(IMAGE_TAG),$(IMAGE_TAG),latest)
 
 .bin/clidoc:


### PR DESCRIPTION
`make quickstart-dev` uses the make variable `QUICKSTART_OPTIONS` which is set to `""` by default. This will result in two double quotes (`""`) in the final shell command e.g. `docker-compose "" up` when the variable is not set on the make command line, which fails at the shell level. The fix is to leave the variable empty by default. No semantic changes.