### PR TITLE
fix: remove redundant ORDER BY in QueryForCredentials

### DIFF
--- a/persistence/sql/identity/persister_identity.go
+++ b/persistence/sql/identity/persister_identity.go
@@ -880,8 +880,6 @@ func QueryForCredentials(con *pop.Connection, where ...Where) (credentialsPerIde
 		"identity_credentials.updated_at",
 	).LeftJoin(identifiersTableNameWithIndexHint(con),
 		"identity_credential_identifiers.identity_credential_id = identity_credentials.id AND identity_credential_identifiers.nid = identity_credentials.nid",
-	).Order(
-		"identity_credential_identifiers.identifier ASC",
 	)
 	for _, w := range where {
 		q = q.Where("("+w.Condition+")", w.Args...)


### PR DESCRIPTION
The database-level ORDER BY is redundant since identifiers are already sorted in-memory (line 917-921 in persistence/sql/identity/persister_identity.go)  Removing this improves PostgreSQL performance as it cannot use index hints.

Fixes #4520

## Related issue(s)

Fixes #4520

This PR addresses a performance regression reported after upgrading from v1.3.0 to v25.4.0. Users observed:
- Significantly higher P95/P99 latencies for credential queries on PostgreSQL
- Increased database CPU usage

**Root cause**: The `ORDER BY identifier ASC` clause in [QueryForCredentials](cci:1://file:///Users/wangyinhe/Desktop/projects/kratos-v25.4.0/kratos/persistence/sql/identity/persister_identity.go:868:0-929:1) is redundant because identifiers are already sorted in-memory using `sort.Strings()`. Additionally, PostgreSQL cannot use index hints (unlike MySQL/CockroachDB/SQLite), causing the optimizer to potentially choose suboptimal execution plans.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I am following the [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

This is a minimal fix that removes redundant database sorting. The in-memory `sort.Strings()` already guarantees deterministic ordering for testing purposes (as noted in the existing code comment).

No new tests are added because:
1. Existing tests already verify the correctness of credential retrieval
2. The change only removes redundant sorting - the final result remains identical
3. This is a performance optimization, not a behavioral change