### PR TITLE
docs: update examples in config.schema.json for domains

### DIFF
--- a/embedx/config.schema.json
+++ b/embedx/config.schema.json
@@ -1892,7 +1892,7 @@
                           "type": "string",
                           "title": "Relying Party Identifier",
                           "description": "The id must be a subset of the domain currently in the browser.",
-                          "examples": ["ory.sh"]
+                          "examples": ["ory.com"]
                         },
                         "origin": {
                           "type": "string",
@@ -1911,7 +1911,7 @@
                             "format": "uri",
                             "examples": [
                               "https://www.ory.com",
-                              "https://auth.ory.sh"
+                              "https://auth.ory.com"
                             ]
                           }
                         },
@@ -2006,7 +2006,7 @@
                           "type": "string",
                           "title": "Relying Party Identifier",
                           "description": "The id must be a subset of the domain currently in the browser.",
-                          "examples": ["ory.sh"]
+                          "examples": ["ory.com"]
                         },
                         "origins": {
                           "type": "array",
@@ -2016,7 +2016,7 @@
                             "type": "string",
                             "examples": [
                               "https://www.ory.com",
-                              "https://auth.ory.sh"
+                              "https://auth.ory.com"
                             ]
                           }
                         }


### PR DESCRIPTION
Replaces .sh in examples with .com

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [ X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [ X] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [X ] I have read the [security policy](../security/policy).
- [ X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.com](mailto:security@ory.com)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

Examples with .sh references are appearing in the documentation. This change will update the docs to show .com instead of .sh.
