### PR TITLE
feat: optionally resolve OIDC provider secrets from file:// and base64:// URIs

### DIFF
--- a/driver/config/config.go
+++ b/driver/config/config.go
@@ -131,6 +131,7 @@ const (
 	ViperKeySelfServiceLoginFlowStyle                        = "selfservice.flows.login.style"
 	ViperKeySecurityAccountEnumerationMitigate               = "security.account_enumeration.mitigate"
 	ViperKeySecurityDisallowRefInIdentitySchemas             = "security.disallow_ref_in_identity_schemas"
+	ViperKeySecurityAllowSecretURIsInOIDCConfig              = "security.allow_secret_uris_in_oidc_config"
 	ViperKeySelfServiceLoginRequestLifespan                  = "selfservice.flows.login.lifespan"
 	ViperKeySelfServiceLoginAfter                            = "selfservice.flows.login.after"
 	ViperKeySelfServiceLoginBeforeHooks                      = "selfservice.flows.login.before.hooks"
@@ -1729,4 +1730,8 @@ func (p *Config) SecurityAccountEnumerationMitigate(ctx context.Context) bool {
 
 func (p *Config) SecurityDisallowRefInIdentitySchemas(ctx context.Context) bool {
 	return p.GetProvider(ctx).Bool(ViperKeySecurityDisallowRefInIdentitySchemas)
+}
+
+func (p *Config) SecurityAllowSecretURIsInOIDCConfig(ctx context.Context) bool {
+	return p.GetProvider(ctx).Bool(ViperKeySecurityAllowSecretURIsInOIDCConfig)
 }

--- a/embedx/config.schema.json
+++ b/embedx/config.schema.json
@@ -506,7 +506,14 @@
           "type": "string"
         },
         "client_secret": {
-          "type": "string"
+          "title": "Client Secret",
+          "description": "The client secret. If `security.allow_secret_uris_in_oidc_config` is enabled, the value may also be given as a `file://` or `base64://` URI, which is resolved to the referenced value when the provider is used. A value resolved this way must not be empty.",
+          "type": "string",
+          "examples": [
+            "client-secret",
+            "file:///etc/secrets/oidc/acme",
+            "base64://Y2xpZW50LXNlY3JldA=="
+          ]
         },
         "issuer_url": {
           "type": "string",
@@ -575,10 +582,11 @@
         },
         "apple_private_key": {
           "title": "Apple Private Key",
-          "description": "Sign In with Apple Private Key needed for generating a JWT token for client secret",
+          "description": "Sign In with Apple Private Key needed for generating a JWT token for client secret. If `security.allow_secret_uris_in_oidc_config` is enabled, the value may also be given as a `file://` or `base64://` URI, which is resolved to the referenced value when the provider is used.",
           "type": "string",
           "examples": [
-            "-----BEGIN PRIVATE KEY-----\n........\n-----END PRIVATE KEY-----"
+            "-----BEGIN PRIVATE KEY-----\n........\n-----END PRIVATE KEY-----",
+            "file:///etc/secrets/oidc/apple_private_key.pem"
           ]
         },
         "requested_claims": {
@@ -3074,6 +3082,12 @@
         "disallow_ref_in_identity_schemas": {
           "title": "Disallow external `$ref` resolution in identity schemas",
           "description": "If true, `$ref` URLs inside identity schemas may not resolve to `file://`, `http://`, or `https://` sources. This blocks server-side file reads (`file://`) and server-side request forgery (`http(s)://`) via malicious identity schemas. Internal JSON-pointer refs (`#/definitions/...`) and self-contained `base64://` refs remain allowed. Leave at the default (false) to preserve existing behavior for operators who intentionally reference external schemas. Ory Network forces this to true.",
+          "type": "boolean",
+          "default": false
+        },
+        "allow_secret_uris_in_oidc_config": {
+          "title": "Allow `file://` and `base64://` values in OIDC provider secrets",
+          "description": "If true, the `client_secret` and `apple_private_key` of an OpenID Connect provider may be given as a `file://` or `base64://` URI, which is resolved to the referenced value when the provider is used. Enable this to keep provider secrets out of the rendered configuration, for example when the configuration is stored in a Kubernetes ConfigMap. Leave at the default (false) if the provider configuration is written by parties who must not be able to read files from the host's filesystem; with the default, such values are passed through verbatim.",
           "type": "boolean",
           "default": false
         }

--- a/selfservice/strategy/oidc/provider_config.go
+++ b/selfservice/strategy/oidc/provider_config.go
@@ -4,6 +4,7 @@
 package oidc
 
 import (
+	"context"
 	"encoding/json"
 	"maps"
 	"net/url"
@@ -232,6 +233,80 @@ type ConfigurationCollection struct {
 	Providers       []Configuration `json:"providers"`
 }
 
+// configSecretSchemes are the fetcher schemes a secret-valued provider field
+// may use to reference its value indirectly, guarded by the
+// security.allow_secret_uris_in_oidc_config setting. Remote schemes are not
+// supported because resolution runs whenever the provider is used.
+var configSecretSchemes = []string{"file", "base64"}
+
+func configSecretScheme(value string) (string, bool) {
+	for _, scheme := range configSecretSchemes {
+		if strings.HasPrefix(value, scheme+"://") {
+			return scheme, true
+		}
+	}
+
+	return "", false
+}
+
+// resolveConfigSecrets replaces every secret-valued field expressed as one of
+// configSecretSchemes with the value it points to, mirroring the indirection
+// mapper_url already supports. Values without a supported scheme are left
+// untouched. Resolved values are not cached, so rotating the source takes
+// effect without a restart.
+func (s *Strategy) resolveConfigSecrets(ctx context.Context, p *Configuration) error {
+	for _, field := range []struct {
+		name  string
+		value *string
+	}{
+		{"client_secret", &p.ClientSecret},
+		{"apple_private_key", &p.PrivateKey},
+	} {
+		if err := s.resolveConfigSecret(ctx, p.ID, field.name, field.value); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *Strategy) resolveConfigSecret(ctx context.Context, providerID, field string, value *string) error {
+	scheme, ok := configSecretScheme(*value)
+	if !ok {
+		return nil
+	}
+
+	read, err := s.configSecretFetcher.FetchContext(ctx, *value)
+	if err != nil {
+		// The fetcher's error contains the source (a file path, or a redacted
+		// base64 payload). It is logged for the operator but kept out of the
+		// herodot error entirely: both the reason and the debug field are
+		// serialized into the response returned to the client that triggered
+		// the flow.
+		s.d.Logger().WithError(err).
+			WithField("provider", providerID).WithField("field", field).
+			Error("Unable to resolve a secret reference in the OpenID Connect provider configuration.")
+		return errors.WithStack(herodot.ErrMisconfiguration().
+			WithReasonf("Unable to resolve the %s configured for OpenID Connect Provider %q.", field, providerID).
+			WithWrap(err))
+	}
+
+	resolved := read.String()
+	if scheme == "file" {
+		// Files created with echo or kubectl typically end in one newline that
+		// is not part of the secret; base64:// decodes to exact bytes.
+		resolved = strings.TrimSuffix(resolved, "\n")
+		resolved = strings.TrimSuffix(resolved, "\r")
+	}
+	if resolved == "" {
+		return errors.WithStack(herodot.ErrMisconfiguration().WithReasonf(
+			"The %s resolved for OpenID Connect Provider %q is empty.", field, providerID))
+	}
+
+	*value = resolved
+	return nil
+}
+
 // !!! WARNING !!!
 //
 // If you add a provider here, please also add a test to
@@ -266,15 +341,35 @@ var supportedProviders = map[string]func(config *Configuration, reg Dependencies
 	"uaepass":     NewProviderUAEPass,
 }
 
-func (c ConfigurationCollection) Provider(id string, reg Dependencies) (Provider, error) {
+// ProviderConfig returns a copy of the configuration for the provider with the
+// given id, so that callers may modify it without affecting the collection.
+// Secret-valued fields are returned as configured and may still contain
+// unresolved file:// or base64:// references.
+func (c ConfigurationCollection) ProviderConfig(id string) (*Configuration, error) {
 	for _, p := range c.Providers {
 		if p.ID == id {
-			if f, ok := supportedProviders[p.Provider]; ok {
-				return f(&p, reg), nil
-			}
-
-			return nil, errors.Errorf("provider type %s is not supported, supported are: %v", p.Provider, maps.Keys(supportedProviders))
+			return &p, nil
 		}
 	}
 	return nil, errors.WithStack(herodot.ErrNotFound().WithReasonf(`OpenID Connect Provider "%s" is unknown or has not been configured`, id))
+}
+
+// Provider constructs the provider with the given id for enumeration purposes
+// (listing providers, rendering forms, looking up labels). Secret-valued fields
+// are not resolved: a provider that will perform an OAuth2 exchange must be
+// obtained via (*Strategy).Provider instead.
+func (c ConfigurationCollection) Provider(id string, reg Dependencies) (Provider, error) {
+	p, err := c.ProviderConfig(id)
+	if err != nil {
+		return nil, err
+	}
+	return newProviderFromConfig(p, reg)
+}
+
+func newProviderFromConfig(p *Configuration, reg Dependencies) (Provider, error) {
+	if f, ok := supportedProviders[p.Provider]; ok {
+		return f(p, reg), nil
+	}
+
+	return nil, errors.Errorf("provider type %s is not supported, supported are: %v", p.Provider, maps.Keys(supportedProviders))
 }

--- a/selfservice/strategy/oidc/provider_config_test.go
+++ b/selfservice/strategy/oidc/provider_config_test.go
@@ -4,11 +4,21 @@
 package oidc_test
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ory/herodot"
 	"github.com/ory/kratos/driver/config"
 	"github.com/ory/kratos/identity"
 	"github.com/ory/kratos/pkg"
@@ -27,6 +37,180 @@ func TestConfig(t *testing.T) {
 
 	require.Len(t, collection.Providers, 1)
 	assert.Equal(t, "generic", collection.Providers[0].Provider)
+}
+
+func TestConfigSecretResolution(t *testing.T) {
+	t.Parallel()
+
+	providersKey := config.ViperKeySelfServiceStrategyConfig + "." + string(identity.CredentialsTypeOIDC) + ".config"
+
+	writeSecret := func(t *testing.T, contents string) string {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "client_secret")
+		require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+		return path
+	}
+
+	configFor := func(secret string) map[string]any {
+		return map[string]any{"providers": []map[string]any{
+			{"provider": "generic", "id": "acme", "client_secret": secret},
+		}}
+	}
+
+	newStrategy := func(t *testing.T, providers map[string]any, allowSecretURIs bool) *oidc.Strategy {
+		t.Helper()
+		_, reg := pkg.NewFastRegistryWithMocks(t,
+			configx.WithValue(providersKey, providers),
+			configx.WithValue(config.ViperKeySecurityAllowSecretURIsInOIDCConfig, allowSecretURIs))
+		return oidc.NewStrategy(reg)
+	}
+
+	clientSecretFor := func(t *testing.T, providers map[string]any) string {
+		t.Helper()
+		p, err := newStrategy(t, providers, true).Provider(t.Context(), "acme")
+		require.NoError(t, err)
+		return p.Config().ClientSecret
+	}
+
+	t.Run("resolves file:// to the file contents", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, "s3cr3t", clientSecretFor(t, configFor("file://"+writeSecret(t, "s3cr3t"))))
+	})
+
+	t.Run("trims exactly one trailing newline from a file secret", func(t *testing.T) {
+		t.Parallel()
+		for contents, want := range map[string]string{
+			"s3cr3t\n":   "s3cr3t",
+			"s3cr3t\r\n": "s3cr3t",
+			"s3cr3t\n\n": "s3cr3t\n",
+			"s3cr3t \n":  "s3cr3t ",
+			"  s3cr3t\n": "  s3cr3t",
+		} {
+			assert.Equal(t, want, clientSecretFor(t, configFor("file://"+writeSecret(t, contents))), "%q", contents)
+		}
+	})
+
+	t.Run("resolves base64:// to the exact decoded bytes", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, "s3cr3t\n", clientSecretFor(t, configFor(
+			"base64://"+base64.StdEncoding.EncodeToString([]byte("s3cr3t\n")))))
+	})
+
+	t.Run("leaves an inline secret untouched", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, "s3cr3t", clientSecretFor(t, configFor("s3cr3t")))
+	})
+
+	t.Run("leaves an unsupported scheme untouched", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, "https://example.com/secret", clientSecretFor(t, configFor("https://example.com/secret")))
+	})
+
+	t.Run("resolves apple_private_key", func(t *testing.T) {
+		t.Parallel()
+
+		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		der, err := x509.MarshalPKCS8PrivateKey(key)
+		require.NoError(t, err)
+		pemKey := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+
+		s := newStrategy(t, map[string]any{"providers": []map[string]any{{
+			"provider":             "apple",
+			"id":                   "apple",
+			"client_id":            "client",
+			"apple_team_id":        "team",
+			"apple_private_key_id": "key-id",
+			"apple_private_key":    "file://" + writeSecret(t, pemKey),
+		}}}, true)
+
+		p, err := s.Provider(t.Context(), "apple")
+		require.NoError(t, err)
+		assert.Equal(t, strings.TrimSuffix(pemKey, "\n"), p.Config().PrivateKey)
+	})
+
+	t.Run("passes URIs through verbatim by default", func(t *testing.T) {
+		t.Parallel()
+
+		secret := "file://" + writeSecret(t, "s3cr3t")
+		_, reg := pkg.NewFastRegistryWithMocks(t, configx.WithValue(providersKey, configFor(secret)))
+
+		p, err := oidc.NewStrategy(reg).Provider(t.Context(), "acme")
+		require.NoError(t, err)
+		assert.Equal(t, secret, p.Config().ClientSecret)
+	})
+
+	t.Run("does not mutate the shared configuration collection", func(t *testing.T) {
+		t.Parallel()
+
+		secret := "file://" + writeSecret(t, "s3cr3t")
+		s := newStrategy(t, configFor(secret), true)
+
+		p, err := s.Provider(t.Context(), "acme")
+		require.NoError(t, err)
+		assert.Equal(t, "s3cr3t", p.Config().ClientSecret)
+
+		collection, err := s.Config(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, secret, collection.Providers[0].ClientSecret)
+	})
+
+	t.Run("a broken provider does not affect enumeration or other providers", func(t *testing.T) {
+		t.Parallel()
+
+		s := newStrategy(t, map[string]any{"providers": []map[string]any{
+			{"provider": "generic", "id": "acme", "client_secret": "s3cr3t"},
+			{"provider": "generic", "id": "broken", "client_secret": "file://" + filepath.Join(t.TempDir(), "does-not-exist")},
+		}}, true)
+
+		collection, err := s.Config(t.Context())
+		require.NoError(t, err)
+		assert.Len(t, collection.Providers, 2)
+
+		p, err := s.Provider(t.Context(), "acme")
+		require.NoError(t, err)
+		assert.Equal(t, "s3cr3t", p.Config().ClientSecret)
+
+		_, err = s.Provider(t.Context(), "broken")
+		require.Error(t, err)
+	})
+
+	t.Run("errors when the file is missing without leaking the path", func(t *testing.T) {
+		t.Parallel()
+
+		path := filepath.Join(t.TempDir(), "does-not-exist")
+		s := newStrategy(t, configFor("file://"+path), true)
+
+		_, err := s.Provider(t.Context(), "acme")
+		var he *herodot.DefaultError
+		require.ErrorAs(t, err, &he)
+		assert.Contains(t, he.Reason(), "acme", "%+v", err)
+		assert.Contains(t, he.Reason(), "client_secret", "%+v", err)
+		assert.NotContains(t, he.Reason(), path, "%+v", err)
+	})
+
+	t.Run("errors when the resolved secret is empty", func(t *testing.T) {
+		t.Parallel()
+
+		s := newStrategy(t, configFor("file://"+writeSecret(t, "\n")), true)
+
+		_, err := s.Provider(t.Context(), "acme")
+		var he *herodot.DefaultError
+		require.ErrorAs(t, err, &he)
+		assert.Contains(t, he.Reason(), "acme", "%+v", err)
+	})
+
+	t.Run("does not leak the secret into the error", func(t *testing.T) {
+		t.Parallel()
+
+		s := newStrategy(t, configFor("base64://not-valid-base64!!"), true)
+
+		_, err := s.Provider(t.Context(), "acme")
+		var he *herodot.DefaultError
+		require.ErrorAs(t, err, &he)
+		assert.NotContains(t, he.Reason(), "not-valid-base64", "%+v", err)
+		assert.NotContains(t, he.DebugField, "not-valid-base64", "%+v", err)
+	})
 }
 
 func TestConfiguration_AALForClaims(t *testing.T) {

--- a/selfservice/strategy/oidc/strategy.go
+++ b/selfservice/strategy/oidc/strategy.go
@@ -47,6 +47,7 @@ import (
 	"github.com/ory/kratos/x/nosurfx"
 	"github.com/ory/kratos/x/redir"
 	"github.com/ory/x/clock"
+	"github.com/ory/x/fetcher"
 	"github.com/ory/x/httprouterx"
 	"github.com/ory/x/httpx"
 	"github.com/ory/x/jsonnetsecure"
@@ -153,6 +154,7 @@ type Strategy struct {
 	credType                    identity.CredentialsType
 	handleUnknownProviderError  func(err error) error
 	handleMethodNotAllowedError func(err error) error
+	configSecretFetcher         *fetcher.Fetcher
 
 	conflictingIdentityPolicy ConflictingIdentityPolicy
 }
@@ -287,6 +289,7 @@ func NewStrategy(d Dependencies, opts ...NewStrategyOpt) *Strategy {
 		credType:                    identity.CredentialsTypeOIDC,
 		handleUnknownProviderError:  func(err error) error { return err },
 		handleMethodNotAllowedError: func(err error) error { return err },
+		configSecretFetcher:         fetcher.NewFetcher(fetcher.WithAllowedSchemes(configSecretSchemes...)),
 	}
 
 	for _, opt := range opts {
@@ -660,14 +663,38 @@ func (s *Strategy) Config(ctx context.Context) (*ConfigurationCollection, error)
 	return &c, nil
 }
 
+// Provider returns the provider with the given id, ready for use in an OAuth2
+// exchange: it is the only constructor that resolves file:// and base64://
+// references in secret-valued configuration fields (when
+// security.allow_secret_uris_in_oidc_config is enabled). Enumeration-only
+// callers should use ConfigurationCollection.Provider or ProviderConfig, which
+// perform no resolution and no file I/O.
 func (s *Strategy) Provider(ctx context.Context, id string) (Provider, error) {
-	if c, err := s.Config(ctx); err != nil {
+	c, err := s.Config(ctx)
+	if err != nil {
 		return nil, err
-	} else if provider, err := c.Provider(id, s.d); err != nil {
-		return nil, s.handleUnknownProviderError(err)
-	} else {
-		return provider, nil
 	}
+
+	p, err := c.ProviderConfig(id)
+	if err != nil {
+		return nil, s.handleUnknownProviderError(err)
+	}
+
+	// Secrets are resolved on the copy of the configuration held by this
+	// provider instance only, so that a broken reference fails flows using this
+	// provider without affecting other providers or provider enumeration.
+	if s.d.Config().SecurityAllowSecretURIsInOIDCConfig(ctx) {
+		if err := s.resolveConfigSecrets(ctx, p); err != nil {
+			return nil, err
+		}
+	}
+
+	provider, err := newProviderFromConfig(p, s.d)
+	if err != nil {
+		return nil, s.handleUnknownProviderError(err)
+	}
+
+	return provider, nil
 }
 
 func (s *Strategy) forwardError(ctx context.Context, w http.ResponseWriter, r *http.Request, f flow.Flow, err error) {
@@ -787,11 +814,16 @@ func (s *Strategy) HandleError(ctx context.Context, w http.ResponseWriter, r *ht
 func (s *Strategy) populateAccountLinkingUI(ctx context.Context, lf *login.Flow, usedProviderID string, duplicateIdentifier string, availableCredentials []string, availableProviders []string) {
 	newLoginURL := s.d.Config().SelfServiceFlowLoginUI(ctx).String()
 	usedProviderLabel := usedProviderID
-	provider, _ := s.Provider(ctx, usedProviderID)
-	if provider != nil && provider.Config() != nil {
-		usedProviderLabel = provider.Config().Label
+	if conf, err := s.Config(ctx); err != nil {
+		s.d.Logger().WithError(err).WithField("provider", usedProviderID).
+			Warn("Unable to load the OpenID Connect provider configuration while populating the account linking UI.")
+	} else if providerConfig, err := conf.ProviderConfig(usedProviderID); err != nil {
+		s.d.Logger().WithError(err).WithField("provider", usedProviderID).
+			Warn("Unable to find the OpenID Connect provider while populating the account linking UI.")
+	} else {
+		usedProviderLabel = providerConfig.Label
 		if usedProviderLabel == "" {
-			usedProviderLabel = provider.Config().Provider
+			usedProviderLabel = providerConfig.Provider
 		}
 	}
 	loginHintsEnabled := s.d.Config().SelfServiceFlowRegistrationLoginHints(ctx)

--- a/selfservice/strategy/oidc/strategy_test.go
+++ b/selfservice/strategy/oidc/strategy_test.go
@@ -13,6 +13,8 @@ import (
 	"net/http/cookiejar"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
@@ -333,6 +335,56 @@ func TestStrategy(t *testing.T) {
 				assertSystemErrorWithReason(t, res, body, http.StatusNotFound, "is unknown or has not been configured")
 			})
 		}
+	})
+
+	t.Run("case=client_secret is resolved from a file and reaches the token exchange", func(t *testing.T) {
+		// The Hydra client is created with a real secret, which is then only
+		// available through a file:// reference. If resolution did not wire
+		// through to the OAuth2 code exchange, Hydra would reject the client.
+		provider := newOIDCProvider(t, ts, hydraPublic, hydraAdmin, "file-secret")
+		secretPath := filepath.Join(t.TempDir(), "client_secret")
+		require.NoError(t, os.WriteFile(secretPath, []byte(provider.ClientSecret+"\n"), 0o600))
+		provider.ClientSecret = "file://" + secretPath
+		setProviderConfig(t, conf, provider)
+
+		conf.MustSet(t.Context(), config.ViperKeySecurityAllowSecretURIsInOIDCConfig, true)
+		t.Cleanup(func() {
+			conf.MustSet(t.Context(), config.ViperKeySecurityAllowSecretURIsInOIDCConfig, false)
+		})
+
+		subject := testhelpers.RandomEmail()
+		params := hydraFlowParams{subject: subject, scope: []string{"openid"}}
+
+		t.Run("step=browser registration", func(t *testing.T) {
+			r := newBrowserRegistrationFlow(t, returnTS.URL, time.Minute)
+			action := assertFormValues(t, r.ID, "file-secret")
+			res, body := makeRequest(t, action, "file-secret", params, nil)
+			assertIdentity(t, res, body, subject, idTokenClaims{})
+		})
+
+		t.Run("step=API login", func(t *testing.T) {
+			f := newAPILoginFlow(t, returnTS.URL+"?return_session_token_exchange_code=true&return_to=/app_code", time.Minute)
+			action := assertFormValues(t, f.ID, "file-secret")
+			returnToURL := makeAPICodeFlowRequest(t, nil, action, "file-secret", params)
+
+			codeResponse, err := exchangeCodeForToken(t, sessiontokenexchange.Codes{
+				InitCode:     f.SessionTokenExchangeCode,
+				ReturnToCode: returnToURL.Query().Get("code"),
+			})
+			require.NoError(t, err)
+			assert.NotEmpty(t, codeResponse.Token)
+			assert.Equal(t, subject, gjson.GetBytes(codeResponse.Session.Identity.Traits, "subject").String())
+		})
+
+		t.Run("step=login fails when the secret file is removed", func(t *testing.T) {
+			require.NoError(t, os.Remove(secretPath))
+
+			r := newBrowserLoginFlow(t, returnTS.URL, time.Minute)
+			action := assertFormValues(t, r.ID, "file-secret")
+			res, body := makeRequest(t, action, "file-secret", params, nil)
+			assertSystemErrorWithReason(t, res, body, http.StatusInternalServerError, "Unable to resolve the client_secret")
+			assert.NotContains(t, string(body), secretPath, "the file path must not leak into the error response")
+		})
 	})
 
 	t.Run("case=should fail because the issuer is mismatching", func(t *testing.T) {


### PR DESCRIPTION
## Problem

An OIDC provider's `client_secret` (and `apple_private_key`) can only be supplied inline, so the credential has to live in the Kratos configuration itself. On Kubernetes that has an awkward consequence: the official Helm chart renders all of `kratos.config` into a **ConfigMap** (`templates/configmap-config.yaml`), so upstream IdP client secrets end up somewhere that

- is not covered by Kubernetes Secret encryption at rest,
- is readable by anyone holding `get configmap` — a far more commonly granted verb than `get secret`,
- appears unredacted in `kubectl describe`, support bundles, and cluster backups.

The chart already routes `dsn`, `secrets.*`, and `courier.smtp.connection_uri` through a Secret + `secretKeyRef` (`templates/secrets.yaml`), so the "this value is too sensitive for a ConfigMap" pattern exists — provider secrets just can't participate while inline is the only way to express them.

## What this PR does

When the new opt-in setting `security.allow_secret_uris_in_oidc_config` is enabled, `client_secret` and `apple_private_key` may be given as `file://` or `base64://` URIs — the same indirection `mapper_url` already supports — and are resolved to the referenced value when the provider is used:

```yaml
security:
  allow_secret_uris_in_oidc_config: true   # default: false

selfservice:
  methods:
    oidc:
      config:
        providers:
          - id: acme
            provider: generic
            client_id: ...
            client_secret: file:///etc/secrets/oidc/acme
            mapper_url: base64://bG9jYWwg...
```

On Kubernetes, mounting a Secret via the chart's existing `deployment.extraVolumes` / `extraVolumeMounts` keeps the credential out of the ConfigMap entirely — no chart change required.

## Design

- **Opt-in, ctx-scoped security setting** (default `false`), following the precedent of `security.disallow_ref_in_identity_schemas` (40ce7fcdb). Whoever can write provider configuration also controls `token_url`, so an always-on `file://` resolver would be an arbitrary-file-read-and-exfiltrate primitive wherever provider config is written by untrusted parties (e.g. through an API in multi-tenant deployments). Because the setting is read from `ctx`, embedders can pin it per project. With the default, URI-shaped values pass through verbatim — exactly today's behavior, so the change is fully backward compatible.
- **Resolution happens in `(*Strategy).Provider`, on the per-use copy of the provider configuration.** Provider *enumeration* (login/registration/settings form rendering, unlink, linkability checks) does no file I/O, and a broken secret reference only fails flows that actually use that provider — never the whole login screen. The shared configuration collection is never mutated, so resolved plaintext is never cached or written back.
- **Local schemes only, enforced by the fetcher.** The fetcher is built once per strategy with `fetcher.WithAllowedSchemes("file", "base64")`. `http(s)://` is deliberately not resolved — fetching a credential over the network on the callback path is undesirable — so an `https://` value keeps its current meaning (a literal secret).
- **Not cached.** The value is re-read each time the provider is used, so rotating the mounted file or Secret takes effect without a restart. Since resolution never runs on render paths, this costs one `os.ReadFile` per actual OAuth2 exchange.
- **Exactly one trailing newline is trimmed, for `file://` sources only** — what `echo` or `kubectl create secret --from-file` of a newline-terminated file adds. Leading whitespace, trailing spaces, and additional newlines are preserved; `base64://` decodes to exact bytes. An empty resolved value is treated as a misconfiguration (an inline empty secret remains legal for public/PKCE clients; this is documented in the schema).
- **Errors never expose the source.** The herodot reason names only the provider `id` and field. The underlying fetcher error (which contains the file path) is logged server-side for the operator and attached via `WithWrap` only — deliberately not `WithDebugf`, because herodot serializes the `debug` field into the response returned by the self-service errors endpoint. The end-to-end test asserts the path appears nowhere in the error body; `base64://` payloads are additionally redacted by `ory/x/fetcher` itself.

## Related issue(s)

There is no design document for this, so please treat it as a starting point for discussion — I'm glad to convert it into an issue first if that's the preferred path.

- #1535 — *Setting up OIDC secrets via environment variables.* The whole-array env override did not work at the time (2021); it does in current Kratos (`configx` JSON-decodes env values into arrays — verified against this tree). See below for why this PR still adds value over that route.
- ory/k8s#423 — asked for exactly this capability and was closed with the whole-array env-var workaround (`SELFSERVICE_METHODS_OIDC_CONFIG_PROVIDERS` from a Secret). That workaround is legitimate but all-or-nothing: every provider's *non-secret* configuration moves into a single opaque JSON line inside a Secret, overriding just one provider's secret is impossible, and rotation requires a pod restart (env vars are immutable per pod) — where `file://` picks up a rotated Secret volume without one.
- ory/k8s#386 — *Change kratos ConfigMap to kind Secret.* Closed with "we strongly encourage users to supply sensitive information via a custom secret" — the pattern this PR completes for provider secrets.
- #1186 — *How to set the `client_secret` in kratos.yml for an OIDC provider?* Answered with "write it in your `kratos.yml`", which is the behavior this change makes optional.
- 40ce7fcdb — *reject `file://` `$ref` in identity schemas* — the security-gating pattern this PR follows.

Longer term, this could live in `ory/x/configx` as a general secret-reference mechanism (schema-annotation driven), so `dsn`, `courier.smtp.connection_uri`, and other Ory projects get uniform behavior. This PR is deliberately scoped to the OIDC provider fields; happy to open an issue for the general mechanism.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change introduces a new feature. — **not done**, see above; happy to open one first.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs). — the config schema `title`/`description`/`examples` are updated here; the ory/docs social sign-in page needs a companion PR.

## Testing

**Unit** — `TestConfigSecretResolution` (`provider_config_test.go`), observing resolution through `Strategy.Provider`: `file://` and `base64://` resolution, single-trailing-newline trim semantics (leading/extra whitespace preserved, base64 untrimmed), inline and unsupported-scheme passthrough, **default-off passthrough**, missing file, empty resolved value, no path/payload leakage into the error reason or debug, a real PKCS#8 EC key for `apple_private_key`, no mutation of the shared collection, and pinned blast radius (a broken provider affects neither `Config()` enumeration nor other providers).

**End-to-end** — `TestStrategy/case=client_secret is resolved from a file and reaches the token exchange`: a real Hydra client whose secret exists only behind a `file://` reference completes a browser registration and an API login through the callback — proving the resolved secret is what reaches the OAuth2 code exchange. A final step deletes the secret file and asserts the login fails with a 500 whose body does not contain the file path.

```
go test ./selfservice/strategy/oidc/   ok   (incl. Hydra-backed TestStrategy, TestSettingsStrategy, TestPostEndpointRedirect)
go test ./embedx/...                   ok
go test ./driver/config/...            ok
```

## Not addressed here

`(*Strategy).Config` logs the raw configuration on a decode failure (`s.d.Logger().WithError(err).WithField("config", conf)` in `strategy.go`), which writes every `client_secret` into the application log when decoding fails. That is the mirror image of the error-hygiene work in this PR and is fixed separately in my `fix/oidc-config-decode-log` branch — happy to fold it in if you'd rather have both together.
