### PR TITLE
create impossible travel hook and add it to post login and post recovery

### DIFF
--- a/driver/registry_default.go
+++ b/driver/registry_default.go
@@ -93,12 +93,13 @@ type RegistryDefault struct {
 	persister       persistence.Persister
 	migrationStatus popx.MigrationStatuses
 
-	hookVerifier           *hook.Verifier
-	hookSessionIssuer      *hook.SessionIssuer
-	hookSessionDestroyer   *hook.SessionDestroyer
-	hookAddressVerifier    *hook.AddressVerifier
-	hookShowVerificationUI *hook.ShowVerificationUIHook
-	hookVerifyNewAddress   *hook.VerifyNewAddress
+	hookVerifier                        *hook.Verifier
+	hookSessionIssuer                   *hook.SessionIssuer
+	hookSessionDestroyer                *hook.SessionDestroyer
+	hookSessionImpossibleTravelDetector *hook.SessionImpossibleTravelDetector
+	hookAddressVerifier                 *hook.AddressVerifier
+	hookShowVerificationUI              *hook.ShowVerificationUIHook
+	hookVerifyNewAddress                *hook.VerifyNewAddress
 
 	identityHandler        *identity.Handler
 	identityValidator      *identity.Validator

--- a/driver/registry_default_hooks.go
+++ b/driver/registry_default_hooks.go
@@ -35,6 +35,13 @@ func (m *RegistryDefault) HookSessionDestroyer() *hook.SessionDestroyer {
 	return m.hookSessionDestroyer
 }
 
+func (m *RegistryDefault) HookSessionImpossibleTravelDetector() *hook.SessionImpossibleTravelDetector {
+	if m.hookSessionImpossibleTravelDetector == nil {
+		m.hookSessionImpossibleTravelDetector = hook.NewSessionImpossibleTravelDetector()
+	}
+	return m.hookSessionImpossibleTravelDetector
+}
+
 func (m *RegistryDefault) HookAddressVerifier() *hook.AddressVerifier {
 	if m.hookAddressVerifier == nil {
 		m.hookAddressVerifier = hook.NewAddressVerifier(m)
@@ -79,6 +86,10 @@ allHooksLoop:
 			addSessionIssuer = true
 		case hook.KeySessionDestroyer:
 			if h, ok := any(m.HookSessionDestroyer()).(T); ok {
+				hooks = append(hooks, h)
+			}
+		case hook.KeySessionImpossibleTravelDetector:
+			if h, ok := any(m.HookSessionImpossibleTravelDetector()).(T); ok {
 				hooks = append(hooks, h)
 			}
 		case hook.KeyWebHook:

--- a/persistence/sql/migrations/sql/20260517000000000000_add_geolocation_data_to_sessions.cockroach.down.sql
+++ b/persistence/sql/migrations/sql/20260517000000000000_add_geolocation_data_to_sessions.cockroach.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE sessions
+  DROP COLUMN last_location_lat,
+  DROP COLUMN last_location_lon,
+  DROP COLUMN last_location_at,
+  DROP COLUMN impossible_travel;

--- a/persistence/sql/migrations/sql/20260517000000000000_add_geolocation_data_to_sessions.cockroach.up.sql
+++ b/persistence/sql/migrations/sql/20260517000000000000_add_geolocation_data_to_sessions.cockroach.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE sessions
+  ADD COLUMN last_location_lat DECIMAL(10, 8),
+  ADD COLUMN last_location_lon DECIMAL(11, 8),
+  ADD COLUMN last_location_at TIMESTAMP,
+  ADD COLUMN impossible_travel BOOLEAN NOT NULL DEFAULT FALSE;

--- a/persistence/sql/migrations/sql/20260517000000000000_add_geolocation_data_to_sessions.mysql.down.sql
+++ b/persistence/sql/migrations/sql/20260517000000000000_add_geolocation_data_to_sessions.mysql.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE sessions
+  DROP COLUMN last_location_lat,
+  DROP COLUMN last_location_lon,
+  DROP COLUMN last_location_at,
+  DROP COLUMN impossible_travel;

--- a/persistence/sql/migrations/sql/20260517000000000000_add_geolocation_data_to_sessions.mysql.up.sql
+++ b/persistence/sql/migrations/sql/20260517000000000000_add_geolocation_data_to_sessions.mysql.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE sessions
+  ADD COLUMN last_location_lat DECIMAL(10, 8),
+  ADD COLUMN last_location_lon DECIMAL(11, 8),
+  ADD COLUMN last_location_at TIMESTAMP NULL DEFAULT NULL,
+  ADD COLUMN impossible_travel BOOLEAN NOT NULL DEFAULT FALSE;

--- a/persistence/sql/migrations/sql/20260517000000000000_add_geolocation_data_to_sessions.postgres.down.sql
+++ b/persistence/sql/migrations/sql/20260517000000000000_add_geolocation_data_to_sessions.postgres.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE sessions
+  DROP COLUMN last_location_lat,
+  DROP COLUMN last_location_lon,
+  DROP COLUMN last_location_at,
+  DROP COLUMN impossible_travel;

--- a/persistence/sql/migrations/sql/20260517000000000000_add_geolocation_data_to_sessions.postgres.up.sql
+++ b/persistence/sql/migrations/sql/20260517000000000000_add_geolocation_data_to_sessions.postgres.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE sessions
+  ADD COLUMN last_location_lat DECIMAL(10, 8),
+  ADD COLUMN last_location_lon DECIMAL(11, 8),
+  ADD COLUMN last_location_at TIMESTAMP,
+  ADD COLUMN impossible_travel BOOLEAN NOT NULL DEFAULT FALSE;

--- a/persistence/sql/migrations/sql/20260517000000000000_add_geolocation_data_to_sessions.sqlite3.down.sql
+++ b/persistence/sql/migrations/sql/20260517000000000000_add_geolocation_data_to_sessions.sqlite3.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE sessions DROP COLUMN last_location_lat;
+ALTER TABLE sessions DROP COLUMN last_location_lon;
+ALTER TABLE sessions DROP COLUMN last_location_at;
+ALTER TABLE sessions DROP COLUMN impossible_travel;

--- a/persistence/sql/migrations/sql/20260517000000000000_add_geolocation_data_to_sessions.sqlite3.up.sql
+++ b/persistence/sql/migrations/sql/20260517000000000000_add_geolocation_data_to_sessions.sqlite3.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE sessions ADD COLUMN last_location_lat REAL;
+ALTER TABLE sessions ADD COLUMN last_location_lon REAL;
+ALTER TABLE sessions ADD COLUMN last_location_at DATETIME;
+ALTER TABLE sessions ADD COLUMN impossible_travel BOOLEAN NOT NULL DEFAULT FALSE;

--- a/selfservice/hook/hooks.go
+++ b/selfservice/hook/hooks.go
@@ -4,12 +4,13 @@
 package hook
 
 const (
-	KeySessionIssuer           = "session"
-	KeySessionDestroyer        = "revoke_active_sessions"
-	KeyWebHook                 = "web_hook"
-	KeyRequireVerifiedAddress  = "require_verified_address"
-	KeyVerificationUI          = "show_verification_ui"
-	KeyVerifier                = "verification"
-	KeyVerifyNewAddress        = "verify_new_address"
-	KeyNotifyPreviousAddresses = "notify_previous_addresses"
+	KeySessionIssuer                   = "session"
+	KeySessionDestroyer                = "revoke_active_sessions"
+	KeySessionImpossibleTravelDetector = "flag_sessions_with_impossible_travel_distance"
+	KeyWebHook                         = "web_hook"
+	KeyRequireVerifiedAddress          = "require_verified_address"
+	KeyVerificationUI                  = "show_verification_ui"
+	KeyVerifier                        = "verification"
+	KeyVerifyNewAddress                = "verify_new_address"
+	KeyNotifyPreviousAddresses         = "notify_previous_addresses"
 )

--- a/selfservice/hook/session_travel_detector.go
+++ b/selfservice/hook/session_travel_detector.go
@@ -1,0 +1,99 @@
+package hook
+
+import (
+	"math"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/ory/kratos/selfservice/flow/login"
+	"github.com/ory/kratos/selfservice/flow/recovery"
+	"github.com/ory/kratos/session"
+	"github.com/ory/kratos/ui/node"
+)
+
+const earthRadiusKm = 6371.0
+
+var (
+	_ login.PostHookExecutor    = new(SessionImpossibleTravelDetector)
+	_ recovery.PostHookExecutor = new(SessionImpossibleTravelDetector)
+)
+
+type SessionImpossibleTravelDetector struct {
+}
+
+func NewSessionImpossibleTravelDetector() *SessionImpossibleTravelDetector {
+	return &SessionImpossibleTravelDetector{}
+}
+
+func (e *SessionImpossibleTravelDetector) ExecuteLoginPostHook(_ http.ResponseWriter, r *http.Request, _ node.UiNodeGroup, _ *login.Flow, s *session.Session) error {
+	return e.checkLocationAndFlagSession(r, s)
+}
+
+func (e *SessionImpossibleTravelDetector) ExecutePostRecoveryHook(_ http.ResponseWriter, r *http.Request, _ *recovery.Flow, s *session.Session) error {
+	return e.checkLocationAndFlagSession(r, s)
+}
+
+func (e *SessionImpossibleTravelDetector) checkLocationAndFlagSession(r *http.Request, s *session.Session) error {
+	// since we assume Kratos is behind Cloudflare we can extract geolocation data
+	// from CF-IPLatitude, CF-IPLongitude headers
+	latStr := r.Header.Get("CF-IPLatitude")
+	lonStr := r.Header.Get("CF-IPLongitude")
+
+	// just for the sake of making everything safe
+	if latStr == "" || lonStr == "" {
+		return nil
+	}
+
+	// whenever those headers are invalid we don't have enough info to flag sessions
+	// so we silently skip
+	currentLat, err := strconv.ParseFloat(latStr, 64)
+	if err != nil {
+		return nil
+	}
+	currentLon, err := strconv.ParseFloat(lonStr, 64)
+	if err != nil {
+		return nil
+	}
+	now := time.Now().UTC()
+	if s.LastLocationLat != nil && s.LastLocationLon != nil && s.LastLocationAt != nil {
+		distanceKm := e.calculateHaversineDistance(*s.LastLocationLat, *s.LastLocationLon, currentLat, currentLon)
+		timeDiffMinutes := now.Sub(*s.LastLocationAt).Minutes()
+
+		if timeDiffMinutes > 0 {
+			// ignore small distances cause it can happen when connecting to different networks
+			if distanceKm > 50.0 {
+				speedKmPerMinute := distanceKm / timeDiffMinutes
+
+				// 900 km/h is exactly 15 km/minute.
+				// we flag everything that's faster than a commercial plane
+				if speedKmPerMinute > 15.0 {
+					s.ImpossibleTravel = true
+				}
+			}
+		}
+	}
+	// update session with the latest values, executed every time
+	// if session is new we just update the info so that consequential logins
+	// can be checked
+	s.LastLocationLon = &currentLon
+	s.LastLocationLat = &currentLat
+	s.LastLocationAt = &now
+	return nil
+}
+
+// calculates distance between two coordinates in km
+func (e *SessionImpossibleTravelDetector) calculateHaversineDistance(lat1, lon1, lat2, lon2 float64) float64 {
+	// Convert degrees to radians
+	dLat := (lat2 - lat1) * (math.Pi / 180.0)
+	dLon := (lon2 - lon1) * (math.Pi / 180.0)
+
+	lat1Rad := lat1 * (math.Pi / 180.0)
+	lat2Rad := lat2 * (math.Pi / 180.0)
+
+	// Haversine formula
+	a := math.Pow(math.Sin(dLat/2), 2) + math.Pow(math.Sin(dLon/2), 2)*math.Cos(lat1Rad)*math.Cos(lat2Rad)
+	c := 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
+
+	return earthRadiusKm * c
+}

--- a/selfservice/hook/session_travel_detector_test.go
+++ b/selfservice/hook/session_travel_detector_test.go
@@ -1,0 +1,133 @@
+package hook
+
+import (
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/ory/kratos/session"
+	"github.com/ory/kratos/ui/node"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionImpossibleTravelDetector(t *testing.T) {
+	detector := NewSessionImpossibleTravelDetector()
+
+	// Helper function to create float pointers
+	floatPtr := func(f float64) *float64 { return &f }
+	timePtr := func(t time.Time) *time.Time { return &t }
+
+	now := time.Now().UTC()
+
+	// Coordinates for testing
+	nyLat, nyLon := 40.7128, -74.0060
+
+	tests := []struct {
+		name                 string
+		reqHeaders           map[string]string
+		existingSession      *session.Session
+		expectedFlag         bool
+		expectLocationUpdate bool
+	}{
+		{
+			name: "missing headers does nothing",
+			reqHeaders: map[string]string{
+				"CF-IPLatitude": "", // Missing longitude
+			},
+			existingSession:      &session.Session{},
+			expectedFlag:         false,
+			expectLocationUpdate: false,
+		},
+		{
+			name: "invalid headers does nothing",
+			reqHeaders: map[string]string{
+				"CF-IPLatitude":  "invalid",
+				"CF-IPLongitude": "-74.0060",
+			},
+			existingSession:      &session.Session{},
+			expectedFlag:         false,
+			expectLocationUpdate: false,
+		},
+		{
+			name: "first login stamps session but does not flag",
+			reqHeaders: map[string]string{
+				"CF-IPLatitude":  "40.7128",
+				"CF-IPLongitude": "-74.0060",
+			},
+			existingSession:      &session.Session{}, // Empty session
+			expectedFlag:         false,
+			expectLocationUpdate: true,
+		},
+		{
+			name: "subsequent login with normal travel (10 hours to London) does not flag",
+			reqHeaders: map[string]string{
+				"CF-IPLatitude":  "51.5074", // London
+				"CF-IPLongitude": "-0.1278",
+			},
+			existingSession: &session.Session{
+				LastLocationLat: floatPtr(nyLat),
+				LastLocationLon: floatPtr(nyLon),
+				LastLocationAt:  timePtr(now.Add(-10 * time.Hour)), // 10 hours ago
+			},
+			expectedFlag:         false,
+			expectLocationUpdate: true,
+		},
+		{
+			name: "subsequent login with impossible travel (1 hour to London) flags session",
+			reqHeaders: map[string]string{
+				"CF-IPLatitude":  "51.5074", // London
+				"CF-IPLongitude": "-0.1278",
+			},
+			existingSession: &session.Session{
+				LastLocationLat: floatPtr(nyLat),
+				LastLocationLon: floatPtr(nyLon),
+				LastLocationAt:  timePtr(now.Add(-1 * time.Hour)), // Only 1 hour ago!
+			},
+			expectedFlag:         true,
+			expectLocationUpdate: true,
+		},
+		{
+			name: "network jitter (instant travel but short distance) does not flag",
+			reqHeaders: map[string]string{
+				"CF-IPLatitude":  "40.7300", // NJ
+				"CF-IPLongitude": "-74.0500",
+			},
+			existingSession: &session.Session{
+				LastLocationLat: floatPtr(nyLat),
+				LastLocationLon: floatPtr(nyLon),
+				LastLocationAt:  timePtr(now.Add(-1 * time.Minute)), // 1 minute ago, technically > 900kmh but < 50km total distance
+			},
+			expectedFlag:         false,
+			expectLocationUpdate: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest("POST", "/login", nil)
+			require.NoError(t, err)
+			for k, v := range tc.reqHeaders {
+				req.Header.Set(k, v)
+			}
+
+			err = detector.ExecuteLoginPostHook(nil, req, node.DefaultGroup, nil, tc.existingSession)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expectedFlag, tc.existingSession.ImpossibleTravel, "ImpossibleTravel flag mismatch")
+
+			if tc.expectLocationUpdate {
+				assert.NotNil(t, tc.existingSession.LastLocationLat)
+				assert.NotNil(t, tc.existingSession.LastLocationLon)
+				assert.NotNil(t, tc.existingSession.LastLocationAt)
+
+				// Verify the stamped coordinates match the headers we passed in
+				expectedLat, _ := strconv.ParseFloat(tc.reqHeaders["CF-IPLatitude"], 64)
+				assert.Equal(t, expectedLat, *tc.existingSession.LastLocationLat)
+			} else {
+				assert.Nil(t, tc.existingSession.LastLocationLat)
+			}
+		})
+	}
+}

--- a/session/session.go
+++ b/session/session.go
@@ -132,6 +132,18 @@ type Session struct {
 	// IdentityID is a helper struct field for gobuffalo.pop.
 	IdentityID uuid.UUID `json:"-" faker:"-" db:"identity_id"`
 
+	// LastLocationLat is the latitude of the last successful login.
+	LastLocationLat *float64 `db:"last_location_lat" json:"-"`
+
+	// LastLocationLon is the longitude of the last successful login.
+	LastLocationLon *float64 `db:"last_location_lon" json:"-"`
+
+	// LastLocationAt is the timestamp of the last successful login.
+	LastLocationAt *time.Time `db:"last_location_at" json:"-"`
+
+	// ImpossibleTravel indicates if the session has been flagged.
+	ImpossibleTravel bool `db:"impossible_travel" json:"impossible_travel"`
+
 	// CreatedAt is a helper struct field for gobuffalo.pop.
 	CreatedAt time.Time `json:"-" faker:"-" db:"created_at"`
 


### PR DESCRIPTION
feat(session): implement impossible travel detection post-login hook

Implements a post-login and post-recovery hook to detect impossible
travel within a user's session. The hook calculates the Haversine distance
and time delta between subsequent logins using Cloudflare geolocation headers
(CF-IPLatitude, CF-IPLongitude). If the travel speed exceeds 900km/h,
the session is flagged with `impossible_travel = true`. I have taken this value for handling cases
where jumps between distances are impossible, since we're just flagging the session.

Zero extra database calls were added,
as the session struct is mutated in memory prior to the Kratos
upsert.

Known Limitations & Blind Spots:
- Session-Scoped Blind Spot: Currently only stores the most recent login geodata
  and uses it to detect whether something's off. Unfortunately I figured out the device level
  tracking only after I finished this.
- VPN/Proxy False Positives: Corporate VPNs exiting in different countries
  will trigger false positives. Standard IP-jitter is handled via a 50km
  minimum distance threshold.
- Cross-Session Vulnerability: If an attacker steals a user's password and authenticates from a distant country on a new device, Kratos creates a brand new session. Because the new session has no prior location data to compare against, this implementation will not flag it.

Future Improvement: Device-Level Tracking
To solve the cross-session blind spot and map to real-world domain boundaries,
location tracking should be moved to the `Device` struct.
- Add `latitude`, `longitude`, and `timestamp` directly to the `devices` table.
- Modify the device append logic to stamp these coordinates upon device creation.
- During any authentication flow, sort the devices array by their timestamps,
  iterate through it to calculate distances between all neighbouring device entries. This would allow
  us to validate the user's entire physical travel history across multiple
  devices, providing a much more robust security posture.
- Another thing to add would be integration tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced impossible travel detection security feature to identify suspicious login activity and prevent unauthorized account access
  * Automatically analyzes geolocation data during login and flags sessions when travel between locations exceeds realistic speed limits (~900 km/h)
  * Captures and tracks session location data to enable fraud detection and enhance account security

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ory/kratos/pull/4569?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->