### PR TITLE
fix: fix 'occured' -> 'occurred' in message_dispatch.go doc comment

### DIFF
--- a/courier/message_dispatch.go
+++ b/courier/message_dispatch.go
@@ -20,7 +20,7 @@ const (
 )
 
 // MessageDispatch represents an attempt of sending a courier message
-// It contains the status of the attempt (failed or successful) and the error if any occured
+// It contains the status of the attempt (failed or successful) and the error if any occurred
 //
 // swagger:model messageDispatch
 type MessageDispatch struct {


### PR DESCRIPTION
Doc comment in `courier/message_dispatch.go` line 23 reads `the error if any occured`. Fixed to `occurred`. Comment-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected a spelling mistake in a code comment to improve clarity and accuracy of internal documentation. No behavioral or API changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->