### PR TITLE
feat: add LoginStarted and RegistrationStarted events

### DIFF
--- a/hydra/fake.go
+++ b/hydra/fake.go
@@ -14,7 +14,7 @@ import (
 const (
 	FakeInvalidLoginChallenge = "2e98454e-031b-4870-9ad6-8517df1ce604"
 	FakeValidLoginChallenge   = "5ff59a39-ecc5-467e-bb10-26644c0700ee"
-	FakePostLoginURL          = "https://www.ory.sh/fake-post-login"
+	FakePostLoginURL          = "https://www.example.com/fake-post-login"
 )
 
 var ErrFakeAcceptLoginRequestFailed = errors.New("failed to accept login request")

--- a/selfservice/flow/login/handler.go
+++ b/selfservice/flow/login/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/julienschmidt/httprouter"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ory/herodot"
 	hydraclientgo "github.com/ory/hydra-client-go/v2"
@@ -270,6 +271,8 @@ preLoginHook:
 		return nil, nil, err
 	}
 
+	span := trace.SpanFromContext(r.Context())
+	span.AddEvent(events.NewLoginStarted(r.Context(), f.ID, ft.String(), f.Refresh, f.OrganizationID, string(f.RequestedAAL)))
 	return f, nil, nil
 }
 

--- a/selfservice/flow/login/handler.go
+++ b/selfservice/flow/login/handler.go
@@ -272,7 +272,7 @@ preLoginHook:
 	}
 
 	span := trace.SpanFromContext(r.Context())
-	span.AddEvent(events.NewLoginStarted(r.Context(), f.ID, ft.String(), f.Refresh, f.OrganizationID, string(f.RequestedAAL)))
+	span.AddEvent(events.NewLoginInitiated(r.Context(), f.ID, ft.String(), f.Refresh, f.OrganizationID, string(f.RequestedAAL)))
 	return f, nil, nil
 }
 

--- a/selfservice/flow/registration/handler.go
+++ b/selfservice/flow/registration/handler.go
@@ -174,12 +174,12 @@ func (h *Handler) NewRegistrationFlow(w http.ResponseWriter, r *http.Request, ft
 		return nil, err
 	}
 
-	span := trace.SpanFromContext(r.Context())
-	span.AddEvent(events.NewRegistrationInitiated(r.Context(), f.ID, string(ft), f.OrganizationID))
-
 	if err := h.d.RegistrationFlowPersister().CreateRegistrationFlow(r.Context(), f); err != nil {
 		return nil, err
 	}
+
+	span := trace.SpanFromContext(r.Context())
+	span.AddEvent(events.NewRegistrationInitiated(r.Context(), f.ID, string(ft), f.OrganizationID))
 
 	return f, nil
 }

--- a/selfservice/flow/registration/handler.go
+++ b/selfservice/flow/registration/handler.go
@@ -175,7 +175,7 @@ func (h *Handler) NewRegistrationFlow(w http.ResponseWriter, r *http.Request, ft
 	}
 
 	span := trace.SpanFromContext(r.Context())
