### PR TITLE
fix: use default group for signup nodes in oidc

### DIFF
--- a/driver/config/config.go
+++ b/driver/config/config.go
@@ -121,6 +121,7 @@ const (
 	ViperKeySessionWhoAmICachingMaxAge                       = "feature_flags.cacheable_sessions_max_age"
 	ViperKeyUseContinueWithTransitions                       = "feature_flags.use_continue_with_transitions"
 	ViperKeyUseLegacyShowVerificationUI                      = "feature_flags.legacy_continue_with_verification_ui"
+	ViperKeyLegacyOIDCRegistrationGroup                      = "feature_flags.legacy_oidc_registration_node_group"
 	ViperKeySessionRefreshMinTimeLeft                        = "session.earliest_possible_extend"
 	ViperKeyCookieSameSite                                   = "cookies.same_site"
 	ViperKeyCookieDomain                                     = "cookies.domain"
@@ -704,6 +705,10 @@ func (p *Config) SelfServiceFlowRegistrationPasswordMethodProfileGroup(ctx conte
 	default:
 		return "default"
 	}
+}
+
+func (p *Config) SelfServiceLegacyOIDCRegistrationGroup(ctx context.Context) bool {
+	return p.GetProvider(ctx).Bool(ViperKeyLegacyOIDCRegistrationGroup)
 }
 
 func (p *Config) SelfServiceFlowRegistrationTwoSteps(ctx context.Context) bool {

--- a/embedx/config.schema.json
+++ b/embedx/config.schema.json
@@ -3314,9 +3314,15 @@
         },
         "password_profile_registration_node_group": {
           "title": "Registration node group",
-          "description": "The node group to use for registration flows. Previously, the node group for the password method's profile fields was `password`. Going forward, it will be `default`. This switch can toggle between those two for backwards compatibility",
+          "description": "The node group to use for registration flows. Previously, the node group for the password method's profile fields was `password`. Going forward, it will be `default`. This switch can toggle between those two for backwards compatibility.",
           "enum": ["password", "default"],
           "default": "default"
+        },
+        "legacy_oidc_registration_node_group": {
+          "title": "Registration node group for OIDC",
+          "description": "The node group to use for registration flows. Previously, the node group for the oidc method's profile fields was `odic`. Going forward, it will be `default`. This switch can toggle between those two for backwards compatibility and will be removed in the future.",
+          "default": false,
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/selfservice/strategy/oidc/strategy.go
+++ b/selfservice/strategy/oidc/strategy.go
@@ -692,19 +692,24 @@ func (s *Strategy) HandleError(ctx context.Context, w http.ResponseWriter, r *ht
 		rf.UI.SetCSRF(s.d.GenerateCSRFToken(r))
 		AddProvider(rf.UI, usedProviderID, text.NewInfoRegistrationContinue(), s.ID())
 
+		group := node.DefaultGroup
+		if s.d.Config().SelfServiceLegacyOIDCRegistrationGroup(ctx) {
+			group = node.OpenIDConnectGroup
+		}
+
 		if traits != nil {
 			ds, err := s.d.Config().DefaultIdentityTraitsSchemaURL(ctx)
 			if err != nil {
 				return err
 			}
 
-			traitNodes, err := container.NodesFromJSONSchema(ctx, node.OpenIDConnectGroup, ds.String(), "", nil)
+			traitNodes, err := container.NodesFromJSONSchema(ctx, group, ds.String(), "", nil)
 			if err != nil {
 				return err
 			}
 
 			rf.UI.Nodes = append(rf.UI.Nodes, traitNodes...)
-			rf.UI.UpdateNodeValuesFromJSON(traits, "traits", node.OpenIDConnectGroup)
+			rf.UI.UpdateNodeValuesFromJSON(traits, "traits", group)
 		}
 
 		return err

--- a/selfservice/strategy/oidc/strategy_login.go
+++ b/selfservice/strategy/oidc/strategy_login.go
@@ -111,7 +111,7 @@ func (s *Strategy) handleConflictingIdentity(ctx context.Context, w http.Respons
 	}
 	// Validate the identity itself
 	if err := s.d.IdentityValidator().Validate(ctx, newIdentity); err != nil {
-		return ConflictingIdentityVerdictUnknown, nil, nil, s.HandleError(ctx, w, r, loginFlow, provider.Config().ID, newIdentity.Traits, err)
+		return ConflictingIdentityVerdictReject, nil, nil, err
 	}
 
 	for n := range newIdentity.VerifiableAddresses {
@@ -128,7 +128,7 @@ func (s *Strategy) handleConflictingIdentity(ctx context.Context, w http.Respons
 
 	creds, err := identity.NewOIDCLikeCredentials(token, s.ID(), provider.Config().ID, claims.Subject, provider.Config().OrganizationID)
 	if err != nil {
-		return ConflictingIdentityVerdictUnknown, nil, nil, s.HandleError(ctx, w, r, loginFlow, provider.Config().ID, newIdentity.Traits, err)
+		return ConflictingIdentityVerdictUnknown, nil, nil, err
 	}
 
 	newIdentity.SetCredentials(s.ID(), *creds)
@@ -141,11 +141,11 @@ func (s *Strategy) handleConflictingIdentity(ctx context.Context, w http.Respons
 	verdict = s.conflictingIdentityPolicy(ctx, existingIdentity, newIdentity, provider, claims)
 	if verdict == ConflictingIdentityVerdictMerge {
 		if err = existingIdentity.MergeOIDCCredentials(s.ID(), *creds); err != nil {
-			return ConflictingIdentityVerdictUnknown, nil, nil, s.HandleError(ctx, w, r, loginFlow, provider.Config().ID, newIdentity.Traits, err)
+			return ConflictingIdentityVerdictUnknown, nil, nil, err
 		}
 
 		if err = s.d.PrivilegedIdentityPool().UpdateIdentity(ctx, existingIdentity); err != nil {
-			return ConflictingIdentityVerdictUnknown, nil, nil, s.HandleError(ctx, w, r, loginFlow, provider.Config().ID, newIdentity.Traits, err)
+			return ConflictingIdentityVerdictUnknown, nil, nil, err
 		}
 	}
 

--- a/selfservice/strategy/oidc/strategy_login.go
+++ b/selfservice/strategy/oidc/strategy_login.go
@@ -109,9 +109,17 @@ func (s *Strategy) handleConflictingIdentity(ctx context.Context, w http.Respons
 	if err != nil {
 		return ConflictingIdentityVerdictReject, nil, nil, nil
 	}
+
 	// Validate the identity itself
 	if err := s.d.IdentityValidator().Validate(ctx, newIdentity); err != nil {
-		return ConflictingIdentityVerdictReject, nil, nil, nil
+		// We ignore the error here because the claims may not fulfil the requirements
+		// of the identity schema.
+		//
+		// However, this is not a problem because the identity will be merged with the existing
+		// identity and the existing identity will be updated with the new credentials, but not any traits.
+		//
+		// We do need the validation step however, to "hydrate" the verifiable address of the user, which is then
+		// used in subsequent calls to match the existing with the new identity.
 	}
 
 	for n := range newIdentity.VerifiableAddresses {

--- a/selfservice/strategy/oidc/strategy_login.go
+++ b/selfservice/strategy/oidc/strategy_login.go
@@ -111,16 +111,15 @@ func (s *Strategy) handleConflictingIdentity(ctx context.Context, w http.Respons
 	}
 
 	// Validate the identity itself
-	if err := s.d.IdentityValidator().Validate(ctx, newIdentity); err != nil {
-		// We ignore the error here because the claims may not fulfil the requirements
-		// of the identity schema.
-		//
-		// However, this is not a problem because the identity will be merged with the existing
-		// identity and the existing identity will be updated with the new credentials, but not any traits.
-		//
-		// We do need the validation step however, to "hydrate" the verifiable address of the user, which is then
-		// used in subsequent calls to match the existing with the new identity.
-	}
+	// We ignore the error here because the claims may not fulfil the requirements
+	// of the identity schema.
+	//
+	// However, this is not a problem because the identity will be merged with the existing
+	// identity and the existing identity will be updated with the new credentials, but not any traits.
+	//
+	// We do need the validation step however, to "hydrate" the verifiable address of the user, which is then
+	// used in subsequent calls to match the existing with the new identity.
+	_ = s.d.IdentityValidator().Validate(ctx, newIdentity)
 
 	for n := range newIdentity.VerifiableAddresses {
 		verifiable := &newIdentity.VerifiableAddresses[n]

--- a/selfservice/strategy/oidc/strategy_registration.go
+++ b/selfservice/strategy/oidc/strategy_registration.go
@@ -361,7 +361,6 @@ func (s *Strategy) processRegistration(ctx context.Context, w http.ResponseWrite
 }
 
 func (s *Strategy) newIdentityFromClaims(ctx context.Context, claims *Claims, provider Provider, container *AuthCodeContainer) (_ *identity.Identity, _ []VerifiedAddress, err error) {
-
 	fetch := fetcher.NewFetcher(fetcher.WithClient(s.d.HTTPClient(ctx)), fetcher.WithCache(jsonnetCache, 60*time.Minute))
 	jsonnetSnippet, err := fetch.FetchContext(ctx, provider.Config().Mapper)
 	if err != nil {

--- a/test/e2e/profiles/kratos.base.yml
+++ b/test/e2e/profiles/kratos.base.yml
@@ -55,3 +55,4 @@ session:
 
 feature_flags:
   legacy_continue_with_verification_ui: true
+  legacy_oidc_registration_node_group: false


### PR DESCRIPTION
BREAKING CHANGE: Going forward, the node group of fields that are failing validation during oidc sign up are `default` and no longer `oidc`. For now, you can get the legacy behavior back by turning on `feature_flags.legacy_oidc_registration_node_group=true`.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [ ] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
