### PR TITLE
feat: emit events on jsonnet failure when templating a jwt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ docs/swagger:
 	touch -a -m .bin/buf
 
 .PHONY: lint
-lint: .bin/golangci-lint
+lint: .bin/golangci-lint .bin/buf
 	.bin/golangci-lint run -v --timeout 10m ./...
 	.bin/buf lint
 

--- a/persistence/sql/identity/persister_identity.go
+++ b/persistence/sql/identity/persister_identity.go
@@ -573,8 +573,8 @@ func (p *IdentityPersister) CreateIdentities(ctx context.Context, identities ...
 		p.normalizeAllAddressess(ctx, identities...)
 
 		if err = p.createVerifiableAddresses(ctx, tx, identities...); err != nil {
-			if paritalErr := new(batch.PartialConflictError[identity.VerifiableAddress]); errors.As(err, &paritalErr) {
-				for _, k := range paritalErr.Failed {
+			if partialErr := new(batch.PartialConflictError[identity.VerifiableAddress]); errors.As(err, &partialErr) {
+				for _, k := range partialErr.Failed {
 					failedIdentityIDs[k.IdentityID] = struct{}{}
 				}
 			} else {
@@ -582,8 +582,8 @@ func (p *IdentityPersister) CreateIdentities(ctx context.Context, identities ...
 			}
 		}
 		if err = p.createRecoveryAddresses(ctx, tx, identities...); err != nil {
-			if paritalErr := new(batch.PartialConflictError[identity.RecoveryAddress]); errors.As(err, &paritalErr) {
-				for _, k := range paritalErr.Failed {
+			if partialErr := new(batch.PartialConflictError[identity.RecoveryAddress]); errors.As(err, &partialErr) {
+				for _, k := range partialErr.Failed {
 					failedIdentityIDs[k.IdentityID] = struct{}{}
 				}
 			} else {
@@ -591,12 +591,12 @@ func (p *IdentityPersister) CreateIdentities(ctx context.Context, identities ...
 			}
 		}
 		if err = p.createIdentityCredentials(ctx, tx, identities...); err != nil {
-			if paritalErr := new(batch.PartialConflictError[identity.Credentials]); errors.As(err, &paritalErr) {
-				for _, k := range paritalErr.Failed {
+			if partialErr := new(batch.PartialConflictError[identity.Credentials]); errors.As(err, &partialErr) {
+				for _, k := range partialErr.Failed {
 					failedIdentityIDs[k.IdentityID] = struct{}{}
 				}
-			} else if paritalErr := new(batch.PartialConflictError[identity.CredentialIdentifier]); errors.As(err, &paritalErr) {
-				for _, k := range paritalErr.Failed {
+			} else if partialErr := new(batch.PartialConflictError[identity.CredentialIdentifier]); errors.As(err, &partialErr) {
+				for _, k := range partialErr.Failed {
 					credID := k.IdentityCredentialsID
 					for _, ident := range identities {
 						for _, cred := range ident.Credentials {

--- a/persistence/sql/identity/persister_identity.go
+++ b/persistence/sql/identity/persister_identity.go
@@ -1133,6 +1133,8 @@ func (p *IdentityPersister) DeleteIdentity(ctx context.Context, id uuid.UUID) (e
 	return nil
 }
 
+// This function is only used internally to cleanup inconsistent database state.
+// This should not be visible externally and thus we do not emit an event.
 func (p *IdentityPersister) DeleteIdentities(ctx context.Context, ids []uuid.UUID) (err error) {
 	stringIDs := make([]string, len(ids))
 	for k, id := range ids {

--- a/persistence/sql/identity/persister_identity.go
+++ b/persistence/sql/identity/persister_identity.go
@@ -1129,8 +1129,9 @@ func (p *IdentityPersister) DeleteIdentity(ctx context.Context, id uuid.UUID) (e
 	return nil
 }
 
-// This function is only used internally to cleanup inconsistent database state.
-// This should not be visible externally and thus we do not emit an event.
+// This function is only used internally to cleanup partially created identities,
+// when creating a batch of identities at once and some failed to be fully created.
+// This act should not be observable externally and thus we do not emit an event.
 func (p *IdentityPersister) DeleteIdentities(ctx context.Context, ids []uuid.UUID) (err error) {
 	stringIDs := make([]string, len(ids))
 	for k, id := range ids {

--- a/persistence/sql/identity/persister_identity.go
+++ b/persistence/sql/identity/persister_identity.go
@@ -1044,18 +1044,14 @@ func (p *IdentityPersister) UpdateIdentityColumns(ctx context.Context, i *identi
 			attribute.Stringer("network.id", p.NetworkID(ctx))))
 	defer otelx.End(span, &err)
 
-	var affectedRows int64
 	if err := p.Transaction(ctx, func(ctx context.Context, tx *pop.Connection) error {
-		var err error
-		affectedRows, err = tx.Where("id = ? AND nid = ?", i.ID, p.NetworkID(ctx)).UpdateQuery(i, columns...)
+		_, err := tx.Where("id = ? AND nid = ?", i.ID, p.NetworkID(ctx)).UpdateQuery(i, columns...)
 		return sqlcon.HandleError(err)
 	}); err != nil {
 		return err
 	}
 
-	if affectedRows != 0 {
-		span.AddEvent(events.NewIdentityUpdated(ctx, i.ID))
-	}
+	span.AddEvent(events.NewIdentityUpdated(ctx, i.ID))
 	return nil
 }
 

--- a/persistence/sql/identity/persister_identity.go
+++ b/persistence/sql/identity/persister_identity.go
@@ -1129,10 +1129,11 @@ func (p *IdentityPersister) DeleteIdentity(ctx context.Context, id uuid.UUID) (e
 	return nil
 }
 
-// This function is only used internally to cleanup partially created identities,
-// when creating a batch of identities at once and some failed to be fully created.
-// This act should not be observable externally and thus we do not emit an event.
 func (p *IdentityPersister) DeleteIdentities(ctx context.Context, ids []uuid.UUID) (err error) {
+	// This function is only used internally to cleanup partially created identities,
+	// when creating a batch of identities at once and some failed to be fully created.
+	// This act should not be observable externally and thus we do not emit an event.
+
 	stringIDs := make([]string, len(ids))
 	for k, id := range ids {
 		stringIDs[k] = id.String()

--- a/selfservice/hook/verification.go
+++ b/selfservice/hook/verification.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/tidwall/sjson"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/ory/x/otelx/semconv"
 
@@ -76,8 +77,7 @@ func (e *Verifier) ExecuteLoginPostHook(w http.ResponseWriter, r *http.Request, 
 	r = r.WithContext(ctx)
 	defer otelx.End(span, &err)
 	if f.RequestedAAL != identity.AuthenticatorAssuranceLevel1 {
-		// NOTE: This is a debug event thus not using a documented event name.
-		span.AddEvent("Skipping verification hook because AAL is not 1")
+		span.SetAttributes(attribute.String("skip_reason", "skipping verification hook because AAL is not 1"))
 		return nil
 	}
 

--- a/selfservice/hook/verification.go
+++ b/selfservice/hook/verification.go
@@ -76,7 +76,7 @@ func (e *Verifier) ExecuteLoginPostHook(w http.ResponseWriter, r *http.Request, 
 	r = r.WithContext(ctx)
 	defer otelx.End(span, &err)
 	if f.RequestedAAL != identity.AuthenticatorAssuranceLevel1 {
-		// NOTE: This is a debug event thus not using a document event name.
+		// NOTE: This is a debug event thus not using a documented event name.
 		span.AddEvent("Skipping verification hook because AAL is not 1")
 		return nil
 	}

--- a/selfservice/hook/verification.go
+++ b/selfservice/hook/verification.go
@@ -76,7 +76,7 @@ func (e *Verifier) ExecuteLoginPostHook(w http.ResponseWriter, r *http.Request, 
 	r = r.WithContext(ctx)
 	defer otelx.End(span, &err)
 	if f.RequestedAAL != identity.AuthenticatorAssuranceLevel1 {
-		// NOTE: Debug event thus not using a document event name.
+		// NOTE: This is a debug event thus not using a document event name.
 		span.AddEvent("Skipping verification hook because AAL is not 1")
 		return nil
 	}

--- a/selfservice/hook/verification.go
+++ b/selfservice/hook/verification.go
@@ -76,6 +76,7 @@ func (e *Verifier) ExecuteLoginPostHook(w http.ResponseWriter, r *http.Request, 
 	r = r.WithContext(ctx)
 	defer otelx.End(span, &err)
 	if f.RequestedAAL != identity.AuthenticatorAssuranceLevel1 {
+		// NOTE: Debug event thus not using a document event name.
 		span.AddEvent("Skipping verification hook because AAL is not 1")
 		return nil
 	}

--- a/session/tokenizer.go
+++ b/session/tokenizer.go
@@ -123,11 +123,17 @@ func (s *Tokenizer) TokenizeSession(ctx context.Context, template string, sessio
 		}
 		evaluated, err := vm.EvaluateAnonymousSnippet(tpl.ClaimsMapperURL, jsonnet.String())
 		if err != nil {
+			trace.SpanFromContext(ctx).AddEvent(events.NewJsonnetMappingFailed(
+				ctx, err, jsonnet.Bytes(), evaluated, "", "",
+			))
 			return errors.WithStack(herodot.ErrBadRequest.WithWrap(err).WithDebug(err.Error()).WithReasonf("Unable to execute tokenizer JsonNet."))
 		}
 
 		evaluatedClaims := gjson.Get(evaluated, "claims")
 		if !evaluatedClaims.IsObject() {
+			trace.SpanFromContext(ctx).AddEvent(events.NewJsonnetMappingFailed(
+				ctx, err, jsonnet.Bytes(), evaluated, "", "",
+			))
 			return errors.WithStack(herodot.ErrBadRequest.WithWrap(err).WithReasonf("Expected tokenizer JsonNet to return a claims object but it did not."))
 		}
 


### PR DESCRIPTION
- Fix typo: parital -> partial
- Document with comments why an event is not emitted or not documented
- Emit `JsonnetMappingFailed` events on jsonnet failure when templating a jwt (see https://www.ory.sh/docs/identities/session-to-jwt-cors). After review it seems we otherwise always emit events in all the right places, except in this very case. Tested end-to-end manually with the UI.

## Related issue(s)

https://github.com/ory-corp/cloud/issues/7291

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