-	span.AddEvent(events.NewRegistrationStarted(r.Context(), f.ID, string(ft), f.OrganizationID.UUID))
+	span.AddEvent(events.NewRegistrationInitiated(r.Context(), f.ID, string(ft), f.OrganizationID.UUID))
 
 	if err := h.d.RegistrationFlowPersister().CreateRegistrationFlow(r.Context(), f); err != nil {
 		return nil, err

--- a/selfservice/flow/registration/handler.go
+++ b/selfservice/flow/registration/handler.go
@@ -175,7 +175,7 @@ func (h *Handler) NewRegistrationFlow(w http.ResponseWriter, r *http.Request, ft
 	}
 
 	span := trace.SpanFromContext(r.Context())
-	span.AddEvent(events.NewRegistrationInitiated(r.Context(), f.ID, string(ft), f.OrganizationID.UUID))
+	span.AddEvent(events.NewRegistrationInitiated(r.Context(), f.ID, string(ft), f.OrganizationID))
 
 	if err := h.d.RegistrationFlowPersister().CreateRegistrationFlow(r.Context(), f); err != nil {
 		return nil, err

--- a/selfservice/flow/registration/handler.go
+++ b/selfservice/flow/registration/handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/julienschmidt/httprouter"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ory/herodot"
 	hydraclientgo "github.com/ory/hydra-client-go/v2"
@@ -172,6 +173,9 @@ func (h *Handler) NewRegistrationFlow(w http.ResponseWriter, r *http.Request, ft
 	if err := h.d.RegistrationExecutor().PreRegistrationHook(w, r, f); err != nil {
 		return nil, err
 	}
+
+	span := trace.SpanFromContext(r.Context())
+	span.AddEvent(events.NewRegistrationStarted(r.Context(), f.ID, string(ft), f.OrganizationID.UUID))
 
 	if err := h.d.RegistrationFlowPersister().CreateRegistrationFlow(r.Context(), f); err != nil {
 		return nil, err

--- a/selfservice/hook/session_issuer_test.go
+++ b/selfservice/hook/session_issuer_test.go
@@ -213,7 +213,7 @@ func TestSessionIssuer(t *testing.T) {
 			require.ErrorIs(t, err, registration.ErrHookAbortFlow, "%+v", err)
 			require.Len(t, f.ContinueWithItems, 1)
 			require.EqualValues(t, flow.ContinueWithActionRedirectBrowserToString, f.ContinueWithItems[0].GetAction())
-			require.EqualValues(t, "https://www.ory.sh/fake-post-login", f.ContinueWithItems[0].(*flow.ContinueWithRedirectBrowserTo).RedirectTo)
+			require.EqualValues(t, hydra.FakePostLoginURL, f.ContinueWithItems[0].(*flow.ContinueWithRedirectBrowserTo).RedirectTo)
 
 			got, err := reg.SessionPersister().GetSession(context.Background(), s.ID, session.ExpandNothing)
 			require.NoError(t, err)
@@ -295,7 +295,7 @@ func TestSessionIssuer(t *testing.T) {
 		require.ErrorIs(t, err, registration.ErrHookAbortFlow, "%+v", err)
 		require.Len(t, f.ContinueWithItems, 2)
 		require.EqualValues(t, flow.ContinueWithActionShowRecoveryUIString, f.ContinueWithItems[0].GetAction())
-		require.EqualValues(t, "https://www.ory.sh/fake-post-login", f.ContinueWithItems[1].(*flow.ContinueWithRedirectBrowserTo).RedirectTo)
+		require.EqualValues(t, hydra.FakePostLoginURL, f.ContinueWithItems[1].(*flow.ContinueWithRedirectBrowserTo).RedirectTo)
 
 		got, err := reg.SessionPersister().GetSession(context.Background(), s.ID, session.ExpandNothing)
 		require.NoError(t, err)

--- a/x/events/events.go
+++ b/x/events/events.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"net/url"
-	"strconv"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -22,32 +21,32 @@ import (
 )
 
 const (
-	SessionIssued            semconv.Event = "SessionIssued"
+	IdentityCreated          semconv.Event = "IdentityCreated"
+	IdentityDeleted          semconv.Event = "IdentityDeleted"
+	IdentityUpdated          semconv.Event = "IdentityUpdated"
+	JsonnetMappingFailed     semconv.Event = "JsonnetMappingFailed"
+	LoginFailed              semconv.Event = "LoginFailed"
+	LoginInitiated           semconv.Event = "LoginInitiated"
+	LoginSucceeded           semconv.Event = "LoginSucceeded"
+	RecoveryFailed           semconv.Event = "RecoveryFailed"
+	RecoveryInitiatedByAdmin semconv.Event = "RecoveryInitiatedByAdmin"
+	RecoverySucceeded        semconv.Event = "RecoverySucceeded"
+	RegistrationFailed       semconv.Event = "RegistrationFailed"
+	RegistrationInitiated    semconv.Event = "RegistrationInitiated"
+	RegistrationSucceeded    semconv.Event = "RegistrationSucceeded"
 	SessionChanged           semconv.Event = "SessionChanged"
+	SessionChecked           semconv.Event = "SessionChecked"
+	SessionIssued            semconv.Event = "SessionIssued"
 	SessionLifespanExtended  semconv.Event = "SessionLifespanExtended"
 	SessionRevoked           semconv.Event = "SessionRevoked"
-	SessionChecked           semconv.Event = "SessionChecked"
 	SessionTokenizedAsJWT    semconv.Event = "SessionTokenizedAsJWT"
-	RegistrationFailed       semconv.Event = "RegistrationFailed"
-	RegistrationSucceeded    semconv.Event = "RegistrationSucceeded"
-	LoginFailed              semconv.Event = "LoginFailed"
-	LoginSucceeded           semconv.Event = "LoginSucceeded"
 	SettingsFailed           semconv.Event = "SettingsFailed"
 	SettingsSucceeded        semconv.Event = "SettingsSucceeded"
-	RecoveryFailed           semconv.Event = "RecoveryFailed"
-	RecoverySucceeded        semconv.Event = "RecoverySucceeded"
-	RecoveryInitiatedByAdmin semconv.Event = "RecoveryInitiatedByAdmin"
 	VerificationFailed       semconv.Event = "VerificationFailed"
 	VerificationSucceeded    semconv.Event = "VerificationSucceeded"
-	IdentityCreated          semconv.Event = "IdentityCreated"
-	IdentityUpdated          semconv.Event = "IdentityUpdated"
-	IdentityDeleted          semconv.Event = "IdentityDeleted"
 	WebhookDelivered         semconv.Event = "WebhookDelivered"
-	WebhookSucceeded         semconv.Event = "WebhookSucceeded"
 	WebhookFailed            semconv.Event = "WebhookFailed"
-	JsonnetMappingFailed     semconv.Event = "JsonnetMappingFailed"
-	LoginInitiated           semconv.Event = "LoginInitiated"
-	RegistrationInitiated    semconv.Event = "RegistrationInitiated"
+	WebhookSucceeded         semconv.Event = "WebhookSucceeded"
 )
 
 const (
@@ -99,7 +98,7 @@ func attLoginRequestedAAL(val string) otelattr.KeyValue {
 }
 
 func attrFlowRefresh(val bool) otelattr.KeyValue {
-	return otelattr.String(AttributeKeyFlowRefresh.String(), strconv.FormatBool(val))
+	return otelattr.Bool(AttributeKeyFlowRefresh.String(), val)
 }
 
 func attrOrganizationID(val string) otelattr.KeyValue {

--- a/x/events/events.go
+++ b/x/events/events.go
@@ -46,8 +46,8 @@ const (
 	WebhookSucceeded         semconv.Event = "WebhookSucceeded"
 	WebhookFailed            semconv.Event = "WebhookFailed"
 	JsonnetMappingFailed     semconv.Event = "JsonnetMappingFailed"
-	LoginStarted             semconv.Event = "LoginStarted"
-	RegistrationStarted      semconv.Event = "RegistrationStarted"
+	LoginInitiated           semconv.Event = "LoginInitiated"
+	RegistrationInitiated    semconv.Event = "RegistrationInitiated"
 )
 
 const (
@@ -483,7 +483,7 @@ func NewJsonnetMappingFailed(ctx context.Context, err error, jsonnetInput []byte
 		)
 }
 
-func NewLoginStarted(ctx context.Context, flowID uuid.UUID, flowType string, refresh bool, organizationID uuid.NullUUID, requestedAAL string) (string, trace.EventOption) {
+func NewLoginInitiated(ctx context.Context, flowID uuid.UUID, flowType string, refresh bool, organizationID uuid.NullUUID, requestedAAL string) (string, trace.EventOption) {
 	attrs := append(semconv.AttributesFromContext(ctx),
 		attrFlowID(flowID),
 		attrSelfServiceFlowType(flowType),
@@ -496,12 +496,12 @@ func NewLoginStarted(ctx context.Context, flowID uuid.UUID, flowType string, ref
 			attrOrganizationID(organizationID.UUID.String()))
 	}
 
-	return LoginStarted.String(),
+	return LoginInitiated.String(),
 		trace.WithAttributes(attrs...)
 }
 
-func NewRegistrationStarted(ctx context.Context, flowID uuid.UUID, flowType string, organizationID uuid.UUID) (string, trace.EventOption) {
-	return RegistrationStarted.String(),
+func NewRegistrationInitiated(ctx context.Context, flowID uuid.UUID, flowType string, organizationID uuid.UUID) (string, trace.EventOption) {
+	return RegistrationInitiated.String(),
 		trace.WithAttributes(
 			append(
 				semconv.AttributesFromContext(ctx),

--- a/x/events/events.go
+++ b/x/events/events.go
@@ -499,15 +499,19 @@ func NewLoginInitiated(ctx context.Context, flowID uuid.UUID, flowType string, r
 		trace.WithAttributes(attrs...)
 }
 
-func NewRegistrationInitiated(ctx context.Context, flowID uuid.UUID, flowType string, organizationID uuid.UUID) (string, trace.EventOption) {
+func NewRegistrationInitiated(ctx context.Context, flowID uuid.UUID, flowType string, organizationID uuid.NullUUID) (string, trace.EventOption) {
+	attrs := append(semconv.AttributesFromContext(ctx),
+		attrFlowID(flowID),
+		attrSelfServiceFlowType(flowType),
+	)
+
+	if organizationID.Valid {
+		attrs = append(attrs,
+			attrOrganizationID(organizationID.UUID.String()))
+	}
+
 	return RegistrationInitiated.String(),
-		trace.WithAttributes(
-			append(
-				semconv.AttributesFromContext(ctx),
-				attrFlowID(flowID),
-				attrSelfServiceFlowType(flowType),
-			)...,
-		)
+		trace.WithAttributes(attrs...)
 }
 
 func reasonForError(err error) string {


### PR DESCRIPTION
<!--

This text will be used for the merge commit.

Please read https://www.notion.so/Merging-PRs-998760750c5740debdb6d7ea1661ac01

-->

**Changes:**
- Add `LoginStarted` and `RegistrationStarted` events along their required attributes
- Sort all event attributes alphabetically
- Emit these events when a new login/registration flow is created, *after* basic validation passed
- It is unclear yet how many of these events will be emitted, as such it is suggested that in a first phase, they remain internal and are not yet sent externally to avoid surprises (note: sometimes, these events can be emitted without user action such as simply visiting/being redirected to the sign-in page, etc)

**Documentation PR:** [ory/docs#2144](https://github.com/ory/docs/pull/2144)

**Issue:** https://github.com/ory-corp/cloud/issues/7895

<!-- Dependency update: https://github.com/ory/{repo}/compare/{old-commit-hash}...{new-commit-hash} -->


Examples in Grafana:
- LoginStarted: <img width="955" alt="Screenshot 2025-05-06 at 14 54 32" src="https://github.com/user-attachments/assets/f066f0a7-4b03-4f71-b6e9-385c3f772425" />
- RegistrationStarted: <img width="953" alt="Screenshot 2025-05-06 at 14 46 17" src="https://github.com/user-attachments/assets/e4e07f59-ecbb-4bfb-a01e-72412adca2f5" />

