### PR TITLE
fix: propagate transient_payload to settings flow hooks

### DIFF
--- a/selfservice/strategy/lookup/settings.go
+++ b/selfservice/strategy/lookup/settings.go
@@ -147,6 +147,7 @@ func (s *Strategy) decodeSettingsFlow(r *http.Request, dest interface{}) error {
 }
 
 func (s *Strategy) continueSettingsFlow(ctx context.Context, r *http.Request, ctxUpdate *settings.UpdateContext, p updateSettingsFlowWithLookupMethod) error {
+	ctxUpdate.Flow.TransientPayload = p.TransientPayload
 	if p.ConfirmLookup || p.RevealLookup || p.RegenerateLookup || p.DisableLookup {
 		if err := flow.MethodEnabledAndAllowed(ctx, flow.SettingsFlow, s.SettingsStrategyID(), s.SettingsStrategyID(), s.d); err != nil {
 			return err

--- a/selfservice/strategy/password/settings.go
+++ b/selfservice/strategy/password/settings.go
@@ -150,6 +150,7 @@ func isNewPasswordSameAsOld(ctx context.Context, oldHashedPassword string, newPa
 }
 
 func (s *Strategy) continueSettingsFlow(ctx context.Context, r *http.Request, ctxUpdate *settings.UpdateContext, p updateSettingsFlowWithPasswordMethod) error {
+	ctxUpdate.Flow.TransientPayload = p.TransientPayload
 	if err := flow.MethodEnabledAndAllowed(ctx, flow.SettingsFlow, s.SettingsStrategyID(), p.Method, s.d); err != nil {
 		return err
 	}

--- a/selfservice/strategy/password/settings_test.go
+++ b/selfservice/strategy/password/settings_test.go
@@ -631,6 +631,20 @@ func TestSettings(t *testing.T) {
 				v.Set("transient_payload", `{"stuff":"42"}`)
 			}))
 		})
