### PR TITLE
feat: allow using identity external_id as oauth2 subject

### DIFF
--- a/driver/config/config.go
+++ b/driver/config/config.go
@@ -192,7 +192,7 @@ const (
 	ViperKeyOAuth2ProviderURL                                = "oauth2_provider.url"
 	ViperKeyOAuth2ProviderHeader                             = "oauth2_provider.headers"
 	ViperKeyOAuth2ProviderOverrideReturnTo                   = "oauth2_provider.override_return_to"
-	ViperKeyOAuth2ProviderUseExternalID                      = "oauth2_provider.use_external_id"
+	ViperKeyOAuth2ProviderSubjectSource                      = "oauth2_provider.subject_source"
 	ViperKeyClientHTTPNoPrivateIPRanges                      = "clients.http.disallow_private_ip_ranges"
 	ViperKeyClientHTTPPrivateIPExceptionURLs                 = "clients.http.private_ip_exception_urls"
 	ViperKeyWebhookHeaderAllowlist                           = "clients.web_hook.header_allowlist"
@@ -961,8 +961,8 @@ func (p *Config) OAuth2ProviderOverrideReturnTo(ctx context.Context) bool {
 	return p.GetProvider(ctx).Bool(ViperKeyOAuth2ProviderOverrideReturnTo)
 }
 
-func (p *Config) OAuth2ProviderUseExternalID(ctx context.Context) bool {
-	return p.GetProvider(ctx).Bool(ViperKeyOAuth2ProviderUseExternalID)
+func (p *Config) OAuth2ProviderSubjectSource(ctx context.Context) string {
+	return p.GetProvider(ctx).String(ViperKeyOAuth2ProviderSubjectSource)
 }
 
 func (p *Config) OAuth2ProviderURL(ctx context.Context) *url.URL {

--- a/driver/config/config.go
+++ b/driver/config/config.go
@@ -192,6 +192,7 @@ const (
 	ViperKeyOAuth2ProviderURL                                = "oauth2_provider.url"
 	ViperKeyOAuth2ProviderHeader                             = "oauth2_provider.headers"
 	ViperKeyOAuth2ProviderOverrideReturnTo                   = "oauth2_provider.override_return_to"
+	ViperKeyOAuth2ProviderUseExternalID                      = "oauth2_provider.use_external_id"
 	ViperKeyClientHTTPNoPrivateIPRanges                      = "clients.http.disallow_private_ip_ranges"
 	ViperKeyClientHTTPPrivateIPExceptionURLs                 = "clients.http.private_ip_exception_urls"
 	ViperKeyWebhookHeaderAllowlist                           = "clients.web_hook.header_allowlist"
@@ -958,6 +959,10 @@ func (p *Config) OAuth2ProviderHeader(ctx context.Context) http.Header {
 
 func (p *Config) OAuth2ProviderOverrideReturnTo(ctx context.Context) bool {
 	return p.GetProvider(ctx).Bool(ViperKeyOAuth2ProviderOverrideReturnTo)
+}
+
+func (p *Config) OAuth2ProviderUseExternalID(ctx context.Context) bool {
+	return p.GetProvider(ctx).Bool(ViperKeyOAuth2ProviderUseExternalID)
 }
 
 func (p *Config) OAuth2ProviderURL(ctx context.Context) *url.URL {

--- a/driver/config/config_test.go
+++ b/driver/config/config_test.go
@@ -1299,6 +1299,7 @@ func TestOAuth2Provider(t *testing.T) {
 		assert.Equal(t, "https://oauth2_provider/", conf.OAuth2ProviderURL(ctx).String())
 		assert.Equal(t, http.Header{"Authorization": {"Basic"}}, conf.OAuth2ProviderHeader(ctx))
 		assert.True(t, conf.OAuth2ProviderOverrideReturnTo(ctx))
+		assert.True(t, conf.OAuth2ProviderUseExternalID(ctx))
 	})
 
 	t.Run("case=defaults", func(t *testing.T) {
@@ -1306,6 +1307,7 @@ func TestOAuth2Provider(t *testing.T) {
 		assert.Empty(t, conf.OAuth2ProviderURL(ctx))
 		assert.Empty(t, conf.OAuth2ProviderHeader(ctx))
 		assert.False(t, conf.OAuth2ProviderOverrideReturnTo(ctx))
+		assert.False(t, conf.OAuth2ProviderUseExternalID(ctx))
 	})
 }
 

--- a/driver/config/config_test.go
+++ b/driver/config/config_test.go
@@ -1299,7 +1299,7 @@ func TestOAuth2Provider(t *testing.T) {
 		assert.Equal(t, "https://oauth2_provider/", conf.OAuth2ProviderURL(ctx).String())
 		assert.Equal(t, http.Header{"Authorization": {"Basic"}}, conf.OAuth2ProviderHeader(ctx))
 		assert.True(t, conf.OAuth2ProviderOverrideReturnTo(ctx))
-		assert.True(t, conf.OAuth2ProviderUseExternalID(ctx))
+		assert.Equal(t, "external_id", conf.OAuth2ProviderSubjectSource(ctx))
 	})
 
 	t.Run("case=defaults", func(t *testing.T) {
@@ -1307,7 +1307,7 @@ func TestOAuth2Provider(t *testing.T) {
 		assert.Empty(t, conf.OAuth2ProviderURL(ctx))
 		assert.Empty(t, conf.OAuth2ProviderHeader(ctx))
 		assert.False(t, conf.OAuth2ProviderOverrideReturnTo(ctx))
-		assert.False(t, conf.OAuth2ProviderUseExternalID(ctx))
+		assert.Equal(t, "id", conf.OAuth2ProviderSubjectSource(ctx))
 	})
 }
 

--- a/driver/config/stub/.kratos.oauth2_provider.yaml
+++ b/driver/config/stub/.kratos.oauth2_provider.yaml
@@ -3,3 +3,4 @@ oauth2_provider:
   headers:
     Authorization: Basic
   override_return_to: true
+  use_external_id: true

--- a/driver/config/stub/.kratos.oauth2_provider.yaml
+++ b/driver/config/stub/.kratos.oauth2_provider.yaml
@@ -3,4 +3,4 @@ oauth2_provider:
   headers:
     Authorization: Basic
   override_return_to: true
-  use_external_id: true
+  subject_source: external_id

--- a/embedx/config.schema.json
+++ b/embedx/config.schema.json
@@ -2285,6 +2285,12 @@
           "type": "boolean",
           "default": false,
           "description": "Override the return_to query parameter with the OAuth2 provider request URL when perfoming an OAuth2 login flow."
+        },
+        "use_external_id": {
+          "title": "Use external_id as subject",
+          "type": "boolean",
+          "default": false,
+          "description": "If set, the external_id of the identity will be used as the subject in the OAuth2 login request. If no external_id is set, the identity ID will be used."
         }
       },
       "additionalProperties": false

--- a/embedx/config.schema.json
+++ b/embedx/config.schema.json
@@ -2286,11 +2286,12 @@
           "default": false,
           "description": "Override the return_to query parameter with the OAuth2 provider request URL when perfoming an OAuth2 login flow."
         },
-        "use_external_id": {
-          "title": "Use external_id as subject",
-          "type": "boolean",
-          "default": false,
-          "description": "If set, the external_id of the identity will be used as the subject in the OAuth2 login request. If no external_id is set, the identity ID will be used."
+        "subject_source": {
+          "title": "Subject source for OAuth2 login",
+          "type": "string",
+          "enum": ["id", "external_id"],
+          "default": "id",
+          "description": "Determines which identifier to use as the subject in OAuth2 login requests. Can be either 'id' (identity ID, default) or 'external_id' (identity's external ID). If 'external_id' is selected but not set on the identity, an error will be returned."
         }
       },
       "additionalProperties": false

--- a/hydra/fake.go
+++ b/hydra/fake.go
@@ -22,6 +22,11 @@ var ErrFakeAcceptLoginRequestFailed = errors.New("failed to accept login request
 type FakeHydra struct {
 	Skip       bool
 	RequestURL string
+	params     []AcceptLoginRequestParams
+}
+
+func (h *FakeHydra) Params() []AcceptLoginRequestParams {
+	return h.params
 }
 
 var _ Hydra = &FakeHydra{}
@@ -33,6 +38,7 @@ func NewFake() *FakeHydra {
 }
 
 func (h *FakeHydra) AcceptLoginRequest(_ context.Context, params AcceptLoginRequestParams) (string, error) {
+	h.params = append(h.params, params)
 	if params.SessionID == "" {
 		return "", errors.New("session id must not be empty")
 	}

--- a/hydra/fake.go
+++ b/hydra/fake.go
@@ -20,13 +20,16 @@ const (
 var ErrFakeAcceptLoginRequestFailed = errors.New("failed to accept login request")
 
 type FakeHydra struct {
-	Skip       bool
-	RequestURL string
-	params     []AcceptLoginRequestParams
+	Skip          bool
+	RequestURL    string
+	SubjectSource string
+	params        []AcceptLoginRequestParams
 }
 
 func (h *FakeHydra) Params() []AcceptLoginRequestParams {
-	return h.params
+	out := make([]AcceptLoginRequestParams, len(h.params))
+	copy(out, h.params)
+	return out
 }
 
 var _ Hydra = &FakeHydra{}
@@ -42,6 +45,19 @@ func (h *FakeHydra) AcceptLoginRequest(_ context.Context, params AcceptLoginRequ
 	if params.SessionID == "" {
 		return "", errors.New("session id must not be empty")
 	}
+
+	// Validate subject source just like DefaultHydra does
+	switch h.SubjectSource {
+	case "", "id":
+		// Use identity ID - no validation needed
+	case "external_id":
+		if params.ExternalID == "" {
+			return "", herodot.ErrBadRequest.WithReasonf("The identity does not have an external ID set, but it is required for the OAuth2 provider subject.")
+		}
+	default:
+		return "", herodot.ErrBadRequest.WithReasonf("Unknown OAuth2 provider subject source %q", h.SubjectSource)
+	}
+
 	switch params.LoginChallenge {
 	case FakeInvalidLoginChallenge:
 		return "", ErrFakeAcceptLoginRequestFailed

--- a/hydra/hydra.go
+++ b/hydra/hydra.go
@@ -30,6 +30,7 @@ type (
 	AcceptLoginRequestParams struct {
 		LoginChallenge        string
 		IdentityID            string
+		ExternalID            string
 		SessionID             string
 		AuthenticationMethods session.AuthenticationMethods
 	}
@@ -93,7 +94,12 @@ func (h *DefaultHydra) AcceptLoginRequest(ctx context.Context, params AcceptLogi
 	remember := h.d.Config().SessionPersistentCookie(ctx)
 	rememberFor := int64(h.d.Config().SessionLifespan(ctx) / time.Second)
 
-	alr := hydraclientgo.NewAcceptOAuth2LoginRequest(params.IdentityID)
+	subject := params.IdentityID
+	if h.d.Config().OAuth2ProviderUseExternalID(ctx) && params.ExternalID != "" {
+		subject = params.ExternalID
+	}
+
+	alr := hydraclientgo.NewAcceptOAuth2LoginRequest(subject)
 	alr.IdentityProviderSessionId = &params.SessionID
 	alr.Remember = &remember
 	alr.RememberFor = &rememberFor

--- a/hydra/hydra.go
+++ b/hydra/hydra.go
@@ -94,9 +94,17 @@ func (h *DefaultHydra) AcceptLoginRequest(ctx context.Context, params AcceptLogi
 	remember := h.d.Config().SessionPersistentCookie(ctx)
 	rememberFor := int64(h.d.Config().SessionLifespan(ctx) / time.Second)
 
-	subject := params.IdentityID
-	if h.d.Config().OAuth2ProviderUseExternalID(ctx) && params.ExternalID != "" {
+	var subject string
+	switch h.d.Config().OAuth2ProviderSubjectSource(ctx) {
+	case "", "id":
+		subject = params.IdentityID
+	case "external_id":
+		if params.ExternalID == "" {
+			return "", errors.WithStack(herodot.ErrBadRequest.WithReasonf("The identity does not have an external ID set, but it is required for the OAuth2 provider subject."))
+		}
 		subject = params.ExternalID
+	default:
+		return "", errors.WithStack(herodot.ErrBadRequest.WithReasonf("Unknown OAuth2 provider subject source %q", h.d.Config().OAuth2ProviderSubjectSource(ctx)))
 	}
 
 	alr := hydraclientgo.NewAcceptOAuth2LoginRequest(subject)

--- a/selfservice/flow/login/hook.go
+++ b/selfservice/flow/login/hook.go
@@ -319,6 +319,7 @@ func (e *HookExecutor) PostLoginHook(
 				hydra.AcceptLoginRequestParams{
 					LoginChallenge:        string(f.OAuth2LoginChallenge),
 					IdentityID:            i.ID.String(),
+					ExternalID:            string(i.ExternalID),
 					SessionID:             s.ID.String(),
 					AuthenticationMethods: s.AMR,
 				})
@@ -373,6 +374,7 @@ func (e *HookExecutor) PostLoginHook(
 			hydra.AcceptLoginRequestParams{
 				LoginChallenge:        string(f.OAuth2LoginChallenge),
 				IdentityID:            i.ID.String(),
+				ExternalID:            string(i.ExternalID),
 				SessionID:             s.ID.String(),
 				AuthenticationMethods: s.AMR,
 			})

--- a/selfservice/flow/login/hook_external_id_test.go
+++ b/selfservice/flow/login/hook_external_id_test.go
@@ -1,0 +1,88 @@
+// Copyright © 2026 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package login_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ory/kratos/driver/config"
+	"github.com/ory/kratos/hydra"
+	"github.com/ory/kratos/identity"
+	"github.com/ory/kratos/internal"
+	"github.com/ory/kratos/internal/testhelpers"
+	"github.com/ory/kratos/selfservice/flow"
+	"github.com/ory/kratos/selfservice/flow/login"
+	"github.com/ory/kratos/session"
+	"github.com/ory/x/sqlxx"
+)
+
+func TestLoginExecutorWithExternalID(t *testing.T) {
+	ctx := context.Background()
+	conf, reg := internal.NewFastRegistryWithMocks(t)
+	fakeHydra := hydra.NewFake()
+	reg.SetHydra(fakeHydra)
+
+	testhelpers.SetDefaultIdentitySchema(conf, "file://./stub/login.schema.json")
+	conf.MustSet(ctx, config.ViperKeySelfServiceBrowserDefaultReturnTo, "https://www.ory.sh/kratos/return_to")
+	conf.MustSet(ctx, config.ViperKeyOAuth2ProviderURL, "https://hydra.example.com")
+
+	i := &identity.Identity{
+		ID:         uuid.Must(uuid.NewV4()),
+		ExternalID: sqlxx.NullString("external-id"),
+		SchemaID:   config.DefaultIdentityTraitsSchemaID,
+		State:      identity.StateActive,
+	}
+	require.NoError(t, reg.Persister().CreateIdentity(ctx, i))
+
+	t.Run("case=use_external_id=false", func(t *testing.T) {
+		conf.MustSet(ctx, config.ViperKeyOAuth2ProviderUseExternalID, false)
+		loginFlow, err := login.NewFlow(conf, time.Minute, hydra.FakeValidLoginChallenge, &http.Request{URL: &url.URL{Path: "/", RawQuery: "login_challenge=" + hydra.FakeValidLoginChallenge}}, flow.TypeBrowser)
+		require.NoError(t, err)
+		loginFlow.OAuth2LoginChallenge = hydra.FakeValidLoginChallenge
+
+		w := httptest.NewRecorder()
+		r := &http.Request{URL: &url.URL{Path: "/login/post"}}
+		sess := session.NewInactiveSession()
+		sess.CompletedLoginFor(identity.CredentialsTypePassword, identity.AuthenticatorAssuranceLevel1)
+
+		err = reg.LoginHookExecutor().PostLoginHook(w, r, identity.CredentialsTypePassword.ToUiNodeGroup(), loginFlow, i, sess, "")
+		require.NoError(t, err)
+
+		require.Len(t, fakeHydra.Params(), 1)
+		assert.Equal(t, i.ID.String(), fakeHydra.Params()[0].IdentityID)
+		assert.Equal(t, "external-id", fakeHydra.Params()[0].ExternalID)
+	})
+
+	t.Run("case=use_external_id=true", func(t *testing.T) {
+		conf.MustSet(ctx, config.ViperKeyOAuth2ProviderUseExternalID, true)
+		loginFlow, err := login.NewFlow(conf, time.Minute, hydra.FakeValidLoginChallenge, &http.Request{URL: &url.URL{Path: "/", RawQuery: "login_challenge=" + hydra.FakeValidLoginChallenge}}, flow.TypeBrowser)
+		require.NoError(t, err)
+		loginFlow.OAuth2LoginChallenge = hydra.FakeValidLoginChallenge
+
+		w := httptest.NewRecorder()
+		r := &http.Request{URL: &url.URL{Path: "/login/post"}}
+		sess := session.NewInactiveSession()
+		sess.CompletedLoginFor(identity.CredentialsTypePassword, identity.AuthenticatorAssuranceLevel1)
+
+		fakeHydra.Params()
+
+		err = reg.LoginHookExecutor().PostLoginHook(w, r, identity.CredentialsTypePassword.ToUiNodeGroup(), loginFlow, i, sess, "")
+		require.NoError(t, err)
+
+		params := fakeHydra.Params()
+		require.NotEmpty(t, params)
+		lastParams := params[len(params)-1]
+		assert.Equal(t, i.ID.String(), lastParams.IdentityID)
+		assert.Equal(t, "external-id", lastParams.ExternalID)
+	})
+}

--- a/selfservice/flow/login/hook_external_id_test.go
+++ b/selfservice/flow/login/hook_external_id_test.go
@@ -18,8 +18,8 @@ import (
 	"github.com/ory/kratos/driver/config"
 	"github.com/ory/kratos/hydra"
 	"github.com/ory/kratos/identity"
-	"github.com/ory/kratos/internal"
-	"github.com/ory/kratos/internal/testhelpers"
+	"github.com/ory/kratos/pkg"
+	"github.com/ory/kratos/pkg/testhelpers"
 	"github.com/ory/kratos/selfservice/flow"
 	"github.com/ory/kratos/selfservice/flow/login"
 	"github.com/ory/kratos/session"
@@ -28,7 +28,7 @@ import (
 
 func TestLoginExecutorWithExternalID(t *testing.T) {
 	ctx := context.Background()
-	conf, reg := internal.NewFastRegistryWithMocks(t)
+	conf, reg := pkg.NewFastRegistryWithMocks(t)
 	fakeHydra := hydra.NewFake()
 	reg.SetHydra(fakeHydra)
 
@@ -44,8 +44,9 @@ func TestLoginExecutorWithExternalID(t *testing.T) {
 	}
 	require.NoError(t, reg.Persister().CreateIdentity(ctx, i))
 
-	t.Run("case=use_external_id=false", func(t *testing.T) {
-		conf.MustSet(ctx, config.ViperKeyOAuth2ProviderUseExternalID, false)
+	t.Run("case=subject_source=id", func(t *testing.T) {
+		conf.MustSet(ctx, config.ViperKeyOAuth2ProviderSubjectSource, "id")
+		fakeHydra.SubjectSource = "id"
 		loginFlow, err := login.NewFlow(conf, time.Minute, hydra.FakeValidLoginChallenge, &http.Request{URL: &url.URL{Path: "/", RawQuery: "login_challenge=" + hydra.FakeValidLoginChallenge}}, flow.TypeBrowser)
 		require.NoError(t, err)
 		loginFlow.OAuth2LoginChallenge = hydra.FakeValidLoginChallenge
@@ -63,8 +64,9 @@ func TestLoginExecutorWithExternalID(t *testing.T) {
 		assert.Equal(t, "external-id", fakeHydra.Params()[0].ExternalID)
 	})
 
-	t.Run("case=use_external_id=true", func(t *testing.T) {
-		conf.MustSet(ctx, config.ViperKeyOAuth2ProviderUseExternalID, true)
+	t.Run("case=subject_source=external_id", func(t *testing.T) {
+		conf.MustSet(ctx, config.ViperKeyOAuth2ProviderSubjectSource, "external_id")
+		fakeHydra.SubjectSource = "external_id"
 		loginFlow, err := login.NewFlow(conf, time.Minute, hydra.FakeValidLoginChallenge, &http.Request{URL: &url.URL{Path: "/", RawQuery: "login_challenge=" + hydra.FakeValidLoginChallenge}}, flow.TypeBrowser)
 		require.NoError(t, err)
 		loginFlow.OAuth2LoginChallenge = hydra.FakeValidLoginChallenge
@@ -74,8 +76,6 @@ func TestLoginExecutorWithExternalID(t *testing.T) {
 		sess := session.NewInactiveSession()
 		sess.CompletedLoginFor(identity.CredentialsTypePassword, identity.AuthenticatorAssuranceLevel1)
 
-		fakeHydra.Params()
-
 		err = reg.LoginHookExecutor().PostLoginHook(w, r, identity.CredentialsTypePassword.ToUiNodeGroup(), loginFlow, i, sess, "")
 		require.NoError(t, err)
 
@@ -84,5 +84,29 @@ func TestLoginExecutorWithExternalID(t *testing.T) {
 		lastParams := params[len(params)-1]
 		assert.Equal(t, i.ID.String(), lastParams.IdentityID)
 		assert.Equal(t, "external-id", lastParams.ExternalID)
+	})
+
+	t.Run("case=subject_source=external_id without external_id set", func(t *testing.T) {
+		iWithoutExtID := &identity.Identity{
+			ID:       uuid.Must(uuid.NewV4()),
+			SchemaID: config.DefaultIdentityTraitsSchemaID,
+			State:    identity.StateActive,
+		}
+		require.NoError(t, reg.Persister().CreateIdentity(ctx, iWithoutExtID))
+
+		conf.MustSet(ctx, config.ViperKeyOAuth2ProviderSubjectSource, "external_id")
+		fakeHydra.SubjectSource = "external_id"
+		loginFlow, err := login.NewFlow(conf, time.Minute, hydra.FakeValidLoginChallenge, &http.Request{URL: &url.URL{Path: "/", RawQuery: "login_challenge=" + hydra.FakeValidLoginChallenge}}, flow.TypeBrowser)
+		require.NoError(t, err)
+		loginFlow.OAuth2LoginChallenge = hydra.FakeValidLoginChallenge
+
+		w := httptest.NewRecorder()
+		r := &http.Request{URL: &url.URL{Path: "/login/post"}}
+		sess := session.NewInactiveSession()
+		sess.CompletedLoginFor(identity.CredentialsTypePassword, identity.AuthenticatorAssuranceLevel1)
+
+		err = reg.LoginHookExecutor().PostLoginHook(w, r, identity.CredentialsTypePassword.ToUiNodeGroup(), loginFlow, iWithoutExtID, sess, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "external ID set")
 	})
 }


### PR DESCRIPTION
## Description

This PR introduces the ability to use an identity's `external_id` as the OpenID Connect `subject` (`sub` claim) when Ory Kratos acts as the identity provider for Ory Hydra.

Previously, Kratos always passed the internal UUID as the subject. For users migrating from legacy systems or integrating with third-party services that rely on specific string identifiers, this new configuration option allows for seamless identity mapping without requiring a custom consent provider middleware.

The logic implements a safe fallback: if the configuration is enabled but an identity does not have an `external_id` set, it will continue to use the Kratos Identity UUID to prevent flow breakage.

## Related issue(s)

Fixes #4528

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I am following the [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

### Solution Choice
I implemented this via a new configuration toggle `oauth2_provider.use_external_id`. This maintains backward compatibility by defaulting to `false`. 

The subject selection logic in `hydra/hydra.go` follows this priority:
1. If `oauth2_provider.use_external_id` is `false`: Use `Identity.ID`.
2. If `oauth2_provider.use_external_id` is `true` AND `Identity.ExternalID` is present: Use `Identity.ExternalID`.
3. If `oauth2_provider.use_external_id` is `true` AND `Identity.ExternalID` is empty: Fallback to `Identity.ID`.

### Alternatives Considered
**Custom Integration Layer:** One could bypass the native Kratos-Hydra integration and handle the `acceptLoginRequest` manually in a custom UI/backend. However, this requires users to write and maintain "glue code" for a very common architectural need. Providing this natively simplifies the Ory stack for enterprise migrations.

### Testing
- Updated `driver/config/config_test.go` to verify schema parsing.
- Updated `hydra/fake.go` to capture and verify parameters.
- Verified that the `PostLoginHook` correctly extracts the `external_id` from the identity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth2 provider supports configurable subject source for login requests—choose identity ID (default) or external ID.

* **Configuration**
  * Added oauth2_provider.subject_source setting ("id" or "external_id", default "id"); selecting external_id requires identities to have an external ID and will error if missing.

* **Tests**
  * Added tests validating subject-source behavior and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->