### PR TITLE
docs: fix typo in recovery strategy comment

### DIFF
--- a/oryx/httpx/ssrf.go
+++ b/oryx/httpx/ssrf.go
@@ -11,9 +11,10 @@ import (
 	"time"
 
 	"github.com/gobwas/glob"
-	"github.com/ory/x/ipx"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+
+	"github.com/ory/x/ipx"
 )
 
 var _ http.RoundTripper = (*noInternalIPRoundTripper)(nil)

--- a/oryx/otelx/middleware.go
+++ b/oryx/otelx/middleware.go
@@ -8,8 +8,9 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/ory/x/httprouterx"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+
+	"github.com/ory/x/httprouterx"
 )
 
 var withDefaultFilters = otelhttp.WithFilter(func(r *http.Request) bool {

--- a/oryx/prometheusx/metrics.go
+++ b/oryx/prometheusx/metrics.go
@@ -11,10 +11,11 @@ import (
 	"time"
 
 	grpcPrometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
-	"github.com/ory/x/httprouterx"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/urfave/negroni"
+
+	"github.com/ory/x/httprouterx"
 )
 
 type HTTPMetrics struct {

--- a/oryx/region/region.go
+++ b/oryx/region/region.go
@@ -5,8 +5,9 @@ package region
 import (
 	"database/sql/driver"
 
-	"github.com/ory/herodot"
 	"github.com/pkg/errors"
+
+	"github.com/ory/herodot"
 )
 
 // Region is an Ory Network region. Specific regions map to a single CRDB

--- a/oryx/watcherx/directory.go
+++ b/oryx/watcherx/directory.go
@@ -53,7 +53,7 @@ type directoryWatcher struct {
 	// potentially by external callers (e.g. tests) concurrently.
 	subDirsMtx sync.RWMutex
 	subDirs    map[string]struct{}
-	w       *fsnotify.Watcher
+	w          *fsnotify.Watcher
 }
 
 func (w *directoryWatcher) handleEvent(ctx context.Context, e fsnotify.Event) {

--- a/selfservice/strategy/code/strategy_recovery.go
+++ b/selfservice/strategy/code/strategy_recovery.go
@@ -181,7 +181,7 @@ func (s *Strategy) Recover(w http.ResponseWriter, r *http.Request, f *recovery.F
 			WithRequest(r).
 			Debugf("A recovery flow with `DangerousSkipCSRFCheck` set has been submitted, skipping anti-CSRF measures.")
 	} else if err := flow.EnsureCSRF(s.deps, r, f.Type, s.deps.Config().DisableAPIFlowEnforcement(ctx), s.deps.GenerateCSRFToken, body.CSRFToken); err != nil {
-		// If a CSRF violation occurs the flow is most likely FUBAR, as the user either lost the CSRF token, or an attack occured.
+		// If a CSRF violation occurs the flow is most likely FUBAR, as the user either lost the CSRF token, or an attack occurred.
 		// In this case, we just issue a new flow and "abandon" the old flow.
 		return s.retryRecoveryFlow(w, r, flow.TypeBrowser, RetryWithError(err))
 	}


### PR DESCRIPTION
Fix 'an attack occured' -> 'an attack occurred' in `selfservice/strategy/code/strategy_recovery.go`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed a typo in a comment ("occured" → "occurred") and added a clarifying comment about the CSRF violation outcome.
* **Style**
  * Reordered import groups and applied minor whitespace/formatting tweaks across several modules to improve consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ory/kratos/pull/4565)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->