### PR TITLE
fix: set NoStartTLS when disable_startttls=true

### DIFF
--- a/courier/smtp.go
+++ b/courier/smtp.go
@@ -85,6 +85,12 @@ func NewSMTPClient(deps Dependencies, cfg *config.SMTPConfig) (*SMTPClient, erro
 			dialer.TLSConfig = tlsConfig
 			// Enforcing StartTLS
 			dialer.StartTLSPolicy = gomail.MandatoryStartTLS
+		} else {
+			// Set NoStartTLS to completely disable TLS negotiation when disable_starttls=true.
+			// This is required for development environments and SMTP servers that don't support TLS.
+			// Without this, the default OpportunisticStartTLS would still attempt TLS if the server
+			// advertises STARTTLS capability
+			dialer.StartTLSPolicy = gomail.NoStartTLS
 		}
 	case "smtps":
 		dialer.TLSConfig = tlsConfig

--- a/courier/smtp_test.go
+++ b/courier/smtp_test.go
@@ -73,7 +73,7 @@ func TestNewSMTP(t *testing.T) {
 
 	// Should disable StartTLS completely => dialer.StartTLSPolicy = gomail.NoStartTLS and dialer.SSL = false
 	smtp = setupSMTPClient("smtp://foo:bar@my-server:1234/?disable_starttls=true")
-	assert.Equal(t, smtp.StartTLSPolicy, gomail.NoStartTLS, "StartTLS should be completely disabled")
+	assert.Equal(t, int(smtp.StartTLSPolicy), int(gomail.NoStartTLS), "StartTLS should be completely disabled")
 	assert.Equal(t, smtp.SSL, false, "Implicit TLS should not be enabled")
 
 	// Test cert based SMTP client auth

--- a/courier/smtp_test.go
+++ b/courier/smtp_test.go
@@ -71,9 +71,9 @@ func TestNewSMTP(t *testing.T) {
 	smtp = setupSMTPClient("smtps://foo:bar@my-server:1234/")
 	assert.Equal(t, smtp.SSL, true, "Implicit TLS should be enabled")
 
-	// Should allow cleartext => dialer.StartTLSPolicy = gomail.OpportunisticStartTLS and dialer.SSL = false
+	// Should disable StartTLS completely => dialer.StartTLSPolicy = gomail.NoStartTLS and dialer.SSL = false
 	smtp = setupSMTPClient("smtp://foo:bar@my-server:1234/?disable_starttls=true")
-	assert.Equal(t, smtp.StartTLSPolicy, gomail.OpportunisticStartTLS, "StartTLS is enforced")
+	assert.Equal(t, smtp.StartTLSPolicy, gomail.NoStartTLS, "StartTLS should be completely disabled")
 	assert.Equal(t, smtp.SSL, false, "Implicit TLS should not be enabled")
 
 	// Test cert based SMTP client auth


### PR DESCRIPTION
## Problem

Users configuring SMTP with `disable_starttls=true`  to force plaintext connections (common in development environments) experience connection failures with "unencrypted connection" errors, despite explicitly disabling StartTLS.

## Root Cause
In [smtp.go](https://github.com/ory/kratos/blob/8e369de531af4b653448d19f45ef9e1846f4d0fa/courier/smtp.go#L83C3-L83C14), when `disable_starttls=true` is set, the code correctly skips setting `MandatoryStartTLS` but fails to explicitly set `NoStartTLS`. This leaves the dialer with the default `OpportunisticStartTLS` policy, which still attempts TLS connections when the SMTP server advertises STARTTLS capability.

This can be confuse for users, because they explicite set the disable_starttls to true.

## Solution
Explicitly set `StartTLSPolicy = gomail.NoStartTLS` when `disable_starttls=true to completely disable TLS negotiation attempts.

## Related issue(s)
#4498 

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [ ] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [X] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