+
+		t.Run("type=browser/continuity-resume", func(t *testing.T) {
+			conf.MustSet(t.Context(), config.ViperKeySelfServiceSettingsPrivilegedAuthenticationAfter, "1ns")
+			t.Cleanup(func() {
+				conf.MustSet(context.Background(), config.ViperKeySelfServiceSettingsPrivilegedAuthenticationAfter, "5m")
+			})
+			_ = testhelpers.NewSettingsLoginAcceptAPIServer(t, testhelpers.NewSDKCustomClient(publicTS, browserUser), conf)
+
+			check(t, expectSuccess(t, false, false, browserUser, func(v url.Values) {
+				v.Set("method", "password")
+				v.Set("password", randx.MustString(16, randx.AlphaNum))
+				v.Set("transient_payload", `{"stuff":"42"}`)
+			}))
+		})
 	})
 
 	t.Run("description=should update the password and perform the correct redirection", func(t *testing.T) {

--- a/selfservice/strategy/password/settings_test.go
+++ b/selfservice/strategy/password/settings_test.go
@@ -6,17 +6,22 @@ package password_test
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 
 	"github.com/ory/x/configx"
 
@@ -553,6 +558,78 @@ func TestSettings(t *testing.T) {
 		t.Run("type=browser", func(t *testing.T) {
 			actual := expectSuccess(t, false, false, browserUser, payload)
 			check(t, actual, bi)
+		})
+	})
+
+	t.Run("description=should pass transient_payload to after-settings hooks", func(t *testing.T) {
+		bi := newIdentityWithoutCredentials(x.NewUUID().String() + "@ory.sh")
+		si := newIdentityWithoutCredentials(x.NewUUID().String() + "@ory.sh")
+		ai := newIdentityWithoutCredentials(x.NewUUID().String() + "@ory.sh")
+		browserUser := testhelpers.NewHTTPClientWithIdentitySessionCookie(t.Context(), t, reg, bi)
+		spaUser := testhelpers.NewHTTPClientWithIdentitySessionCookie(t.Context(), t, reg, si)
+		apiUser := testhelpers.NewHTTPClientWithIdentitySessionToken(t.Context(), t, reg, ai)
+
+		received := make(chan []byte, 8)
+		webhookServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			received <- body
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(webhookServer.Close)
+
+		conf.MustSet(t.Context(), config.HookStrategyKey(config.ViperKeySelfServiceSettingsAfter, "password"), []map[string]any{{
+			"hook": "web_hook",
+			"config": map[string]any{
+				"url":    webhookServer.URL,
+				"method": "POST",
+				"body":   "base64://" + base64.StdEncoding.EncodeToString([]byte(`function(ctx) ctx`)),
+			},
+		}})
+		t.Cleanup(func() {
+			conf.MustSet(t.Context(), config.HookStrategyKey(config.ViperKeySelfServiceSettingsAfter, "password"), nil)
+		})
+
+		check := func(t *testing.T, actual string) {
+			assert.Equal(t, "success", gjson.Get(actual, "state").String(), "%s", actual)
+			select {
+			case body := <-received:
+				assert.Equal(t, "42", gjson.GetBytes(body, "flow.transient_payload.stuff").String(), "%s", body)
+			case <-time.After(5 * time.Second):
+				t.Fatal("web hook was not invoked")
+			}
+		}
+
+		submitJSON := func(t *testing.T, isAPI bool, hc *http.Client) string {
+			var f *kratos.SettingsFlow
+			if isAPI {
+				f = testhelpers.InitializeSettingsFlowViaAPI(t, hc, publicTS)
+			} else {
+				f = testhelpers.InitializeSettingsFlowViaBrowser(t, hc, true, publicTS)
+			}
+			values := testhelpers.SDKFormFieldsToURLValues(f.Ui.Nodes)
+			values.Set("method", "password")
+			values.Set("password", randx.MustString(16, randx.AlphaNum))
+			payload, err := sjson.SetRaw(testhelpers.EncodeFormAsJSON(t, true, values), "transient_payload", `{"stuff":"42"}`)
+			require.NoError(t, err)
+			actual, res := testhelpers.SettingsMakeRequest(t, isAPI, !isAPI, f, hc, payload)
+			assert.EqualValues(t, http.StatusOK, res.StatusCode, "%s", actual)
+			return actual
+		}
+
+		t.Run("type=api", func(t *testing.T) {
+			check(t, submitJSON(t, true, apiUser))
+		})
+
+		t.Run("type=spa", func(t *testing.T) {
+			check(t, submitJSON(t, false, spaUser))
+		})
+
+		t.Run("type=browser", func(t *testing.T) {
+			check(t, expectSuccess(t, false, false, browserUser, func(v url.Values) {
+				v.Set("method", "password")
+				v.Set("password", randx.MustString(16, randx.AlphaNum))
+				v.Set("transient_payload", `{"stuff":"42"}`)
+			}))
 		})
 	})
 

--- a/selfservice/strategy/profile/strategy.go
+++ b/selfservice/strategy/profile/strategy.go
@@ -160,6 +160,7 @@ func (s *Strategy) Settings(ctx context.Context, w http.ResponseWriter, r *http.
 }
 
 func (s *Strategy) continueFlow(ctx context.Context, r *http.Request, ctxUpdate *settings.UpdateContext, p updateSettingsFlowWithProfileMethod) error {
+	ctxUpdate.Flow.TransientPayload = p.TransientPayload
 	if err := flow.MethodEnabledAndAllowed(ctx, flow.SettingsFlow, s.SettingsStrategyID(), p.Method, s.d); err != nil {
 		return err
 	}

--- a/selfservice/strategy/totp/settings.go
+++ b/selfservice/strategy/totp/settings.go
@@ -132,6 +132,7 @@ func (s *Strategy) decodeSettingsFlow(r *http.Request, dest interface{}) error {
 }
 
 func (s *Strategy) continueSettingsFlow(ctx context.Context, r *http.Request, ctxUpdate *settings.UpdateContext, p updateSettingsFlowWithTotpMethod) error {
+	ctxUpdate.Flow.TransientPayload = p.TransientPayload
 	if err := flow.MethodEnabledAndAllowed(ctx, flow.SettingsFlow, s.SettingsStrategyID(), p.Method, s.d); err != nil {
 		return err
 	}

--- a/selfservice/strategy/webauthn/settings.go
+++ b/selfservice/strategy/webauthn/settings.go
@@ -162,6 +162,7 @@ func (s *Strategy) continueSettingsFlow(
 	w http.ResponseWriter, r *http.Request,
 	ctxUpdate *settings.UpdateContext, p updateSettingsFlowWithWebAuthnMethod,
 ) error {
+	ctxUpdate.Flow.TransientPayload = p.TransientPayload
 	if len(p.Register+p.Remove) > 0 {
 		if err := flow.MethodEnabledAndAllowed(ctx, flow.SettingsFlow, s.SettingsStrategyID(), s.SettingsStrategyID(), s.d); err != nil {
 			return err


### PR DESCRIPTION
DISCLAIMER : FABLE 5 generated (I personally know very little about GO language. The issue mentioned is still legitimate, and the fix seems like it's a simple one liner in a few strategies).


Settings flows accept `transient_payload` in every method's update payload (all method settings schemas define it), but only the `oidc` strategy copies it onto the flow. For `password`, `totp`, `webauthn`, `lookup`, and `profile`, the decoded value is silently dropped, so after-settings web hooks always receive an empty `ctx.flow.transient_payload`.

This copies the decoded payload onto the flow in each strategy's continue function (covering both fresh submissions and flows resumed from continuity), mirroring what the `oidc` settings strategy and the login/registration strategies already do.

## Related issue(s)

I could not find an existing issue for this. Reproduction:

1. Configure an after-settings web hook whose jsonnet body reads `ctx.flow.transient_payload`.
2. Submit a settings flow update, e.g. `{"method": "password", "password": "...", "transient_payload": {"stuff": "42"}}`.
3. The web hook receives `"transient_payload": {}` instead of the submitted value.

The new test in `selfservice/strategy/password/settings_test.go` reproduces this end-to-end for api, spa, and browser flows, and fails without the fix.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.com](mailto:security@ory.com)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

No documentation change is needed: the docs already describe `transient_payload` as available to hooks in all self-service flows — this PR makes the settings flow match the documented behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved transient data submitted during settings updates across password, profile, lookup, TOTP, and passkey flows.
  * Ensured transient data is available to after-settings webhooks for API, browser, and single-page application password updates.

* **Tests**
  * Added coverage verifying transient payloads are correctly forwarded and included in webhook requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->