### PR TITLE
fix: imported totp credentials don't have identifiers

### DIFF
--- a/identity/.snapshots/TestHandler-suite=create_and_update-case=should_update_an_identity_with_totp_credentials.json
+++ b/identity/.snapshots/TestHandler-suite=create_and_update-case=should_update_an_identity_with_totp_credentials.json
@@ -10,7 +10,6 @@
     },
     "totp": {
       "type": "totp",
-      "identifiers": [],
       "config": {
         "totp_url": "totp://example.com?secret=NBSWY3DPEHPK3PXQ\u0026issuer=ORY"
       },

--- a/identity/.snapshots/TestImportTOTPCredentials-new_totp_credential.json
+++ b/identity/.snapshots/TestImportTOTPCredentials-new_totp_credential.json
@@ -1,7 +1,9 @@
 {
   "totp": {
     "type": "totp",
-    "identifiers": null,
+    "identifiers": [
+      "11111111-1111-1111-1111-111111111111"
+    ],
     "config": {
       "totp_url": "otpauth://totp/Example:alice@example.com?secret=JBSWY3DPEHPK3PXP\u0026issuer=Example"
     },

--- a/identity/.snapshots/TestImportTOTPCredentials-update_existing_totp_credential.json
+++ b/identity/.snapshots/TestImportTOTPCredentials-update_existing_totp_credential.json
@@ -1,7 +1,9 @@
 {
   "totp": {
     "type": "totp",
-    "identifiers": null,
+    "identifiers": [
+      "11111111-1111-1111-1111-111111111111"
+    ],
     "config": {
       "totp_url": "otpauth://totp/Example:alice@example.com?secret=NEWSECRET\u0026issuer=Example"
     },

--- a/identity/handler_import.go
+++ b/identity/handler_import.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"slices"
 
+	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 
 	"github.com/ory/herodot"
@@ -181,7 +182,19 @@ func (h *Handler) importLookupSecretCredentials(_ context.Context, i *Identity, 
 }
 
 func (h *Handler) importTOTPCredentials(_ context.Context, i *Identity, creds *AdminIdentityImportCredentialsTOTP) error {
-	return i.SetCredentialsWithConfig(CredentialsTypeTOTP, Credentials{}, CredentialsTOTPConfig{TOTPURL: creds.Config.TOTPURL})
+	if i.ID == uuid.Nil {
+		generated, err := uuid.NewV4()
+		if err != nil {
+			return errors.WithStack(herodot.ErrInternalServerError().WithReasonf("Unable to generate identity ID for TOTP import: %s", err))
+		}
+		i.ID = generated
+	}
+
+	return i.SetCredentialsWithConfig(
+		CredentialsTypeTOTP,
+		Credentials{Identifiers: []string{i.ID.String()}},
+		CredentialsTOTPConfig{TOTPURL: creds.Config.TOTPURL},
+	)
 }
 
 func (h *Handler) ImportPasswordCredentials(ctx context.Context, i *Identity, creds *AdminIdentityImportCredentialsPassword) (err error) {

--- a/identity/handler_import_test.go
+++ b/identity/handler_import_test.go
@@ -715,6 +715,10 @@ func TestImportTOTPCredentials(t *testing.T) {
 	// Setup handler
 	h := &Handler{}
 
+	// Use a fixed identity ID so the credential identifier — and therefore
+	// the snapshot — is deterministic across test runs.
+	identityID := uuid.Must(uuid.FromString("11111111-1111-1111-1111-111111111111"))
+
 	testCases := []struct {
 		name          string
 		setupIdentity func() *Identity
@@ -724,7 +728,7 @@ func TestImportTOTPCredentials(t *testing.T) {
 		{
 			name: "new totp credential",
 			setupIdentity: func() *Identity {
-				return &Identity{}
+				return &Identity{ID: identityID}
 			},
 			credentials: &AdminIdentityImportCredentialsTOTP{
 				Config: AdminIdentityImportCredentialsTOTPConfig{
@@ -739,12 +743,18 @@ func TestImportTOTPCredentials(t *testing.T) {
 				require.NoError(t, json.Unmarshal(creds.Config, &config))
 
 				assert.Equal(t, "otpauth://totp/Example:alice@example.com?secret=JBSWY3DPEHPK3PXP&issuer=Example", config.TOTPURL)
+
+				// The identity UUID must be persisted as the credential
+				// identifier so AAL2 TOTP login can locate the credential
+				// via FindByCredentialsIdentifier. See issue: imported TOTP
+				// credentials returning "You have no TOTP device set up."
+				assert.Equal(t, []string{identityID.String()}, creds.Identifiers)
 			},
 		},
 		{
 			name: "update existing totp credential",
 			setupIdentity: func() *Identity {
-				i := &Identity{}
+				i := &Identity{ID: identityID}
 				err := i.SetCredentialsWithConfig(
 					CredentialsTypeTOTP,
 					Credentials{},
@@ -769,6 +779,8 @@ func TestImportTOTPCredentials(t *testing.T) {
 
 				// Should have the new TOTP URL
 				assert.Equal(t, "otpauth://totp/Example:alice@example.com?secret=NEWSECRET&issuer=Example", config.TOTPURL)
+
+				assert.Equal(t, []string{identityID.String()}, creds.Identifiers)
 			},
 		},
 	}

--- a/identity/handler_test.go
+++ b/identity/handler_test.go
@@ -1036,13 +1036,21 @@ func TestHandler(t *testing.T) {
 			totpConfig = gjson.GetBytes(actual.Credentials[identity.CredentialsTypeTOTP].Config, "totp_url")
 			assert.Equal(t, "totp://example.com?secret=NBSWY3DPEHPK3PXQ&issuer=ORY", totpConfig.String(), "TOTP secret should be updated correctly")
 
+			// The identity UUID must be persisted as the credential identifier
+			// so AAL2 TOTP login can locate the credential via
+			// FindByCredentialsIdentifier.
+			assert.Equal(t, []string{id}, actual.Credentials[identity.CredentialsTypeTOTP].Identifiers)
+
 			// Verify that the traits were also updated
 			assert.Equal(t, "totp-import-updated@ory.sh", gjson.GetBytes(actual.Traits, "email").String())
 
-			// Check full identity using snapshots
+			// Check full identity using snapshots. The TOTP identifier is excluded
+			// from the snapshot because it equals the random identity UUID and is
+			// already asserted explicitly above.
 			snapshotx.SnapshotT(t, identity.WithCredentialsAndAdminMetadataInJSON(*actual),
 				snapshotx.ExceptPaths("id", "schema_url", "state_changed_at", "created_at", "updated_at",
 					"credentials.totp.created_at", "credentials.totp.updated_at",
+					"credentials.totp.identifiers",
 					"credentials.password.created_at", "credentials.password.updated_at"))
 		})
 

--- a/selfservice/strategy/totp/login_test.go
+++ b/selfservice/strategy/totp/login_test.go
@@ -7,7 +7,9 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -47,6 +49,60 @@ func createIdentityWithoutTOTP(ctx context.Context, t *testing.T, reg driver.Reg
 	delete(id.Credentials, identity.CredentialsTypeTOTP)
 	require.NoError(t, reg.PrivilegedIdentityPool().UpdateIdentity(ctx, id))
 	return id
+}
+
+// createIdentityViaAdminImport creates an identity by POSTing to the admin
+// /identities endpoint with imported password and TOTP credentials, mirroring
+// what the admin API does for an external caller. This exercises the
+// handler_import.go importTOTPCredentials code path so we can regress
+// "imported TOTP credentials cannot be used to log in" — see
+// schema.NewNoTOTPDeviceRegistered() in selfservice/strategy/totp/login.go.
+func createIdentityViaAdminImport(ctx context.Context, t *testing.T, reg driver.Registry, adminTS *httptest.Server) (*identity.Identity, string, *otp.Key) {
+	t.Helper()
+
+	identifier := x.NewUUID().String() + "@ory.sh"
+	password := x.NewUUID().String()
+	key, err := totp.NewKey(ctx, "foo", reg)
+	require.NoError(t, err)
+
+	body := identity.CreateIdentityBody{
+		SchemaID: "default",
+		Traits:   []byte(fmt.Sprintf(`{"subject":"%s"}`, identifier)),
+		Credentials: &identity.IdentityWithCredentials{
+			Password: &identity.AdminIdentityImportCredentialsPassword{
+				Config: identity.AdminIdentityImportCredentialsPasswordConfig{
+					Password: password,
+				},
+			},
+			TOTP: &identity.AdminIdentityImportCredentialsTOTP{
+				Config: identity.AdminIdentityImportCredentialsTOTPConfig{
+					TOTPURL: key.URL(),
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, json.NewEncoder(&buf).Encode(body))
+	req, err := http.NewRequest(http.MethodPost, adminTS.URL+"/identities", &buf)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	res, err := adminTS.Client().Do(req)
+	require.NoError(t, err)
+	respBody, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	require.NoError(t, res.Body.Close())
+	require.Equalf(t, http.StatusCreated, res.StatusCode, "%s", respBody)
+
+	id := gjson.GetBytes(respBody, "id").String()
+	require.NotEmpty(t, id)
+
+	identityUUID, err := uuid.FromString(id)
+	require.NoError(t, err)
+
+	created, err := reg.PrivilegedIdentityPool().GetIdentityConfidential(ctx, identityUUID)
+	require.NoError(t, err)
+	return created, password, key
 }
 
 func createIdentity(ctx context.Context, t *testing.T, reg driver.Registry) (*identity.Identity, string, *otp.Key) {
@@ -97,7 +153,7 @@ func TestCompleteLogin(t *testing.T) {
 	conf.MustSet(ctx, config.ViperKeyURLsAllowedReturnToDomains, []string{redirTS.URL + "/return-to-wherever"})
 
 	router := httprouterx.NewTestRouterPublic(t)
-	publicTS, _ := testhelpers.NewKratosServerWithRouters(t, reg, router, httprouterx.NewTestRouterAdminWithPrefix(t))
+	publicTS, adminTS := testhelpers.NewKratosServerWithRouters(t, reg, router, httprouterx.NewTestRouterAdminWithPrefix(t))
 
 	errTS := testhelpers.NewErrorTestServer(t, reg)
 	uiTS := testhelpers.NewLoginUIFlowEchoServer(t, reg)
@@ -362,6 +418,36 @@ func TestCompleteLogin(t *testing.T) {
 			assert.EqualValues(t, flow.ContinueWithActionRedirectBrowserToString, gjson.Get(body, "continue_with.0.action").String(), "%s", body)
 			assert.EqualValues(t, returnTo, gjson.Get(body, "continue_with.0.redirect_browser_to").String(), "%s", body)
 		})
+	})
+
+	// Regression test: TOTP credentials created through the admin import
+	// endpoint must be usable for AAL2 login. Previously
+	// importTOTPCredentials did not set Credentials.Identifiers, so no row
+	// was written into identity_credential_identifiers and the login lookup
+	// in selfservice/strategy/totp/login.go failed with
+	// "You have no TOTP device set up.".
+	t.Run("case=should pass AAL2 login for admin-imported TOTP credentials", func(t *testing.T) {
+		id, _, key := createIdentityViaAdminImport(t.Context(), t, reg, adminTS)
+
+		// Sanity: the identity UUID must have been persisted as the credential
+		// identifier — this is what FindByCredentialsIdentifier joins on.
+		creds, ok := id.GetCredentials(identity.CredentialsTypeTOTP)
+		require.True(t, ok)
+		assert.Equal(t, []string{id.ID.String()}, creds.Identifiers)
+
+		code, err := stdtotp.GenerateCode(key.Secret(), time.Now())
+		require.NoError(t, err)
+		payload := func(v url.Values) {
+			v.Set("totp_code", code)
+		}
+
+		body, _ := doAPIFlow(t, payload, id)
+		assert.True(t, gjson.Get(body, "session.active").Bool(), "%s", body)
+		assert.EqualValues(t, identity.AuthenticatorAssuranceLevel2,
+			gjson.Get(body, "session.authenticator_assurance_level").String(), "%s", body)
+		// The original error message must not appear.
+		assert.NotEqual(t, text.NewErrorValidationNoTOTPDevice().Text,
+			gjson.Get(body, "ui.messages.0.text").String(), "%s", body)
 	})
 
 	t.Run("case=should fail because totp can not handle AAL1", func(t *testing.T) {


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

Closes https://github.com/ory/kratos/issues/4561

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.com/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.com](mailto:security@ory.com)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Imported TOTP credentials now retain the associated identity identifier so admin-imported devices persist correctly and allow successful two-factor (AAL2) logins.

* **Tests**
  * Added/regressed tests verifying admin-imported TOTP credentials persist identifiers and enable complete AAL2 authentication and session creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->