### PR TITLE
fix: duplicated "the" in clidoc/md_docs and oidc/provider_config comments

### DIFF
--- a/oryx/clidoc/md_docs.go
+++ b/oryx/clidoc/md_docs.go
@@ -144,7 +144,7 @@ func GenMarkdownTree(cmd *cobra.Command, dir string) error {
 	return GenMarkdownTreeCustom(cmd, dir, emptyStr, identity)
 }
 
-// GenMarkdownTreeCustom is the the same as GenMarkdownTree, but
+// GenMarkdownTreeCustom is the same as GenMarkdownTree, but
 // with custom filePrepender and linkHandler.
 func GenMarkdownTreeCustom(cmd *cobra.Command, dir string, filePrepender, linkHandler func(string) string) error {
 	for _, c := range cmd.Commands() {

--- a/selfservice/strategy/oidc/provider_config.go
+++ b/selfservice/strategy/oidc/provider_config.go
@@ -96,7 +96,7 @@ type Configuration struct {
 	// Can be either `userinfo` or `me` or `oid`.
 	// If the value is `userinfo` then the subject identifier is taken from sub field of userinfo standard endpoint response.
 	// If the value is `me` then the `id` field of https://graph.microsoft.com/v1.0/me response is taken as subject.
-	// If the value is `oid` then the the oid (Object ID) is taken to identify users across different services.
+	// If the value is `oid` then the oid (Object ID) is taken to identify users across different services.
 	// The default is `userinfo`.
 	SubjectSource string `json:"subject_source"`
 


### PR DESCRIPTION
Two one-line typo fixes for duplicated "the" in doc-comments:
- `oryx/clidoc/md_docs.go` — "// GenMarkdownTreeCustom is the the same as GenMarkdownTree, but" → "// GenMarkdownTreeCustom is the same as GenMarkdownTree, but"
- `selfservice/strategy/oidc/provider_config.go` — "// If the value is `oid` then the the oid (Object ID) is taken to identify users across different services." → "...then the oid (Object ID) is taken..."

No code/behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected duplicated words in documentation comments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ory/kratos/pull/4567)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->