### PR TITLE
fix: emit the OIDC configuration decode failure without the configuration

### DIFF
--- a/selfservice/strategy/oidc/provider_config_test.go
+++ b/selfservice/strategy/oidc/provider_config_test.go
@@ -4,8 +4,11 @@
 package oidc_test
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -27,6 +30,36 @@ func TestConfig(t *testing.T) {
 
 	require.Len(t, collection.Providers, 1)
 	assert.Equal(t, "generic", collection.Providers[0].Provider)
+}
+
+func TestConfigDecodeFailureLogging(t *testing.T) {
+	const secret = "this-value-must-not-be-logged"
+
+	// providers is an array, so a string fails to decode into
+	// ConfigurationCollection while still carrying a secret-like value.
+	_, reg := pkg.NewFastRegistryWithMocks(t, configx.WithValue(
+		config.ViperKeySelfServiceStrategyConfig+"."+string(identity.CredentialsTypeOIDC)+".config",
+		map[string]any{"providers": secret}), configx.SkipValidation())
+
+	hook := new(test.Hook)
+	reg.Logger().Logger.Hooks.Add(hook)
+
+	_, err := oidc.NewStrategy(reg).Config(t.Context())
+	require.Error(t, err)
+
+	require.NotNil(t, hook.LastEntry(), "the decode failure should be logged")
+	assert.Equal(t, logrus.ErrorLevel, hook.LastEntry().Level)
+
+	for _, entry := range hook.AllEntries() {
+		assert.NotContains(t, entry.Message, secret, "the configuration must not be logged")
+
+		// %s so a []byte or json.RawMessage field renders as text rather than
+		// as a slice of byte values, which would hide the secret.
+		for key, value := range entry.Data {
+			assert.NotContainsf(t, fmt.Sprintf("%s", value), secret,
+				"log field %q must not carry the configuration", key)
+		}
+	}
 }
 
 func TestConfiguration_AALForClaims(t *testing.T) {

--- a/selfservice/strategy/oidc/strategy.go
+++ b/selfservice/strategy/oidc/strategy.go
@@ -653,7 +653,9 @@ func (s *Strategy) Config(ctx context.Context) (*ConfigurationCollection, error)
 	if err := json.
 		NewDecoder(bytes.NewBuffer(conf)).
 		Decode(&c); err != nil {
-		s.d.Logger().WithError(err).WithField("config", conf)
+		// The configuration itself is not logged: it holds every provider's
+		// client_secret.
+		s.d.Logger().WithError(err).Error("Unable to decode OpenID Connect Provider configuration.")
 		return nil, errors.WithStack(herodot.ErrMisconfiguration().WithReasonf("Unable to decode OpenID Connect Provider configuration: %s", err))
 	}
 


### PR DESCRIPTION
`(*Strategy).Config` logs a provider configuration decode failure like this:

```go
s.d.Logger().WithError(err).WithField("config", conf)
```

`logrusx.Logger.WithError` and `.WithField` both return a `*Logger`, so this statement builds a derived logger and throws it away. There is no terminal call, so **nothing is ever emitted**. Two problems follow:

1. **The diagnostic is silently lost.** A misconfigured `selfservice.methods.oidc.config` returns a 500 with no corresponding log line, which makes it harder to debug than it needs to be.
2. **The entry it assembles carries the raw configuration**, and `conf` holds every configured provider's `client_secret`. Nothing leaks today only because the entry is discarded — so the obvious fix of appending `.Error(...)` would turn a dormant problem into an active one.

This patch logs the failure at error level with the decode error alone, and does not attach the configuration.

One detail worth recording, because it makes the leak easy to miss in review: `conf` is a `json.RawMessage`, so with a text formatter logrus renders it as `config=[123 34 112 ...]` — a slice of byte values rather than readable JSON. The secrets are fully present but survive a casual grep for them, which is exactly how this kind of thing stays unnoticed. The test asserts on `fmt.Sprintf("%s", value)` for that reason.

### Related issue(s)

Found while working on #4586, which lets `client_secret` be loaded from a `file://` or `base64://` URI. The two are independent: this one is a self-contained fix and does not depend on #4586 in either direction.

They touch `Config()` a few lines apart, so whichever merges second may need a trivial rebase. Happy to reorder or combine them if you'd prefer.

### Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change introduces a new feature. — n/a, this is a bug fix.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added or changed [the documentation](https://github.com/ory/docs). — n/a, no user-facing configuration surface changes.

Remaining checklist items are attestations for the PR author to confirm.

On the security-policy question: this is being raised as an ordinary bug rather than through [security@ory.sh](mailto:security@ory.sh), on the grounds that the current code emits nothing and therefore leaks nothing. If you would rather treat the dormant path as a disclosure matter, say so and I will withdraw this PR and reroute it.

### Testing

`TestConfigDecodeFailureLogging` asserts that a decode failure produces an error-level entry and that neither the message nor any field carries the configuration.

I verified the test actually discriminates, rather than just passing against the new code:

| Implementation | Result |
|---|---|
| Original (`WithField("config", conf)`, no terminal call) | **fails** — `the decode failure should be logged` |
| Naive fix (`WithField("config", conf).Error(...)`) | **fails** — `log field "config" must not carry the configuration` |
| This patch | passes |

The naive-fix case is the reason the assertion formats field values with `%s`; an earlier version of the test compared the rendered entry as a string and passed against the leaking implementation, because the byte-slice rendering hid the value.

```
go test ./selfservice/strategy/oidc/ -run 'TestConfig$|TestConfigDecodeFailureLogging|TestConfiguration_'  ok
go vet ./selfservice/strategy/oidc/                                                                        ok
```

`TestSettingsStrategy` fails in my environment because it requires a Docker-hosted Hydra; it fails identically on an unmodified tree.
